### PR TITLE
docs(projects): add Compare and Merge Projects guide

### DIFF
--- a/src/content/docs/guides/projects/compare-and-merge-projects.mdx
+++ b/src/content/docs/guides/projects/compare-and-merge-projects.mdx
@@ -1,0 +1,92 @@
+---
+title: Compare and Merge Projects
+description: Compare two analyze projects side by side — workflows, steps, variables, dimensions, and more — and selectively merge changes from one project into another.
+sidebar:
+  order: 8
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Compare lets you see exactly what differs between two projects and, for the parts that can be safely copied, merge selected changes from one into the other. It's built for two everyday situations:
+
+- **Promote changes between environments** — review what's different between a QA (development) project and its Production counterpart, then move just the changes you want into Production.
+- **Review against an earlier snapshot or copy** — compare a project to a copy of itself (for example, a month-over-month clone) to see what changed.
+
+You stay in control the whole way: nothing is written until you select specific items and apply them, and you can validate first with a dry run.
+
+## How Matching Works
+
+To compare two projects, PlaidCloud has to decide which item on the left corresponds to which item on the right. It picks the strategy automatically:
+
+- **Copies and snapshots of the same project** are matched by their internal id (a clone keeps the same ids), so even renamed items line up precisely.
+- **Independent projects** — such as a QA project and a separately built Production project — share no ids, so they're matched **by name**. When this happens, items are tagged `(name-matched)`.
+
+Name matching is what makes a QA-to-Production comparison useful, since the two projects were built separately. It also has limits: items with duplicate names can't always be paired one-to-one, and an item flagged `ambiguous match` means more than one candidate shared the same name — review those by hand before merging.
+
+## Opening a Comparison
+
+1. Open **Analyze**
+2. Select **Projects** from the top menu bar
+3. Right-click the project you want to start from (or use its actions menu) and choose **Compare to…**
+4. In the **Compare Projects** window, the project you started from is filled in as the **Source**
+5. Enter the **Target** project id — the project you want to compare against
+6. Click **Compare**
+
+<Aside>Use **Swap** to reverse the Source and Target before comparing — the direction matters, because a merge copies *from* Source *into* Target.</Aside>
+
+Both projects must be in the same workspace.
+
+## Reading the Comparison
+
+The left side groups every difference under its category: **Workflows** (with their **Steps** nested underneath), **Variables**, **Dimensions**, **Editors**, **UDFs**, **Views**, and **Tables**.
+
+Each item is badged with its status:
+
+- **Added** — present in Source but not in Target (it would be created in Target)
+- **Modified** — present in both, but the configuration differs
+- **Deleted** — present in Target but not in Source
+- **Unchanged** — identical on both sides (hidden by default)
+
+Select any item to see its details on the right: a field-by-field **Config diff** and the full text difference. If an item's diff is very large it's truncated — click **Expand full diff** to load the complete version.
+
+### Focusing the List
+
+- **Filter by name or path** narrows the tree to matching items.
+- The status checkboxes show or hide **Added**, **Modified**, **Deleted**, and **Unchanged** items.
+- **Needs manual attention** shows only the changes that can't be merged automatically (see below).
+
+## What Can Be Merged
+
+Not every difference can be safely copied between projects. The comparison labels each item so you always know what's mergeable:
+
+- **Workflows, Steps, and Variables** can be merged.
+- **Dimensions, Editors, UDFs, Views, and Tables** are **view-only** — they appear in the comparison so you can review them, but you copy them across using their own dedicated tools, not from here.
+
+Some individual changes are also marked **manual** (with a lock) even in a mergeable category, because applying them automatically wouldn't be safe. The detail pane explains why and what to do instead. The most common cases:
+
+- **Steps in a name-matched (QA vs Production) comparison** are review-only — a step's configuration can reference environment-specific connections and agents, so it's copied by hand. Use the diff to see precisely what to change in the Target.
+- **Variable deletion** isn't applied for you — remove the variable in the Target project by hand.
+
+The summary line tells you the split at a glance, for example *"12 mergeable · 5 view-only"* and *"3 need manual attention."*
+
+## Merging Changes
+
+1. Select the items you want to copy from Source into Target. Use **Select all** to pick every mergeable item currently shown, or multi-select individual rows. View-only and manual items can't be selected.
+2. Click **Dry run** to validate the selection without writing anything. PlaidCloud reports how many operations would apply (new vs. updated) and flags any that would fail.
+3. When the dry run looks right, click **Apply** (either from the dry-run result or the footer).
+4. Confirm the operation in the **Confirm merge** dialog.
+
+Merged items keep their identity in the Target, so you can run the comparison again later and merge further changes without creating duplicates.
+
+<Aside type="caution">A merge copies *into* the Target project and changes it. Review the diff and run a dry run first, and make sure Source and Target are the right way around.</Aside>
+
+### If Something Goes Wrong
+
+- **Target changed** — if someone else modified the Target after you loaded the comparison, the merge stops to avoid overwriting their work. Refresh the comparison and reapply.
+- **Merge partially applied** — if one operation fails partway through, the rest are reported as remaining. Fix the cause and choose **Retry remaining**, or cancel and refresh.
+
+## Related
+
+- [Manage projects](/guides/projects/managing-projects/) — versioning and point-in-time tracking within a single project
+- [Archive a project](/guides/projects/archive-a-project/) — capture a point-in-time snapshot you can compare against later
+- [Workflows](/guides/workflows/) — the automation primitive a comparison merges between projects

--- a/src/content/docs/guides/projects/index.md
+++ b/src/content/docs/guides/projects/index.md
@@ -18,6 +18,7 @@ Most teams start with one project per analytical area: a project for headcount c
 - [Manage data editors](/guides/projects/managing-data-editors/) — who can modify project data
 - [View the project log](/guides/projects/viewing-the-project-log/) — audit trail of changes
 - [Archive a project](/guides/projects/archive-a-project/) — preserve completed work without deleting
+- [Compare and merge projects](/guides/projects/compare-and-merge-projects/) — diff two projects and selectively copy changes between them
 
 ## Related
 


### PR DESCRIPTION
## Summary

Adds an end-user guide for the new project compare & merge feature under **Guides → Projects**, and links it from the Projects section index.

## User-facing change?

- [x] Yes — customers will notice this
- [ ] No — internal/infrastructure only

**Customer summary:** Compare two analyze projects side by side and selectively merge changes (workflows, steps, variables) from one into another — built for promoting changes from QA to Production and reviewing against earlier snapshots.

## Category

- [x] Added — new feature or capability

## Testing

`npm run build` — clean (1417 pages); the new page (`/guides/projects/compare-and-merge-projects/`) and its OG image build, and it's linked from `guides/projects/index.md`.

## Notes

Documents the shipped behavior: automatic match strategy (id for clones/snapshots, name for independent QA-vs-Prod projects), the diff tree + status badges, mergeable kinds (workflow / step / variable) vs view-only categories (dimensions, editors, UDFs, views, tables), manual-attention cases (cross-lineage steps are review-only; variable deletion is manual), and the dry-run → apply flow including partial-failure and target-changed handling.

Backing feature PRs: PlaidCloud/plaid#6018 (backend), PlaidCloud/PlaidClient#1552 (UI) — both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)