### PR TITLE
docs(singer): document Upsert (merge on key) sync mode

### DIFF
--- a/src/content/docs/guides/connections/singer-sources.mdx
+++ b/src/content/docs/guides/connections/singer-sources.mdx
@@ -76,6 +76,8 @@ Required fields are marked, and the form validates them (including that JSON and
 
 <Aside type="note">Upsert re-extracts the full stream each run (it doesn't use a replication key), so it suits sources where existing rows are updated and you want one row per key. Set each stream's **Key Columns** on the **Streams** tab; they default to the tap's declared primary key.</Aside>
 
+<Aside type="caution">Pick key columns that are always present. Upsert matches rows by exact key value, and an empty (null) key never matches another — so rows with a null key are always inserted rather than merged, and can accumulate across runs.</Aside>
+
 ## How Credentials Are Handled
 
 The step stores a reference to the connection, not a copy of its credentials. Each run reads the connection's current credentials at run time. So when you rotate a token or key, update it once on the connection and every step that uses it picks up the new value on its next run — there's nothing to update on the individual steps.

--- a/src/content/docs/guides/connections/singer-sources.mdx
+++ b/src/content/docs/guides/connections/singer-sources.mdx
@@ -56,21 +56,25 @@ Required fields are marked, and the form validates them (including that JSON and
 2. Add a step and choose **Import: Singer Source** as the type. The editor opens with a **Source** tab and a **Streams** tab.
 3. On the **Source** tab:
    * Choose the **Connection** (your Singer Source connection).
-   * Choose a **Sync Mode** — **Full table (replace each run)** or **Incremental (append new data)**.
+   * Choose a **Sync Mode** — **Full table (replace each run)**, **Incremental (append new data)**, or **Upsert (merge on key)**.
    * Click **Discover Streams**. Discovery runs on the runner and may take up to about three minutes the first time; the status shows how many streams were found.
 4. On the **Streams** tab, you'll see one row per discovered stream. For each stream you want:
    * Open its **Stream** panel and check **Import this stream**.
    * Choose a **Target Table** for where the stream's data lands.
+   * If the sync mode is **Upsert**, set the stream's **Key Columns** — one column name per line. The field defaults to the tap's declared primary key; override it to merge on different columns. Every imported stream needs at least one key column when the mode is **Upsert**.
 5. Save the step and run it as part of the workflow (or [on its own](/guides/workflows/running-one-step-in-a-workflow/)).
 
 <Aside type="caution">The streams you select *are* the saved set. To change which streams import, click **Discover Streams** again — streams that reappear keep the target table and selection you already set.</Aside>
 
-## Full Table vs Incremental
+## Sync Modes
 
 * **Full table (replace each run)** re-extracts the whole stream every run and replaces the target table. Use it for small or fully refreshed sources.
 * **Incremental (append new data)** extracts only the rows that are new since the last run and appends them, resuming from where the previous run left off. It works only for streams the tap can sync incrementally — those that expose a replication key (such as an updated-at timestamp or an incrementing ID). If you choose incremental and a selected stream has no replication key, the step asks you to switch that stream to full table or deselect it.
+* **Upsert (merge on key)** re-extracts the whole stream each run, then merges it into the target on the stream's **Key Columns**: rows whose key matches an existing row are updated in place, and rows with a new key are inserted. Existing rows that aren't in this run are kept. Use it to keep a table in step with a source whose records change over time — without the duplicates an append would create or the full rebuild a replace would do. The target table is created on the first run, so the initial upsert inserts every row.
 
 <Aside type="note">Incremental progress is tracked per step. The first incremental run extracts everything; later runs pick up only new rows.</Aside>
+
+<Aside type="note">Upsert re-extracts the full stream each run (it doesn't use a replication key), so it suits sources where existing rows are updated and you want one row per key. Set each stream's **Key Columns** on the **Streams** tab; they default to the tap's declared primary key.</Aside>
 
 ## How Credentials Are Handled
 

--- a/src/content/docs/reference/workflow-steps/import/import-singer.mdx
+++ b/src/content/docs/reference/workflow-steps/import/import-singer.mdx
@@ -16,14 +16,14 @@ For a full walkthrough, see the [Singer Sources guide](/guides/connections/singe
 ## Configuration
 
 * **Connection** *(required)* — a connection of kind **Singer Source**.
-* **Sync Mode** *(required)* — **Full table (replace each run)** or **Incremental (append new data)**. Incremental works only for streams the tap can sync incrementally (those with a replication key); the step resumes from the previous run's position.
+* **Sync Mode** *(required)* — **Full table (replace each run)**, **Incremental (append new data)**, or **Upsert (merge on key)**. Incremental works only for streams the tap can sync incrementally (those with a replication key); the step resumes from the previous run's position. Upsert merges each run into the target on the stream's key columns.
 * **Discover Streams** — runs the tap's catalog discovery on the runner and lists the streams it offers.
-* **Streams** *(at least one)* — for each discovered stream: **Import this stream** to include it, and a **Target Table** for where it lands. Every selected stream needs a target table.
+* **Streams** *(at least one)* — for each discovered stream: **Import this stream** to include it, and a **Target Table** for where it lands. Every selected stream needs a target table. When the sync mode is **Upsert**, each selected stream also needs **Key Columns** (one column name per line) — the columns a row is matched on; they default to the tap's declared primary key.
 
 ## Behavior
 
 * Discovery runs as its own job and can take up to about three minutes on a cold start; the result is cached, so repeat discovery is instant.
-* **Full table** replaces the target table each run; **incremental** appends only the rows that are new since the last run, using the tap's replication key.
+* **Full table** replaces the target table each run; **incremental** appends only the rows that are new since the last run, using the tap's replication key; **upsert** re-extracts the full stream and merges it into the target on each stream's key columns — matching rows are updated, new keys are inserted, and unmatched existing rows are kept. The target is created on the first run.
 * The selected streams *are* the saved set — to change the selection, re-discover. Streams that reappear keep the target table and selection you set.
 * Source credentials are read from the connection at run time, so rotating them on the connection applies to every step that uses it — no per-step updates.
 

--- a/src/content/docs/reference/workflow-steps/import/import-singer.mdx
+++ b/src/content/docs/reference/workflow-steps/import/import-singer.mdx
@@ -23,7 +23,7 @@ For a full walkthrough, see the [Singer Sources guide](/guides/connections/singe
 ## Behavior
 
 * Discovery runs as its own job and can take up to about three minutes on a cold start; the result is cached, so repeat discovery is instant.
-* **Full table** replaces the target table each run; **incremental** appends only the rows that are new since the last run, using the tap's replication key; **upsert** re-extracts the full stream and merges it into the target on each stream's key columns — matching rows are updated, new keys are inserted, and unmatched existing rows are kept. The target is created on the first run.
+* **Full table** replaces the target table each run; **incremental** appends only the rows that are new since the last run, using the tap's replication key; **upsert** re-extracts the full stream and merges it into the target on each stream's key columns — matching rows are updated, new keys are inserted, and unmatched existing rows are kept. The target is created on the first run. Rows with a null key column never match and are always inserted, so choose key columns that are always present.
 * The selected streams *are* the saved set — to change the selection, re-discover. Streams that reappear keep the target table and selection you set.
 * Source credentials are read from the connection at run time, so rotating them on the connection applies to every step that uses it — no per-step updates.
 


### PR DESCRIPTION
## What

Documents the new third Singer import sync mode, **Upsert (merge on key)**, in the Singer Sources guide and the Import Singer Source step reference.

## Changes

- **Guide** (`guides/connections/singer-sources.mdx`): Upsert added to the Sync Mode choice; per-stream **Key Columns** step on the Streams tab; renamed "Full Table vs Incremental" → "Sync Modes" with an Upsert bullet + behavior note.
- **Reference** (`reference/workflow-steps/import/import-singer.mdx`): Upsert added to the Sync Mode and Streams config items and to the Behavior section.

Matches the shipped UI labels (`Upsert (merge on key)`, `Key Columns (Upsert)`) and behavior (matching keys update, new keys insert, unmatched existing rows kept; target created on first run; keys default to the tap's primary key).

Astro build passes locally.

## Companion PRs

- plaid: PlaidCloud/plaid#6033
- workflow-runner: PlaidCloud/workflow-runner#998
- PlaidClient: PlaidCloud/PlaidClient#1562

🤖 Generated with [Claude Code](https://claude.com/claude-code)