### PR TITLE
Turn off wide screen modifications to top banner

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -163,9 +163,9 @@ body.td-404 main .error-details {
     margin-top: 3.5rem !important;
   }
 
-  @media only screen and (min-width: 1075px) {
-    margin-top: 1rem !important;
-  }
+  // @media only screen and (min-width: 1075px) {
+  //   margin-top: 1rem !important;
+  // }
 }
 
 // Flip-Nav
@@ -485,9 +485,9 @@ body.cid-community > #deprecation-warning > .deprecation-warning > * {
     .td-sidebar__inner {
       top: 8.5rem;
 
-      @media only screen and (min-width: 1075px) {
-        top: 6.5rem;
-      }
+      // @media only screen and (min-width: 1075px) {
+      //   top: 6.5rem;
+      // }
     }
   }
 }


### PR DESCRIPTION
The wide version currently overlaps the "PlaidCloud" header image with the various header navigation links. The narrow version is fine. This fixes that by just turnning off the wide version.