### PR TITLE
docs: remove the "refreshing our docs" homepage banner

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -2,9 +2,6 @@
 title: PlaidCloud Documentation
 description: Unified financial analytics platform for data enrichment, data warehousing, machine learning, and business intelligence.
 template: splash
-banner:
-  content: |
-    We're refreshing the docs with a cleaner structure and faster search. Full content is being migrated and will be back over the next few days. Need help in the meantime? Contact <a href="mailto:support@plaidcloud.com">support@plaidcloud.com</a>.
 hero:
   title: PlaidCloud
   tagline: Unified financial analytics for business users.


### PR DESCRIPTION
Removes the migration banner from the homepage splash (`src/content/docs/index.mdx` frontmatter) — it's no longer needed. No other content changes; Astro build passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)