### PR TITLE
Missing Workflow Steps

### DIFF
--- a/content/en/docs/workflow-steps/allocation/allocation-rules.md
+++ b/content/en/docs/workflow-steps/allocation/allocation-rules.md
@@ -1,0 +1,21 @@
+---
+title: Allocation By Rules
+slug: allocation-rules
+description: Allocate values based on driver data with rules
+date: 2022-05-10T14:00:00
+---
+
+
+## Description
+
+
+Allocate values based on driver data with rules stored in a dimension object
+
+
+
+## Table Selection
+
+
+First, select the “Project” or “Workflow” from the first dropdown list. Then select the table to be cleared from the second dropdown list. The list will include all *Project* or *Workflow* data tables.
+
+

--- a/content/en/docs/workflow-steps/allocation/allocation-split.md
+++ b/content/en/docs/workflow-steps/allocation/allocation-split.md
@@ -1,0 +1,21 @@
+---
+title: Allocation Split
+slug: allocation-split
+description: Allocate values based on driver data
+date: 2022-05-10T14:00:00
+---
+
+
+## Description
+
+
+Allocate values based on driver data
+
+
+
+## Table Selection
+
+
+First, select the “Project” or “Workflow” from the first dropdown list. Then select the table to be cleared from the second dropdown list. The list will include all *Project* or *Workflow* data tables.
+
+

--- a/content/en/docs/workflow-steps/allocation/rule-based-tagging.md
+++ b/content/en/docs/workflow-steps/allocation/rule-based-tagging.md
@@ -1,0 +1,21 @@
+---
+title: Rule-Based Tagging
+slug: rule-based-tagging
+description: Tag data based on rules
+date: 2022-05-10T14:00:00
+---
+
+
+## Description
+
+
+Tag data based on rules stored in a dimension object
+
+
+
+## Table Selection
+
+
+First, select the “Project” or “Workflow” from the first dropdown list. Then select the table to be cleared from the second dropdown list. The list will include all *Project* or *Workflow* data tables.
+
+

--- a/content/en/docs/workflow-steps/document/concatenate-files.md
+++ b/content/en/docs/workflow-steps/document/concatenate-files.md
@@ -1,0 +1,10 @@
+---
+title: Concatenate Files
+slug: concatenate-files
+description: Concatenates two or more documents together
+date: 2022-01-25T07:40:18
+---
+
+
+Documentation coming soon...
+

--- a/content/en/docs/workflow-steps/export/export-project-table.md
+++ b/content/en/docs/workflow-steps/export/export-project-table.md
@@ -1,0 +1,10 @@
+---
+title: Export Project Table
+slug: export-project-table
+description: Export data from a project table
+date: 2022-05-10T14:00:00
+---
+
+## Description
+
+Export data from a project table

--- a/content/en/docs/workflow-steps/export/export-to-xml.md
+++ b/content/en/docs/workflow-steps/export/export-to-xml.md
@@ -1,0 +1,10 @@
+---
+title: Export To XML
+slug: export-to-xml
+description: Export table data to an XML file
+date: 2022-05-10T14:00:00
+---
+
+## Description
+
+Export table data to an XML file

--- a/content/en/docs/workflow-steps/import/import-archive.md
+++ b/content/en/docs/workflow-steps/import/import-archive.md
@@ -1,0 +1,10 @@
+---
+title: Import Archive
+slug: import-archive
+description: Import an archived project
+date: 2022-05-10T14:00:00
+---
+
+## Description
+
+Imports a project from a project archive file

--- a/content/en/docs/workflow-steps/import/import-project-table.md
+++ b/content/en/docs/workflow-steps/import/import-project-table.md
@@ -1,0 +1,10 @@
+---
+title: Import Project Table
+slug: import-project-table
+description: Import table data from a different project
+date: 2022-05-10T14:00:00
+---
+
+## Description
+
+Import table data from a different project

--- a/content/en/docs/workflow-steps/notifications/notify-via-agent.md
+++ b/content/en/docs/workflow-steps/notifications/notify-via-agent.md
@@ -1,8 +1,8 @@
 ---
 title: Notify Agent
-slug: notify-agent
+slug: notify-via-agent
 description: Notify a PlaidCloud Agent
-date: 2022-01-25T07:39:57
+date: 2022-05-10T14:00:00
 ---
 
 

