### PR TITLE
fix(vale): repair vocabulary path so prose linting runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ dist/
 # dependencies
 node_modules/
 
+# Vale style packages synced by `vale sync` (Packages in .vale.ini); the
+# project vocabulary under styles/config/vocabularies/ stays tracked.
+styles/Google/
+
 # logs
 npm-debug.log*
 yarn-debug.log*

--- a/.vale.ini
+++ b/.vale.ini
@@ -17,6 +17,9 @@ Google.We = NO
 # Allow contractions (matches our voice).
 Google.Contractions = NO
 
+# House style uses spaced em dashes ( — ); Google wants them unspaced. Keep ours.
+Google.EmDash = NO
+
 # Allow second-person ("you") which we use deliberately.
 # (no specific rule needed — Vale doesn't flag this)
 

--- a/styles/config/vocabularies/PlaidCloud/accept.txt
+++ b/styles/config/vocabularies/PlaidCloud/accept.txt
@@ -76,7 +76,6 @@ qooxdoo
 RML
 Pagefind
 Astro
-Starlight
 MDX
 Cloudflare
 Wrangler
@@ -108,6 +107,9 @@ upsert
 upserts
 deduplicate
 deduplication
+mergeable
+UDF
+UDFs
 parameterized
 SKU
 SKUs


### PR DESCRIPTION
## Summary

The `vale` PR check has been failing on every PR off `main`. Vale 3.x reads project vocabularies from `styles/config/vocabularies/<name>/`, but the PlaidCloud vocab lives at the vale-2.x path `styles/Vocab/PlaidCloud/`. Vale aborts at startup before linting anything:

```
E100 [vocab] Runtime error
'config/vocabularies/PlaidCloud' directory does not exist
```

So the red check was purely the crash, never prose. This relocates the vocab and tunes a couple of rules so vale actually runs and stays green.

## User-facing change?

- [ ] Yes — customers will notice this
- [x] No — internal/infrastructure only

## Category

- [x] Fixed — bug fix (CI)

## Changes

- Relocate the vocab to `styles/config/vocabularies/PlaidCloud/accept.txt` (vale 3.x layout).
- Add `mergeable`, `UDF`, `UDFs` to the vocabulary.
- Remove `Starlight` from the vocab — it's the docs framework name (not user-facing prose), and as a `Vale.Terms` entry it flagged the required `'@astrojs/starlight/components'` import on every component-importing `.mdx` page. (MDX ESM imports are surfaced as code nodes that bypass `Block`/`TokenIgnores`, so they can't be excluded that way; `Vale.Spelling` already ignores them.)
- Disable `Google.EmDash` — house style uses spaced em dashes ( — ), consistent with the existing `Google.*` disables.
- Gitignore `styles/Google/` (synced by `vale sync`; was untracked, easy to commit by accident).

## Testing

Reproduced the crash locally with vale 3.9.5 (the CI-pinned version), then confirmed a representative component-importing guide reports **0 errors / 0 warnings** (suggestions only, which the action's `level: error` doesn't surface). `npm run build` unaffected.

## Note

This fixes the check for **all** PRs once merged. Because `pull_request` checks run against the PR-merged-with-base ref, open PRs (e.g. the Compare & Merge guide, #148) will go green on their next vale run after this lands in `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)