--- a/content/en/docs/workflow-steps/tables/table-cross-join.md
+++ b/content/en/docs/workflow-steps/tables/table-cross-join.md
@@ -1,0 +1,186 @@
+---
+title: Table Cross Join
+slug: table-cross-join
+description: Use this function to perform an cross join between two data tables
+date: 2022-05-10T14:00:00
+---
+
+
+## Description
+
+
+Use, as you might have expected, to perform a cross join operation on 2 data tables, combining them into a single data table without join key(s).
+
+
+For more details on cross join methodology, see here: [Wikipedia SQL Cross Join](https://en.wikipedia.org/wiki/Join_%28SQL%29#Cross_join)
+
+
+
+## Table A Data Selection
+
+
+### Table Source
+
+
+Specify the source data table by selecting it from the dropdown menu.
+
+
+
+### Select Subset of Source Data
+
+
+Any valid Python expression is acceptable to subset the data. Please see [Expressions](/docs/expressions) for more details and examples.
+
+
+
+### Duplicates
+
+
+There is a checkbox option to use **Distinct Rows Only**. This is especially helpful in cases where duplicates may exist but are not desired. As experienced modelers know, having non-distinct data in an SQL join can increase expected record count significantly.
+
+
+
+Additionally, there is standard function to **Report Duplicates in Table** elsewhere.
+
+
+
+### Duplicates
+
+
+To report duplicates, select the **Report Duplicates in Table** checkbox and then specify an output table, which will contain all of the duplicate records.
+
+
+
+
+{{< caution >}}
+This will **not** remove the duplicate items from the target data table. To remove duplicate items, use the **Distinct** menu options as specified in the [Table Data Selection](../transforms/common_features#table-data-selection) section.
+{{< /caution >}}
+
+
+
+### Source Columns and Replacements
+
+
+Specify any columns to be included in the Inner Join here. Selecting the **Inspect Source** and **Populate Source Mapping Table** buttons will make these columns available for the join operation.
+
+
+
+### Source Table Slicing (Limit)
+
+
+To limit the data, check the **Apply Row Slicer** box and then specify the following:
+
+
+* **Initial Rows to Skip:** Rows of data to skip (column header row is **not** included in count)
+* **End at Row:** Last row of data to include. Note that this is different from simply counting rows at the end to drop
+
+
+
+## Table B Data Selection
+
+
+### Table Source
+
+
+Specify the source data table by selecting it from the dropdown menu.
+
+
+
+### Select Subset of Source Data
+
+
+Any valid Python expression is acceptable to subset the data. Please see [Expressions](/docs/expressions)
+
+
+for more details and examples.
+
+
+
+### Duplicates
+
+
+There is a checkbox option to use **Distinct Rows Only**. This is especially helpful in cases where duplicates may exist but are not desired. As experienced modelers know, having non-distinct data in an SQL join can increase expected record count significantly.
+
+
+
+Additionally, there is standard functionality to **Report Duplicates in Table** elsewhere. For more details on this capability, see details here:
+
+
+
+### Duplicates
+
+
+To report duplicates, select the **Report Duplicates in Table** checkbox and then specify an output table which will contain all of the duplicate records.
+
+
+
+
+{{< caution >}}
+This will **not** remove the duplicate items from the target data table. To remove duplicate items, use the **Distinct** menu options as specified in the [Table Data Selection](../transforms/common_features#table-data-selection) section.
+{{< /caution >}}
+
+
+
+### Source Columns and Replacements
+
+
+Specify any columns to be included in the Inner Join here. Selecting the **Inspect Source** and **Populate Source Mapping Table** buttons will make these columns available for the join operation.
+
+
+
+### Source Table Slicing (Limit)
+
+
+To limit the data, check the **Apply Row Slicer** box and then specify the following:
+
+
+* **Initial Rows to Skip:** Rows of data to skip (column header row is **not** included in count)
+* **End at Row:** Last row of data to include. Note that this is different from simply counting rows at the end to drop
+
+
+
+## Table Output
+
+
+### Target Table
+
+
+Specify the **Target Table** name by either selecting an existing data table from the dropdown menu or typing a new data table name into the same menu. By default, the **Target Table** is automatically populated with the specific transform’s name. Note that data tables must follow Linux naming conventions. As such, we recommend that names only consist of alphanumeric characters. Analyze will automatically scrub any invalid characters from the name.
+
+
+
+### Join Map
+
+
+Specify join conditions. Using the **Guess** button will find all matching columns from both **Table A** as well as **Table B**. To add additional columns manually, right click anywhere in the section and select either **Insert Row** or **Append Row**, to add a row prior to the currently selected row or to add a row at the end, respectively. Then, type the column names to match from **Table A** to **Table B**. To remove a field from the **Join Map**, simply right-click and select **Delete**.
+
+
+
+### Target Output Columns
+
+
+Specify the columns to appear in the target data table. Selecting the **Propagate** button will insert all columns listed in the **Source Columns and Replacements** section of both **Table A** and **Table B**. Any columns included in the **Join Map** will only be listed a single time.
+
+
+
+To add additional columns manually, right click anywhere in the section and select either **Insert Row** or **Append Row**, to add a row prior to the currently selected row or to add a row at the end, respectively. Then, type the column name. To remove a field, simply right-click and select **Delete**.
+
+
+
+### Select Subset of Final Data
+
+
+Any valid Python expression is acceptable to subset the data. Please see [Expressions](/docs/expressions) for more details and examples.
+
+
+
+### Final Data Table Slicing (Limit)
+
+
+To limit the data, simply check the **Apply Row Slicer** box and then specify the following:
+
+
+* **Initial Rows to Skip:** Rows of data to skip (column header row is not included in count)
+* **End at Row:** Last row of data to include. This is different from simply counting rows at the end to drop
+
+

--- a/content/en/docs/workflow-steps/tables/table-drop.md
+++ b/content/en/docs/workflow-steps/tables/table-drop.md
@@ -1,0 +1,21 @@
+---
+title: Table Drop
+slug: table-drop
+description: Drop/Delete a data table
+date: 2022-05-10T14:00:00
+---
+
+
+## Description
+
+
+Drop/delete a data table.
+
+
+
+## Table Selection
+
+
+First, select the “Project” or “Workflow” from the first dropdown list. Then select the table to be cleared from the second dropdown list. The list will include all *Project* or *Workflow* data tables.
+
+

--- a/content/en/docs/workflow-steps/workflow-control/raise-workflow-error.md
+++ b/content/en/docs/workflow-steps/workflow-control/raise-workflow-error.md
@@ -1,0 +1,24 @@
+---
+title: Raise Workflow Error
+slug: raise-workflow-error
+description: Raises an error in a workflow
+date: 2022-01-25T07:39:51
+---
+
+
+## Description
+
+
+Raise an error in a PlaidCloud Analyze workflow.
+
+
+## Raise Workflow Error
+
+
+Mainly for use with step conditions, the step can be set to execute if conditions are met and raise an error within the workflow
+
+
+
+
+
+  

--- a/content/en/docs/workflow-steps/workflow-control/workflow-loop.md
+++ b/content/en/docs/workflow-steps/workflow-control/workflow-loop.md
@@ -1,7 +1,7 @@
 ---
-title: Stop Loop
-slug: stop-loop
-description: Stop a recurring workflow dataset using Project variables
+title: Worklow Loop
+slug: workflow-loop
+description: Runs a workflow looping over a dataset as Project variables
 date: 2022-01-25T07:39:50
 ---
 


### PR DESCRIPTION
The remaining missing docs look like they are probably bespoke so I've not added them at present:

https://docs.plaidcloud.com/docs/workflow-steps/allocation/allocation-split-filter
https://docs.plaidcloud.com/docs/workflow-steps/workflow-control/workflow-include
https://docs.plaidcloud.com/docs/workflow-steps/sap-pcm/export-pcm-model
https://docs.plaidcloud.com/docs/workflow-steps/identity/get-workspace-members
https://docs.plaidcloud.com/docs/workflow-steps/identity/deactivate-workspace-members
https://docs.plaidcloud.com/docs/workflow-steps/bom/load-makeup-volumes
https://docs.plaidcloud.com/docs/workflow-steps/bom/load-part-master
https://docs.plaidcloud.com/docs/workflow-steps/general/report-run
https://docs.plaidcloud.com/docs/workflow-steps/general/run-script


** Import GoogleBigQuery (missing in plaid, entry in docs)
** Export GoogleBigQuery (missing in plaid, entry in docs)
** Export Stata (missing in plaid, entry in docs)
** Export SPSS (missing in plaid, entry in docs)