### PR TITLE
Document Alteryx migration workflows

### DIFF
--- a/src/content/docs/guides/workflows/alteryx-migration-readiness-checklist.mdx
+++ b/src/content/docs/guides/workflows/alteryx-migration-readiness-checklist.mdx
@@ -1,0 +1,101 @@
+---
+title: Alteryx Migration Readiness Checklist
+description: Prepare Alteryx workflows, apps, macros, and dependencies for a smooth PlaidCloud migration.
+sidebar:
+  order: 32
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Use this checklist before importing Alteryx workflows into PlaidCloud. A complete package helps PlaidCloud create Advanced workflows, macro workflows, Document-backed dependencies, and controlled runtime inputs with minimal follow-up.
+
+<Aside type="note">
+  For large portfolios, run this checklist once for the portfolio and again for each high-priority workflow family.
+</Aside>
+
+## Collect Workflow Files
+
+Collect every workflow file that belongs to the migration:
+
+1. Standard workflows: `.yxmd`.
+2. Analytic apps: `.yxwz`.
+3. Macros: `.yxmc`.
+4. Nested or shared macros referenced by other workflows.
+5. Workflow versions that are still used in production.
+
+Keep related workflows and macros together when they call each other. PlaidCloud uses those relationships to generate macro workflows and connect macro input and output ports.
+
+## Collect Data Dependencies
+
+Package the files that the workflows read, write, or inspect:
+
+- CSV, TSV, fixed-width, JSON, XML, Excel, Access, YXDB, and database extract files.
+- Folders used by Directory or Dynamic Input tools.
+- Expected output files for validation.
+- Report assets such as images, PDFs, templates, and map layers.
+- Lookup tables and rule tables used by joins, formulas, replacements, and matching.
+
+If a workflow references a local desktop path, include that file or folder in the import package and choose the Document path where PlaidCloud should store it.
+
+## Collect Spatial Sidecars
+
+Spatial file formats often require multiple files to stay together. Include every sidecar file in the same folder:
+
+- Shapefile groups such as `.shp`, `.shx`, `.dbf`, and `.prj`.
+- MapInfo groups such as `.tab`, `.map`, `.id`, and `.dat`.
+- KML, GeoJSON, and other standalone spatial files.
+- Projection or coordinate reference files used by the workflow.
+
+Missing sidecars are a common source of spatial validation differences.
+
+## Capture Runtime Inputs
+
+For analytic apps, record the values users normally provide:
+
+1. Text, numeric, date, file, and folder inputs.
+2. Drop-down, radio button, check box, list, and tree selections.
+3. Defaults used for scheduled or repeatable runs.
+4. Values that trigger conditions, warnings, or errors.
+
+PlaidCloud converts these inputs to controlled workflow variables.
+
+## Choose The Target Location
+
+Before import, decide:
+
+1. Target PlaidCloud project.
+2. Target Document account.
+3. Target Document folder for imported files.
+4. Naming convention for converted workflows and macros.
+5. Whether the first import is a staging import or production import.
+
+For portfolio migrations, use a dedicated migration folder in Document so dependencies remain easy to audit.
+
+## Choose Validation Evidence
+
+For each workflow, choose the validation level:
+
+- Structural validation confirms the workflow converts into a runnable PlaidCloud DAG.
+- Output parity validation compares schema, row count, and row values against trusted Alteryx outputs.
+- Artifact validation reviews reports, PDFs, images, charts, maps, or model outputs.
+
+Store expected outputs with the migration package whenever output parity is required.
+
+## Import Readiness Checklist
+
+Before importing, confirm:
+
+- Workflow, app, and macro files are present.
+- Referenced macros are present.
+- Input files and folders are present.
+- Spatial sidecars are grouped together.
+- Expected outputs are available when parity validation is part of the migration plan.
+- Runtime input values are known for analytic apps.
+- Target project and Document path are selected.
+- Credentials or external connections needed by the workflow are available in PlaidCloud.
+
+## Related Guides
+
+- [Migrate Alteryx Workflows](/guides/workflows/migrate-alteryx-workflows/)
+- [Package Alteryx Dependencies](/guides/workflows/package-alteryx-dependencies/)
+- [Validate Converted Alteryx Workflows](/guides/workflows/validate-converted-alteryx-workflows/)

--- a/src/content/docs/guides/workflows/index.md
+++ b/src/content/docs/guides/workflows/index.md
@@ -6,3 +6,17 @@ sidebar:
 ---
 
 Workflows are the automation unit in PlaidCloud — orchestrate imports, transforms, allocations, exports, and notifications. Steps can run sequentially, in parallel, conditionally, or in loops.
+
+## Common Tasks
+
+- [Migrate Alteryx Workflows](/guides/workflows/migrate-alteryx-workflows/)
+- [Alteryx Migration Readiness Checklist](/guides/workflows/alteryx-migration-readiness-checklist/)
+- [Package Alteryx Dependencies](/guides/workflows/package-alteryx-dependencies/)
+- [Validate Converted Alteryx Workflows](/guides/workflows/validate-converted-alteryx-workflows/)
+- [Use Converted Alteryx Apps](/guides/workflows/use-converted-alteryx-apps/)
+- [Orchestrate Alteryx Migrations With MCP](/guides/workflows/orchestrate-alteryx-migrations-with-mcp/)
+- [Tune Alteryx Imports](/guides/workflows/troubleshoot-alteryx-imports/)
+- [Validate Alteryx Reports And Artifacts](/guides/workflows/validate-alteryx-reports-and-artifacts/)
+- [Migrate Spatial Alteryx Workflows](/guides/workflows/migrate-spatial-alteryx-workflows/)
+- [Create A Macro](/guides/workflows/create-a-macro/)
+- [Run A Workflow](/guides/workflows/run-a-workflow/)

--- a/src/content/docs/guides/workflows/migrate-alteryx-workflows.mdx
+++ b/src/content/docs/guides/workflows/migrate-alteryx-workflows.mdx
@@ -1,0 +1,147 @@
+---
+title: Migrate Alteryx Workflows
+description: Convert Alteryx workflows, apps, and macros into PlaidCloud Advanced workflows with Document-backed dependencies, typed inputs, validation, and repeatable runs.
+sidebar:
+  order: 30
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+PlaidCloud converts Alteryx workflows, analytic apps, and macros into Advanced workflows that can be reviewed, scheduled, parameterized, and run in PlaidCloud. The importer preserves the workflow graph, uploads referenced files to Document, creates macro workflows when needed, and maps tools to native workflow steps or managed job executors.
+
+Use this guide when you are moving a single workflow, a group of related workflows, or a larger Alteryx portfolio into PlaidCloud.
+
+<Aside type="note">
+  Converted workflows are designed to require very little manual effort. For production workflows, PlaidCloud validation gives teams a clear readiness record before scheduling regular runs.
+</Aside>
+
+## What PlaidCloud Creates
+
+PlaidCloud creates a runnable Advanced workflow from the Alteryx design:
+
+- Workflow tools become PlaidCloud workflow steps with the original upstream and downstream relationships preserved.
+- Alteryx macros become PlaidCloud macro workflows with explicit macro inputs and macro outputs.
+- Analytic app questions become controlled workflow variables that users can set before a run.
+- Input files, output files, spatial sidecars, images, PDFs, and generated artifacts are stored in Document at the path selected during import.
+- Advanced operations such as fuzzy matching, spatial processing, PDF extraction, OCR, machine learning, NLP, and reporting run through PlaidCloud's managed job executors when a native SQL or workflow operation is not the best fit.
+- Browse, layout, annotations, and designer-only objects are retained where they help explain the converted workflow, but they do not add unnecessary runtime work.
+
+## Before You Start
+
+Collect the workflow files and dependencies together before importing:
+
+1. Include Alteryx workflow, app, and macro files: `.yxmd`, `.yxwz`, and `.yxmc`.
+2. Include input data files such as CSV, Excel, Access, YXDB, XML, JSON, and database extracts.
+3. Include spatial sidecar files together. For example, keep shapefile groups and MapInfo files in the same folder.
+4. Include report assets such as images, PDFs, map layers, and templates.
+5. Choose the PlaidCloud project where the converted workflows should be created.
+6. Choose the Document account and folder where PlaidCloud should upload imported files.
+7. Decide whether this migration requires structural validation only or output parity validation.
+
+## Import A Workflow
+
+1. Open the target project in PlaidCloud.
+2. Open **Workflows**.
+3. Choose the import action for Alteryx workflows.
+4. Select the `.yxmd`, `.yxwz`, or `.yxmc` file to import.
+5. Choose the Document account and folder where imported files should be stored.
+6. Add any referenced files or folders that the workflow needs at runtime.
+7. Start the import.
+8. Review the conversion summary for uploaded files, generated workflows, generated macros, readiness notes, and validation recommendations.
+9. Open the generated Advanced workflow.
+
+PlaidCloud stores imported dependencies in the Document location selected during import. Converted steps then reference those Document paths, so the workflow can run repeatedly without relying on a desktop file system.
+
+## Use The Converted Workflow
+
+After import, use the workflow like any other PlaidCloud Advanced workflow:
+
+1. Open the converted workflow canvas.
+2. Review the generated steps and branches.
+3. Set workflow variables for any converted app questions or runtime parameters.
+4. Run the workflow.
+5. Review run history, step outputs, readiness notes, and generated artifacts.
+6. Schedule the workflow when it is ready for repeatable operation.
+
+Converted macros are available as PlaidCloud macro workflows. A workflow that called an Alteryx macro will call the generated PlaidCloud macro through the macro step. Macro runs are isolated from one another, so concurrent workflow runs can safely use the same macro definition.
+
+## Validate The Conversion
+
+PlaidCloud supports two practical validation levels.
+
+### Structural Validation
+
+Structural validation confirms that the workflow was converted into a runnable PlaidCloud DAG:
+
+- Every Alteryx tool has a PlaidCloud conversion route.
+- Required macros were found or generated.
+- Required input files were uploaded to Document.
+- Macro inputs and macro outputs are connected.
+- Workflow variables were created for user-controlled inputs.
+- The generated workflow opens and can be run in PlaidCloud.
+
+Structural validation is useful for migration readiness, inventory review, and early portfolio conversion.
+
+### Output Parity Validation
+
+Output parity validation compares the PlaidCloud run against trusted Alteryx outputs:
+
+- Output schemas match.
+- Row counts match.
+- Row values match.
+- Row order is ignored unless the workflow explicitly depends on ordering.
+
+For workflows that create reports, maps, PDFs, images, or model artifacts, validate the generated artifact or the data behind the artifact according to the way your team uses the output.
+
+See [Validate Converted Alteryx Workflows](/guides/workflows/validate-converted-alteryx-workflows/) for a detailed validation checklist.
+
+## Review Conversion Coverage
+
+The [Alteryx Conversion Matrix](/reference/alteryx-conversion-matrix/) lists each supported Alteryx object, its coverage level, and the PlaidCloud operation used during conversion.
+
+Use the matrix to understand how the importer handles each tool family:
+
+- Native DAG steps for common data preparation, joins, filters, formulas, sorting, unions, sampling, and reshaping.
+- Macro steps for macro inputs, macro outputs, macro invocation, control parameters, and macro concurrency.
+- Controlled workflow variables for analytic app questions such as check boxes, drop-downs, text boxes, radio buttons, folder pickers, and file pickers.
+- Document-backed file operations for input, output, directory, and dynamic file behavior.
+- Managed job executors for specialized spatial, fuzzy matching, machine learning, PDF, OCR, NLP, reporting, and artifact work.
+- Cloud-native equivalents where PlaidCloud creates a durable, shareable artifact rather than reproducing an Alteryx-specific desktop renderer or proprietary file format.
+
+## Recommended Migration Practice
+
+For a large portfolio, migrate in batches:
+
+1. Import the workflows and macros into a migration project.
+2. Complete dependency packages before reviewing individual formulas or business logic.
+3. Run structural validation across the batch.
+4. Prioritize output parity validation for production workflows, regulatory workflows, and workflows with downstream consumers.
+5. Promote validated workflows into the target production project.
+6. Schedule production runs and monitor run history.
+
+## Related Guides
+
+- [Alteryx Migration Readiness Checklist](/guides/workflows/alteryx-migration-readiness-checklist/)
+- [Package Alteryx Dependencies](/guides/workflows/package-alteryx-dependencies/)
+- [Validate Converted Alteryx Workflows](/guides/workflows/validate-converted-alteryx-workflows/)
+- [Use Converted Alteryx Apps](/guides/workflows/use-converted-alteryx-apps/)
+- [Orchestrate Alteryx Migrations With MCP](/guides/workflows/orchestrate-alteryx-migrations-with-mcp/)
+- [Tune Alteryx Imports](/guides/workflows/troubleshoot-alteryx-imports/)
+- [Validate Alteryx Reports And Artifacts](/guides/workflows/validate-alteryx-reports-and-artifacts/)
+- [Migrate Spatial Alteryx Workflows](/guides/workflows/migrate-spatial-alteryx-workflows/)
+- [Create A Macro](/guides/workflows/create-a-macro/)
+- [Run A Workflow](/guides/workflows/run-a-workflow/)
+- [Manage Workflow Variables](/guides/workflows/manage-workflow-variables/)
+- [Alteryx Conversion Matrix](/reference/alteryx-conversion-matrix/)
+
+## Migration Documentation Set
+
+For larger migrations, use these focused guides with this migration guide:
+
+- [Alteryx Migration Readiness Checklist](/guides/workflows/alteryx-migration-readiness-checklist/) for migration planning and package review.
+- [Package Alteryx Dependencies](/guides/workflows/package-alteryx-dependencies/) for files, folders, macros, spatial sidecars, and expected outputs.
+- [Use Converted Alteryx Apps](/guides/workflows/use-converted-alteryx-apps/) for controlled workflow variables and app-style runs.
+- [Orchestrate Alteryx Migrations With MCP](/guides/workflows/orchestrate-alteryx-migrations-with-mcp/) for using an AI agent to organize files, work from connected shared storage, and coordinate many conversions through PlaidCloud's MCP server.
+- [Tune Alteryx Imports](/guides/workflows/troubleshoot-alteryx-imports/) for dependency completion, macro resolution, variables, validation comparisons, and executor readiness notes.
+- [Validate Alteryx Reports And Artifacts](/guides/workflows/validate-alteryx-reports-and-artifacts/) for PDFs, images, maps, charts, dashboards, and model artifacts.
+- [Migrate Spatial Alteryx Workflows](/guides/workflows/migrate-spatial-alteryx-workflows/) for spatial files, SQL geometry logic, managed spatial executors, and spatial validation.

--- a/src/content/docs/guides/workflows/migrate-spatial-alteryx-workflows.mdx
+++ b/src/content/docs/guides/workflows/migrate-spatial-alteryx-workflows.mdx
@@ -1,0 +1,77 @@
+---
+title: Migrate Spatial Alteryx Workflows
+description: Prepare, import, and validate Alteryx spatial workflows in PlaidCloud with Document-backed files, SQL geometry logic, and managed spatial executors.
+sidebar:
+  order: 37
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+PlaidCloud converts Alteryx spatial workflows into Advanced workflows that use Document-backed spatial inputs, SQL geometry logic where appropriate, and managed spatial executors for operations that need specialized geometry processing.
+
+<Aside type="note">
+  PlaidCloud chooses the simplest reliable route for each spatial operation. Some spatial logic can run as SQL, while nearest-neighbor, overlay, buffering, smoothing, trade area, and similar operations may run through managed executors.
+</Aside>
+
+## Package Spatial Inputs
+
+Before import, collect every spatial dependency:
+
+- Shapefile groups with `.shp`, `.shx`, `.dbf`, and `.prj`.
+- MapInfo groups with `.tab`, `.map`, `.id`, and `.dat`.
+- KML, GeoJSON, and other spatial files.
+- Lookup tables used to join spatial and non-spatial records.
+- Expected spatial outputs for validation.
+
+Keep sidecar files together in the same folder before importing.
+
+## How Spatial Tools Convert
+
+PlaidCloud uses the best available execution route for each spatial operation:
+
+- Point creation can convert to native geometry creation.
+- Spatial metadata can convert to SQL geometry expressions or a spatial transform.
+- Spatial matching, nearest-neighbor, overlay, buffer, smoothing, generalization, trade area, and polygon building can run through managed spatial executors.
+- Map and report-map outputs can convert to PlaidCloud map or report artifacts.
+
+This lets converted workflows use fast SQL logic when it is sufficient and executor-backed processing when the operation needs broader geometry support.
+
+## Validate Geometry
+
+For spatial output parity, compare:
+
+1. Output schema.
+2. Row count.
+3. Key field values.
+4. Geometry values or geometry-derived measurements.
+5. Coordinate reference behavior.
+6. Accepted tolerance for distances, areas, and simplified geometry.
+
+Row order does not need to match unless the workflow depends on ordering.
+
+## Validate Spatial Artifacts
+
+For maps and report maps, confirm:
+
+1. Map layers contain the expected records.
+2. Labels and grouped features are correct.
+3. Boundaries, points, and polygons appear in the expected locations.
+4. The artifact is usable by downstream reviewers.
+5. Any intentional cloud-native artifact difference is recorded.
+
+## Common Spatial Issues
+
+If a converted spatial workflow does not validate:
+
+- Confirm sidecar files are present.
+- Confirm projection files are present.
+- Confirm the same source data was used in both runs.
+- Review geometry precision and coordinate reference differences.
+- Review executor notes.
+- Validate the data table behind a map artifact before comparing visual layout.
+
+## Related Guides
+
+- [Package Alteryx Dependencies](/guides/workflows/package-alteryx-dependencies/)
+- [Validate Alteryx Reports And Artifacts](/guides/workflows/validate-alteryx-reports-and-artifacts/)
+- [Alteryx Conversion Matrix](/reference/alteryx-conversion-matrix/)

--- a/src/content/docs/guides/workflows/orchestrate-alteryx-migrations-with-mcp.mdx
+++ b/src/content/docs/guides/workflows/orchestrate-alteryx-migrations-with-mcp.mdx
@@ -1,0 +1,152 @@
+---
+title: Orchestrate Alteryx Migrations With MCP
+description: Use an MCP-connected AI agent to coordinate Alteryx portfolio migrations into PlaidCloud.
+sidebar:
+  order: 38
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+PlaidCloud's MCP server lets an AI agent coordinate a migration across many Alteryx workflows. The agent can help stage and organize files in Document, inventory workflow packages, call the Alteryx converter, organize generated workflows, run validation workflows, and summarize progress for the migration team.
+
+<Aside type="note">
+  MCP is ideal for portfolio-scale coordination. The PlaidCloud importer still performs the conversion; the agent helps plan, sequence, run, and summarize the work.
+</Aside>
+
+## When To Use MCP
+
+Use MCP orchestration when you are migrating many workflows or when you want an AI agent to help with repeatable migration tasks:
+
+- Inventory Alteryx files staged in Document.
+- Upload, copy, move, rename, and organize migration files through Document tools.
+- Work from a connected shared storage account such as OneDrive, Google Drive, SharePoint, S3, Azure Blob, or SFTP.
+- Group workflows, apps, and macros into migration batches.
+- Convert each `.yxmd`, `.yxwz`, or `.yxmc` file into PlaidCloud.
+- Track conversion results across the portfolio.
+- Run converted workflows or validation workflows.
+- Produce a migration summary for review.
+
+For a single workflow, the import form is often the fastest path. For a portfolio, MCP gives the agent a structured way to coordinate the same PlaidCloud capabilities repeatedly.
+
+## What The Agent Can Call
+
+The MCP tool catalog includes an Alteryx conversion tool named `alteryx_convert`. It creates PlaidCloud workflows from Alteryx files stored in Document.
+
+The conversion call includes:
+
+- Source Document account and path for the Alteryx file.
+- Destination PlaidCloud project.
+- Destination Document account and path for conversion artifacts.
+- Optional workflow, step, and table prefixes.
+- Workflow type, with Advanced workflows as the default.
+
+The agent can combine this with the normal MCP project, workflow, Document, workflow-run, and table tools to manage the broader migration.
+
+## Prepare Files With The Agent
+
+An MCP-connected agent can help with the file preparation work around the conversion:
+
+- Find `.yxmd`, `.yxwz`, and `.yxmc` files in Document.
+- Identify likely input files, macro files, report assets, spatial sidecars, and expected outputs.
+- Create a clean migration folder structure.
+- Copy, move, or rename files into that structure.
+- Keep related workflow, macro, data, spatial, report, and validation files together.
+- Summarize the package before conversion.
+
+This is useful when a migration package contains many folders or when teams want the agent to produce a repeatable inventory before conversion begins.
+
+## Use Shared Storage Without Uploading
+
+You do not have to upload files into a new PlaidCloud-owned folder before migration. PlaidCloud Document can connect directly to shared storage that already contains the Alteryx migration package.
+
+Common options include:
+
+- [Google Drive](/guides/documents/adding-accounts/add-google-drive-account/)
+- [OneDrive or SharePoint](/guides/documents/adding-accounts/add-onedrive-account/)
+- [AWS S3](/guides/documents/adding-accounts/add-aws-s3-account/)
+- [Azure Blob Storage](/guides/documents/adding-accounts/add-azure-blob-storage-account/)
+- [SFTP](/guides/documents/adding-accounts/add-sftp-account/)
+
+After the Document account is connected, the agent can work from that Document account and path. This keeps the migration close to the customer's existing shared storage and can eliminate a separate upload step.
+
+## Stage Or Select Files In Document
+
+Before asking an agent to orchestrate the migration, choose one of these paths:
+
+- Connect an existing shared storage location as a Document account.
+- Upload workflow packages to a Document account.
+- Ask the agent to organize files already available in Document.
+
+Then confirm:
+
+1. Workflows, apps, macros, input files, spatial sidecars, reports, and expected outputs are available through Document.
+2. The destination project is selected.
+3. The Document path for converted workflow dependencies and artifacts is selected.
+4. The agent has permission to use the relevant MCP Document and workflow tools.
+
+The agent can then reference stable Document paths when it calls the converter.
+
+## Suggested Agent Prompt
+
+Use a prompt like this with an MCP-connected agent:
+
+```text
+In PlaidCloud, migrate the Alteryx workflows in the connected Document account
+"Migration Share" under /q4-alteryx-package into the project "Q4 Migration".
+
+First inventory the .yxmd, .yxwz, and .yxmc files. Organize the package by
+workflow, macro, input, spatial, report, and expected-output files. Group macros
+with the workflows that call them. Then convert the workflows as Advanced
+workflows using the Document output path /q4-alteryx-converted. Prefix created
+workflows with "Q4 - ". After each conversion, summarize the generated workflow,
+macros, readiness notes, and next validation step. Ask before making mutating calls.
+```
+
+Adjust the project name, source path, destination path, and prefix for your migration batch.
+
+## Recommended Orchestration Flow
+
+For portfolio migrations, ask the agent to follow this flow:
+
+1. Connect or select the Document account that contains the migration package.
+2. Inventory the source Document folder.
+3. Identify `.yxmd`, `.yxwz`, and `.yxmc` files.
+4. Organize files into workflow, macro, input, spatial, report, and expected-output groups.
+5. Group related workflows and macros.
+6. Confirm the destination project and Document output path.
+7. Convert macros and workflows into Advanced workflows.
+8. Open or describe the generated workflows.
+9. Run structural validation.
+10. Run output parity validation where expected outputs are available.
+11. Summarize converted workflows, generated macros, artifacts, and validation status.
+
+This gives the migration team one progress report across the portfolio while still using PlaidCloud's native importer for each conversion.
+
+## Review Mutating Calls
+
+Most MCP clients show tool calls before they run. Review conversion and workflow-run calls before approving them, especially in production projects.
+
+For staging migrations, use a dedicated migration project and Document folder. After validation, promote the converted workflows into the production project.
+
+## Track Results
+
+Ask the agent to produce a migration table with:
+
+- Source Alteryx file.
+- Generated PlaidCloud workflow.
+- Generated macro workflows.
+- Conversion status.
+- Validation level.
+- Output Document path.
+- Notes for follow-up.
+
+This summary is useful for project reporting, handoff, and production readiness review.
+
+## Related Guides
+
+- [AI Agents (MCP)](/integrations/ai-coding-agents/)
+- [Getting Started with AI Coding Agents](/integrations/ai-coding-agents/getting-started/)
+- [Add Document Accounts](/guides/documents/adding-accounts/)
+- [Migrate Alteryx Workflows](/guides/workflows/migrate-alteryx-workflows/)
+- [Package Alteryx Dependencies](/guides/workflows/package-alteryx-dependencies/)
+- [Validate Converted Alteryx Workflows](/guides/workflows/validate-converted-alteryx-workflows/)

--- a/src/content/docs/guides/workflows/package-alteryx-dependencies.mdx
+++ b/src/content/docs/guides/workflows/package-alteryx-dependencies.mdx
@@ -1,0 +1,119 @@
+---
+title: Package Alteryx Dependencies
+description: Package files, folders, macros, spatial sidecars, and validation fixtures before importing Alteryx workflows into PlaidCloud.
+sidebar:
+  order: 33
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+PlaidCloud imports Alteryx workflow files from Document and uses Document paths for dependencies and artifacts. You can upload files into Document, ask an MCP-connected agent to organize files for you, or connect Document directly to shared storage such as OneDrive, Google Drive, SharePoint, S3, Azure Blob, or SFTP.
+
+<Aside type="note">
+  Use the Document path picker during import to choose exactly where PlaidCloud should read source files and store generated artifacts.
+</Aside>
+
+## Upload Or Connect Shared Storage
+
+Choose the source location that best fits your migration:
+
+- Upload the package to a Document account.
+- Connect an existing shared storage location as a Document account.
+- Ask an MCP-connected agent to copy, move, rename, and organize files already available in Document.
+
+Shared storage connections can reduce migration prep because the team can keep files where they already collaborate:
+
+- [Google Drive](/guides/documents/adding-accounts/add-google-drive-account/)
+- [OneDrive or SharePoint](/guides/documents/adding-accounts/add-onedrive-account/)
+- [AWS S3](/guides/documents/adding-accounts/add-aws-s3-account/)
+- [Azure Blob Storage](/guides/documents/adding-accounts/add-azure-blob-storage-account/)
+- [SFTP](/guides/documents/adding-accounts/add-sftp-account/)
+
+## Recommended Folder Shape
+
+For each migration batch, use a folder shape like this before importing:
+
+```text
+workflow-package/
+  workflows/
+  macros/
+  inputs/
+  expected-outputs/
+  reports/
+  spatial/
+```
+
+This structure is optional, but it makes review and validation easier.
+
+## Workflows And Macros
+
+Place workflow files and macros in predictable folders:
+
+- Put `.yxmd` and `.yxwz` files in `workflows/`.
+- Put `.yxmc` files in `macros/`.
+- Keep nested macros with the rest of the macro library.
+- Keep duplicate macro names out of the same package unless they are intentionally versioned.
+
+PlaidCloud uses macro source files to create PlaidCloud macro workflows and connect macro calls from converted workflows.
+
+## Input Files
+
+Put input data under `inputs/`:
+
+- CSV, TSV, fixed-width, JSON, XML, Excel, Access, YXDB, SAS, SPSS, Stata, Avro, Parquet, and HDF files.
+- Lookup files used by formulas, dynamic replace, fuzzy matching, or joins.
+- Folders referenced by Directory and Dynamic Input tools.
+
+When PlaidCloud imports the package, converted steps point to the selected Document locations.
+
+## Spatial Files
+
+Put spatial files under `spatial/` and keep sidecars together:
+
+- Shapefiles: include `.shp`, `.shx`, `.dbf`, and `.prj`.
+- MapInfo files: include `.tab`, `.map`, `.id`, and `.dat`.
+- Include projection files and lookup layers when present.
+- Keep KML, GeoJSON, and other spatial inputs in the same dependency package.
+
+Do not split spatial sidecars across folders. PlaidCloud needs the full group to materialize geometry correctly.
+
+## Report And Artifact Assets
+
+Put report assets under `reports/`:
+
+- Images used by report composer tools.
+- PDF inputs.
+- HTML fragments or templates.
+- Map layers used by report maps.
+- Example generated reports when artifact validation is required.
+
+Converted report steps create PlaidCloud artifacts that can be reviewed from Document and workflow run history.
+
+## Expected Outputs
+
+Put validation fixtures under `expected-outputs/`:
+
+- Trusted Alteryx output tables.
+- Expected reports, PDFs, maps, images, or charts.
+- Notes about accepted row ordering, numeric precision, and date handling.
+
+Expected outputs are optional for structural validation and are the best evidence for output parity validation.
+
+## External Connections
+
+For database, API, and cloud-source workflows, capture:
+
+1. Source system name.
+2. Connection type.
+3. Database, schema, table, endpoint, or bucket names.
+4. Credential owner or secret name.
+5. Snapshot date when output parity depends on a point-in-time source.
+
+Use PlaidCloud connections or credentials for repeatable production runs.
+
+## Related Guides
+
+- [Alteryx Migration Readiness Checklist](/guides/workflows/alteryx-migration-readiness-checklist/)
+- [Migrate Alteryx Workflows](/guides/workflows/migrate-alteryx-workflows/)
+- [Orchestrate Alteryx Migrations With MCP](/guides/workflows/orchestrate-alteryx-migrations-with-mcp/)
+- [Tune Alteryx Imports](/guides/workflows/troubleshoot-alteryx-imports/)

--- a/src/content/docs/guides/workflows/troubleshoot-alteryx-imports.mdx
+++ b/src/content/docs/guides/workflows/troubleshoot-alteryx-imports.mdx
@@ -1,0 +1,122 @@
+---
+title: Tune Alteryx Imports
+description: Tune Alteryx migrations with dependency completion, macro resolution, variables, validation comparisons, and managed executors.
+sidebar:
+  order: 35
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+PlaidCloud imports Alteryx workflows into Advanced workflows and reports conversion details during import. Use this guide to quickly complete dependency packages, review generated macros, tune variables, and interpret validation comparisons.
+
+<Aside type="note">
+  Start with the conversion summary. It highlights dependency, macro, variable, executor, and validation items before you need to inspect individual steps.
+</Aside>
+
+## Complete Input Files
+
+Symptoms:
+
+- A converted input step cannot find a file.
+- Dynamic input resolves to no files.
+- Validation row counts are lower than expected.
+
+Actions:
+
+1. Confirm the file was included in the import package.
+2. Confirm the file was uploaded to the selected Document path.
+3. Confirm dynamic file patterns still match after upload.
+4. Re-import or update the converted step to use the correct Document path.
+
+## Complete Spatial Sidecars
+
+Symptoms:
+
+- Spatial input needs a companion file.
+- Geometry fields are empty.
+- Spatial output differs from the expected result.
+
+Actions:
+
+1. Confirm all shapefile or MapInfo sidecars were included.
+2. Keep sidecars in the same Document folder.
+3. Confirm projection files are present when the workflow depends on coordinate reference behavior.
+4. Rerun the workflow after correcting the package.
+
+## Complete Or Clarify Macros
+
+Symptoms:
+
+- A macro call cannot resolve.
+- Macro inputs or outputs are not connected.
+- A workflow imports structurally and a macro output needs to be connected.
+
+Actions:
+
+1. Include the `.yxmc` file for each referenced macro.
+2. Include nested macros called by those macros.
+3. Avoid duplicate macro names unless the package intentionally includes versioned macros.
+4. Confirm the generated PlaidCloud macro has macro input and macro output steps.
+
+## Workflow Variable Issues
+
+Symptoms:
+
+- A converted app input is unset.
+- A condition fires unexpectedly.
+- A file or folder variable points to a desktop path.
+
+Actions:
+
+1. Review workflow variables before running.
+2. Set required values.
+3. Replace desktop file paths with Document file or folder paths.
+4. Confirm controlled choices match the expected app selection.
+5. Rerun the workflow.
+
+## Validation Differences
+
+Symptoms:
+
+- Schema differs.
+- Row count differs.
+- Row values differ.
+- Artifact output has a difference to review.
+
+Actions:
+
+1. Confirm the same input data was used in both runs.
+2. Confirm variable values match.
+3. Confirm source systems are from the same snapshot date.
+4. Review null handling, date handling, numeric precision, and string collation.
+5. For spatial outputs, review geometry format and coordinate reference behavior.
+6. For artifacts, confirm the intended cloud-native output and compare the business content.
+
+## Executor Notes
+
+Specialized operations such as fuzzy matching, spatial processing, machine learning, PDF extraction, OCR, NLP, and reporting can run through managed executors.
+
+If an executor reports a note:
+
+1. Open the workflow run details.
+2. Review the step note.
+3. Confirm required inputs and parameters are present.
+4. Confirm expected output fixtures are available if parity validation is required.
+5. Rerun after correcting inputs or settings.
+
+## When To Re-Import
+
+Re-import when:
+
+- Important files or macros were added after the original package.
+- The wrong Document path was selected.
+- A newer workflow version should replace the imported version.
+- The workflow package needs a cleaner dependency layout.
+
+If only a variable value, credential, or Document path changed, updating the converted workflow may be enough.
+
+## Related Guides
+
+- [Package Alteryx Dependencies](/guides/workflows/package-alteryx-dependencies/)
+- [Validate Converted Alteryx Workflows](/guides/workflows/validate-converted-alteryx-workflows/)
+- [Alteryx Conversion Matrix](/reference/alteryx-conversion-matrix/)

--- a/src/content/docs/guides/workflows/use-converted-alteryx-apps.mdx
+++ b/src/content/docs/guides/workflows/use-converted-alteryx-apps.mdx
@@ -1,0 +1,84 @@
+---
+title: Use Converted Alteryx Apps
+description: Run converted Alteryx analytic apps in PlaidCloud with controlled workflow variables and repeatable inputs.
+sidebar:
+  order: 34
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+PlaidCloud converts Alteryx analytic app questions into controlled workflow variables. Users can set those variables before a run, then PlaidCloud applies the values to formulas, filters, file paths, conditions, macro parameters, and downstream step settings.
+
+<Aside type="note">
+  Converted app inputs are designed for repeatable cloud runs. Use saved variable values for scheduled workflows and controlled user input for interactive runs.
+</Aside>
+
+## Converted Input Types
+
+PlaidCloud converts common Alteryx app controls to typed workflow inputs:
+
+- Text boxes become text variables.
+- Numeric controls become numeric variables.
+- Date controls become ISO date variables.
+- Check boxes, radio buttons, drop-downs, list boxes, and trees become controlled choice variables.
+- File browse controls become Document file variables.
+- Folder browse controls become Document folder variables.
+
+The converted workflow uses these variables anywhere the Alteryx app used the original question value.
+
+## Set Values Before A Run
+
+Before running a converted app workflow:
+
+1. Open the converted workflow.
+2. Review workflow variables.
+3. Set required text, numeric, date, choice, file, and folder values.
+4. Confirm Document file and folder paths point to the imported dependency location or another approved Document path.
+5. Run the workflow.
+
+For scheduled runs, save the variable values that should be used each time the schedule runs.
+
+## Conditions, Warnings, And Errors
+
+Alteryx app conditions and error checks convert to PlaidCloud step conditions. A condition can:
+
+- Allow the workflow to continue.
+- Emit a warning message.
+- Stop the workflow with a clear error when the app rule calls for it.
+- Route execution through a different branch.
+
+Use this behavior to preserve app-level validation while running the workflow in PlaidCloud.
+
+## File And Folder Inputs
+
+File and folder questions use Document paths:
+
+- File inputs select a file from Document.
+- Folder inputs select a Document folder.
+- Imported desktop dependencies are stored at the Document path selected during import.
+- Dynamic input steps can use variables to resolve the final Document path at runtime.
+
+This keeps converted apps portable across users and scheduled runs.
+
+## Macro Parameters
+
+When a converted app calls a macro, app variables can feed macro parameters. PlaidCloud passes those values into the generated macro workflow through macro input and control parameter handling.
+
+Concurrent macro runs are isolated, so multiple workflow runs can use the same converted macro without sharing intermediate state.
+
+## Validation Checklist
+
+For each converted app, confirm:
+
+- Every expected question appears as a workflow variable.
+- Defaults match the original app where defaults were configured.
+- Controlled lists contain the expected choices.
+- File and folder variables point to Document paths.
+- Conditions produce the expected messages, warnings, or stop behavior.
+- Output parity passes for the selected variable values.
+
+## Related Guides
+
+- [Migrate Alteryx Workflows](/guides/workflows/migrate-alteryx-workflows/)
+- [Manage Workflow Variables](/guides/workflows/manage-workflow-variables/)
+- [Validate Converted Alteryx Workflows](/guides/workflows/validate-converted-alteryx-workflows/)

--- a/src/content/docs/guides/workflows/validate-alteryx-reports-and-artifacts.mdx
+++ b/src/content/docs/guides/workflows/validate-alteryx-reports-and-artifacts.mdx
@@ -1,0 +1,92 @@
+---
+title: Validate Alteryx Reports And Artifacts
+description: Validate converted Alteryx reports, PDFs, images, maps, charts, dashboards, and model artifacts in PlaidCloud.
+sidebar:
+  order: 36
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Some Alteryx workflows create files and visual outputs rather than only tables. PlaidCloud converts these steps into cloud-native artifacts that can be stored in Document, reviewed from workflow run history, and used by downstream processes.
+
+<Aside type="note">
+  Artifact validation focuses on the business content and downstream usability of the generated output. PlaidCloud produces cloud-native artifacts designed for sharing, scheduling, and repeatable review.
+</Aside>
+
+## Artifact Types
+
+Converted workflows can produce or use:
+
+- PDFs.
+- Images.
+- Charts.
+- Maps.
+- HTML or report fragments.
+- Report tables and layouts.
+- Dashboards or insight-style review artifacts.
+- Model, NLP, OCR, or text-analysis outputs.
+
+PlaidCloud stores generated files in Document when the converted workflow writes an artifact.
+
+## Validate Report Content
+
+For reports and PDFs, confirm:
+
+1. The file was created in the expected Document path.
+2. The report contains the expected tables, labels, sections, and values.
+3. Images and logos appear where expected.
+4. Page-level layout is acceptable for the business use.
+5. Downstream users can open or distribute the file.
+
+When exact layout is important, compare the PlaidCloud artifact to a trusted Alteryx output.
+
+## Validate Charts And Dashboards
+
+For charts and dashboard-style outputs, confirm:
+
+1. The source data matches expected schema, row count, and values.
+2. Measures, dimensions, and labels are correct.
+3. Filters or parameters were applied correctly.
+4. The generated chart or dashboard supports the intended review workflow.
+
+PlaidCloud may create a cloud-native visualization rather than reproducing an Alteryx desktop-specific renderer.
+
+## Validate Maps
+
+For map outputs, confirm:
+
+1. Spatial inputs loaded successfully.
+2. Coordinate reference behavior is acceptable.
+3. Map layers contain the expected records.
+4. Labels, boundaries, and geometry are correct for the business use.
+5. Any intentional cloud-native artifact difference is documented.
+
+For data-critical map workflows, also validate the geometry table behind the artifact.
+
+## Validate OCR, PDF, And NLP Outputs
+
+For extraction and text workflows, confirm:
+
+1. The expected files were processed.
+2. Extracted text, tables, scores, topics, or classifications are present.
+3. Output tables match expected schema and row counts.
+4. Values match expected outputs within agreed tolerance.
+5. Executor notes were reviewed.
+
+## Acceptance Record
+
+For production migrations, keep a validation record with:
+
+- Workflow name.
+- Run date.
+- Document output path.
+- Expected output source.
+- Validation level.
+- Accepted cloud-native artifact differences.
+- Approver.
+
+## Related Guides
+
+- [Validate Converted Alteryx Workflows](/guides/workflows/validate-converted-alteryx-workflows/)
+- [Migrate Spatial Alteryx Workflows](/guides/workflows/migrate-spatial-alteryx-workflows/)
+- [Alteryx Conversion Matrix](/reference/alteryx-conversion-matrix/)

--- a/src/content/docs/guides/workflows/validate-converted-alteryx-workflows.mdx
+++ b/src/content/docs/guides/workflows/validate-converted-alteryx-workflows.mdx
@@ -1,0 +1,137 @@
+---
+title: Validate Converted Alteryx Workflows
+description: Validate converted Alteryx workflows with structural checks, output parity checks, macro validation, and artifact review.
+sidebar:
+  order: 31
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Validation confirms that a converted Alteryx workflow is ready to run in PlaidCloud and, when expected outputs are available, produces the same business results.
+
+Use this guide after importing a workflow, app, or macro into PlaidCloud.
+
+<Aside type="note">
+  Output parity means matching schema, row count, and row values. Row order does not need to match unless the workflow uses ordering as part of the business logic.
+</Aside>
+
+## Choose A Validation Level
+
+Most migration programs use two validation levels.
+
+### Structural Validation
+
+Structural validation confirms that PlaidCloud created a complete workflow from the Alteryx design. Use this level when you are measuring migration readiness, preparing a portfolio inventory, or converting workflows before expected outputs are available.
+
+Check that:
+
+1. The converted workflow opens in the Visual Workflow Designer.
+2. The workflow graph contains the expected branches, joins, macros, and outputs.
+3. All required input files were uploaded to the selected Document path.
+4. All required macros were imported or generated.
+5. Macro inputs and macro outputs are connected.
+6. Analytic app questions became workflow variables with controlled input fields.
+7. The workflow run completes and reports clear readiness notes for data-dependent conditions.
+
+### Output Parity Validation
+
+Output parity validation confirms that the converted workflow produces the same tabular results as the Alteryx workflow.
+
+Compare:
+
+1. Output table schema.
+2. Row count.
+3. Row values.
+4. Null handling.
+5. Numeric precision and rounding.
+6. Date and time values.
+7. Geometry values when spatial outputs are part of the result.
+
+Ignore row order unless the workflow explicitly sorts data or the downstream process depends on ordered rows.
+
+## Validate Inputs
+
+Before comparing outputs, confirm that the converted workflow uses the same source data:
+
+1. Open the Document folder selected during import.
+2. Confirm that required files and sidecar files are present.
+3. Confirm that dynamic input patterns resolve to the intended files.
+4. Confirm that database or API credentials are available in the target environment.
+5. Confirm that workflow variables match the values used in the Alteryx run.
+
+Aligned inputs make validation faster and keep comparisons focused on workflow behavior.
+
+## Validate Macros
+
+Converted Alteryx macros become PlaidCloud macro workflows. Validate the macro and the calling workflow together:
+
+1. Open the generated macro workflow.
+2. Confirm that each macro input has a matching macro input step.
+3. Confirm that each macro output has a matching macro output step.
+4. Run a workflow that calls the macro.
+5. Confirm that repeated or concurrent runs remain isolated from one another.
+6. Compare the macro output data when expected macro fixtures are available.
+
+## Validate Analytic Apps
+
+Converted Alteryx analytic apps use workflow variables for controlled user input.
+
+Check that:
+
+- Text boxes, numeric inputs, dates, file pickers, folder pickers, lists, trees, radio buttons, check boxes, and drop-downs expose the expected input controls.
+- Default values match the original app where defaults were present.
+- Required values are set before running the workflow.
+- Conditions produce the expected messages, warnings, or stop behavior for the configured input values.
+
+## Validate Specialized Outputs
+
+Some converted workflows create artifacts instead of only tables. Validate those outputs according to how they are used.
+
+For reports, PDFs, images, charts, and maps:
+
+1. Confirm that the artifact was created in the expected Document path.
+2. Confirm that the artifact contains the expected data, labels, images, and layout.
+3. Confirm that downstream consumers can open or use the artifact.
+4. Compare to an expected artifact when one is available.
+
+For machine learning, NLP, fuzzy matching, and spatial workflows:
+
+1. Confirm that the managed job executor completed successfully.
+2. Review executor notes.
+3. Compare generated tables or scores to expected outputs.
+4. Document any cloud-native artifact differences when PlaidCloud output intentionally differs from an Alteryx desktop-specific output.
+
+## Resolve Validation Differences
+
+When validation finds a difference, review items in this order:
+
+1. Missing or different input files.
+2. Different workflow variable values.
+3. Different database snapshots or API responses.
+4. Date, time zone, null, rounding, or string-collation differences.
+5. Spatial reference or geometry format differences.
+6. Cloud-native artifact differences for reports, maps, proprietary formats, or desktop-only renderers.
+
+After correcting the cause, rerun the workflow and repeat the comparison.
+
+## Promote A Validated Workflow
+
+When validation passes:
+
+1. Move or copy the workflow to the production project if migration was done in a staging project.
+2. Confirm production Document paths and credentials.
+3. Schedule the workflow.
+4. Monitor the first production runs in run history.
+5. Keep the validation results with the migration record for audit and support.
+
+## Related Guides
+
+- [Migrate Alteryx Workflows](/guides/workflows/migrate-alteryx-workflows/)
+- [Alteryx Migration Readiness Checklist](/guides/workflows/alteryx-migration-readiness-checklist/)
+- [Package Alteryx Dependencies](/guides/workflows/package-alteryx-dependencies/)
+- [Use Converted Alteryx Apps](/guides/workflows/use-converted-alteryx-apps/)
+- [Orchestrate Alteryx Migrations With MCP](/guides/workflows/orchestrate-alteryx-migrations-with-mcp/)
+- [Validate Alteryx Reports And Artifacts](/guides/workflows/validate-alteryx-reports-and-artifacts/)
+- [Alteryx Conversion Matrix](/reference/alteryx-conversion-matrix/)
+- [Create A Macro](/guides/workflows/create-a-macro/)
+- [Run A Workflow](/guides/workflows/run-a-workflow/)

--- a/src/content/docs/integrations/ai-coding-agents/getting-started.mdx
+++ b/src/content/docs/integrations/ai-coding-agents/getting-started.mdx
@@ -30,6 +30,7 @@ The catalog covers most of the day-to-day surface an agent needs:
 - **Lakehouse** — branches, snapshots, optimize/vacuum operations.
 - **Identity** — members, groups, sessions, distros.
 - **Documents, dashboards, UDFs, editors, agents, publishes** — domain-specific tools.
+- **Alteryx migration** — convert Alteryx workflows staged in Document and coordinate portfolio migration work.
 - **Workflow logs and run tracking** — `workflow_logs`, `workflow_run_status`, `workflow_job_track`.
 
 Every tool returns a uniform envelope `{ok, data, next_cursor?, total?}`; failures use `{ok: false, error: {code, retryable, message, hint?}}`. Mutations accept `dry_run=True` for plan-without-write validation.

--- a/src/content/docs/reference/alteryx-conversion-matrix.md
+++ b/src/content/docs/reference/alteryx-conversion-matrix.md
@@ -1,0 +1,120 @@
+---
+title: Alteryx Conversion Matrix
+description: Coverage reference for how PlaidCloud converts Alteryx tools into Advanced workflow steps, macros, typed variables, Document assets, and managed job executors.
+sidebar:
+  order: 6
+---
+
+PlaidCloud converts Alteryx workflows, apps, and macros into Advanced workflows. The importer maps each Alteryx object to a native workflow step, macro construct, controlled variable, Document-backed file operation, or managed job executor.
+
+Coverage levels:
+
+- **Fully Converts** - converted directly to native PlaidCloud DAG behavior.
+- **Converts With Validation** - converted to PlaidCloud behavior and should be validated against expected outputs for option-level parity.
+- **Converts To Executor** - converted to a managed PlaidCloud job executor for specialized processing.
+- **Cloud-Native Equivalent** - converted to a useful PlaidCloud artifact or operation that preserves the business purpose in a cloud-native form.
+- **Annotation Only** - retained as workflow context, layout, or pass-through behavior with no separate runtime operation.
+
+| Alteryx Object | Coverage Level | PlaidCloud Operation | Notes |
+| --- | --- | --- | --- |
+| Action | Fully Converts | Variable binding and conditional step configuration | Updates downstream settings from converted app inputs. |
+| AlteryxSelect | Fully Converts | Select and schema projection step | Keeps selected, renamed, and reordered fields. |
+| AppendFields | Fully Converts | Append fields transform | Appends fields from one stream to another. |
+| AutoField | Converts With Validation | Auto field sizing transform | Preserves inferred field sizing intent; validate schema where precision matters. |
+| BrowseV2 | Annotation Only | Browse or passthrough marker | Preserved for inspection without adding runtime work. |
+| Buffer | Converts To Executor | Spatial executor | Creates buffered geometries with validation against spatial fixtures. |
+| CheckBoxGroup | Fully Converts | Controlled workflow variable | Converts app check box choices to controlled user input. |
+| Classification | Converts To Executor | Machine learning executor | Runs classification logic through managed ML execution. |
+| Condition | Fully Converts | Step condition with warning or error action | Uses workflow step conditions to trigger warnings, errors, or branches. |
+| ControlParam | Fully Converts | Macro control parameter | Maps to PlaidCloud macro parameter handling. |
+| CreatePoints | Fully Converts | Geometry point creation transform | Creates point geometry from coordinate fields. |
+| CrossTab | Fully Converts | Pivot or cross-tab transform | Converts rows to columns. |
+| DataCleansePro | Converts With Validation | Data cleanse transform | Cleans whitespace, nulls, punctuation, and casing according to configured options. |
+| Date | Fully Converts | Workflow variable date value | Emits ISO date values for downstream steps and conditions. |
+| DateTime | Converts With Validation | Date and time transform | Converts date and time parsing or formatting logic. |
+| DbFileInput | Fully Converts | Document-backed file input or data materializer | Loads source files from Document into workflow data. |
+| DbFileOutput | Fully Converts | Document-backed file output or table write | Writes output data to Document or PlaidCloud tables. |
+| Detour | Fully Converts | Conditional branch routing | Converts route selection to DAG conditions. |
+| DetourEnd | Fully Converts | Conditional branch merge | Rejoins conditionally selected branches. |
+| Directory | Fully Converts | Document directory listing | Lists files from a Document path. |
+| Distance | Converts To Executor | Spatial distance executor | Computes distance using managed spatial processing. |
+| Download | Converts To Executor | HTTP download executor | Downloads external data or artifacts. |
+| DropDown | Fully Converts | Controlled workflow variable | Converts app drop-down choices to controlled user input. |
+| DynamicInput | Converts With Validation | Dynamic Document input | Resolves file patterns or variable-driven inputs at runtime. |
+| DynamicRename | Fully Converts | Dynamic rename transform | Renames fields using metadata or configured rules. |
+| DynamicReplace | Converts With Validation | Dynamic replace transform | Applies replacement rules from a second data stream. |
+| DynamicSelect | Fully Converts | Dynamic field selection transform | Selects fields by type, name, or rule. |
+| Error | Fully Converts | Step condition with error action | Converts configured error behavior to PlaidCloud step conditions. |
+| FileBrowse | Fully Converts | Controlled Document file variable | Lets users choose a file for a converted app run. |
+| Filter | Fully Converts | Filter transform | Splits records by expression into true and false paths. |
+| FindNearest | Converts To Executor | Spatial nearest-neighbor executor | Finds nearest spatial records with managed spatial processing. |
+| Fit | Converts To Executor | Model training executor | Trains or fits model behavior through managed execution. |
+| FolderBrowse | Fully Converts | Controlled Document folder variable | Lets users choose a folder for a converted app run. |
+| Formula | Fully Converts | Formula transform | Converts field expressions to PlaidCloud expressions or SQL-backed logic. |
+| FuzzyMatch | Converts To Executor | Fuzzy matching executor | Uses managed fuzzy matching for match keys, thresholds, and candidate review. |
+| Generalize | Converts To Executor | Spatial generalization executor | Simplifies geometry while preserving the requested spatial intent. |
+| HtmlBox | Cloud-Native Equivalent | Report text or HTML artifact | Preserves content in PlaidCloud report or artifact output. |
+| ImageToText | Converts To Executor | OCR executor | Extracts text from images through managed OCR. |
+| Insights | Cloud-Native Equivalent | PlaidCloud dashboard or artifact output | Creates a cloud-native review artifact for repeatable sharing and review. |
+| Join | Fully Converts | Join transform | Produces joined, left-only, and right-only streams. |
+| JoinMultiple | Fully Converts | Multi-join transform | Joins multiple input streams. |
+| Label | Annotation Only | Canvas label | Preserved as workflow context. |
+| LabelGroup | Annotation Only | Canvas label group | Preserved as workflow context. |
+| Link | Annotation Only | Canvas link or annotation | Preserved as workflow context. |
+| ListBox | Fully Converts | Controlled workflow variable | Converts app list selections to controlled user input. |
+| MacroInput | Fully Converts | PlaidCloud macro input port | Maps directly to a PlaidCloud macro input step. |
+| MacroOutput | Fully Converts | PlaidCloud macro output port | Maps directly to a PlaidCloud macro output step. |
+| Map | Cloud-Native Equivalent | Map artifact or spatial visualization | Creates a PlaidCloud map artifact for cloud review and sharing. |
+| MapInput | Converts With Validation | Spatial input materializer | Loads spatial input data into the converted workflow. |
+| Message | Fully Converts | Step condition with warning or message action | Emits workflow warning, message, or error based on configured condition. |
+| Modeling | Converts To Executor | Machine learning executor | Runs model-oriented processing through managed execution. |
+| MultiFieldFormula | Converts With Validation | Multi-field formula transform | Applies a formula across selected fields. |
+| MultiRowFormula | Converts With Validation | Window or row-aware formula transform | Converts row-relative logic to PlaidCloud window behavior where possible. |
+| NumericUpDown | Fully Converts | Controlled numeric workflow variable | Converts app numeric input to a typed variable. |
+| Overlay | Converts To Executor | Spatial overlay executor | Performs spatial overlay operations through managed spatial processing. |
+| PDFInput | Converts To Executor | PDF extraction executor | Extracts text or tables from PDFs. |
+| PlotlyCharting | Cloud-Native Equivalent | Chart artifact | Creates a PlaidCloud chart artifact from converted data. |
+| PolyBuild | Converts To Executor | Spatial polygon build executor | Builds polygon geometry from spatial inputs. |
+| PortfolioComposerImage | Cloud-Native Equivalent | Report image artifact | Places images into generated PlaidCloud report artifacts. |
+| PortfolioComposerLayout | Cloud-Native Equivalent | Report layout artifact | Converts layout intent to PlaidCloud report generation. |
+| PortfolioComposerRender | Cloud-Native Equivalent | Report render artifact | Renders report output as a PlaidCloud artifact. |
+| PortfolioComposerTable | Cloud-Native Equivalent | Report table artifact | Converts report table content to PlaidCloud report output. |
+| PortfolioComposerText | Cloud-Native Equivalent | Report text artifact | Converts report text content to PlaidCloud report output. |
+| Predict | Converts To Executor | Prediction executor | Scores records using managed model execution. |
+| RadioButtonGroup | Fully Converts | Controlled workflow variable | Converts app radio choices to controlled user input. |
+| RecordID | Fully Converts | Row identifier transform | Adds a deterministic record identifier. |
+| RegEx | Fully Converts | Regular expression transform | Parses, matches, or replaces text using configured expressions. |
+| Regression | Converts To Executor | Regression executor | Runs regression modeling through managed execution. |
+| ReportMap | Cloud-Native Equivalent | Map report artifact | Produces a cloud-native map/report artifact. |
+| Sample | Fully Converts | Sample transform | Keeps configured records by count, percentage, or grouping rule. |
+| Smooth | Converts To Executor | Spatial smoothing executor | Smooths geometry through managed spatial processing. |
+| Sort | Fully Converts | Sort transform | Sorts records by configured fields and directions. |
+| SpatialInfo | Converts With Validation | Spatial metadata transform | Extracts spatial metadata such as area, length, centroid, or bounds. |
+| SpatialMatch | Converts To Executor | Spatial match executor | Matches records by spatial relationship. |
+| SpatialProcess | Converts To Executor | Spatial processing executor | Runs spatial operations that require executor-backed geometry handling. |
+| Summarize | Fully Converts | Aggregate transform | Groups and aggregates records. |
+| Tab | Annotation Only | App tab grouping | Preserved as converted app structure where relevant. |
+| Test | Fully Converts | Step condition with warning or error action | Converts test assertions to PlaidCloud conditions. |
+| TextBox | Fully Converts | Controlled text workflow variable | Converts app text input to a typed variable. |
+| TextInput | Fully Converts | Inline table input | Creates inline data for the workflow. |
+| TextPreProcessing | Converts To Executor | NLP preprocessing executor | Performs text normalization and preprocessing. |
+| TextToColumns | Fully Converts | Split columns transform | Splits text into fields or rows. |
+| Tile | Converts With Validation | Tile or grouping transform | Assigns tile groups according to configured rules. |
+| ToolContainer | Annotation Only | Canvas container | Preserved as visual workflow organization. |
+| TopicModel | Converts To Executor | Topic modeling executor | Runs topic modeling through managed NLP execution. |
+| TradeArea | Converts To Executor | Spatial trade area executor | Creates trade area geometry through managed spatial processing. |
+| Transformation | Converts With Validation | Transform step | Converts configured transformation logic to PlaidCloud expressions or SQL. |
+| Transpose | Fully Converts | Unpivot transform | Converts columns to rows. |
+| Tree | Fully Converts | Controlled workflow variable | Converts app tree selection to controlled user input. |
+| Union | Fully Converts | Union transform | Combines streams by name, position, or configured field rules. |
+| Unique | Fully Converts | Unique and duplicate split transform | Separates first unique records from duplicates. |
+| VisualLayout | Annotation Only | Canvas layout metadata | Preserved as design context. |
+| WordCloud | Cloud-Native Equivalent | Text visualization artifact | Creates a PlaidCloud visualization artifact from text analysis output. |
+| XMLParse | Converts With Validation | XML parse transform | Extracts XML fields into workflow data. |
+| Missing plugin reference | Fully Converts | Macro invocation or generated placeholder when resolved | Imports known macro sources and maps macro calls to PlaidCloud macro steps. |
+
+## Validation Notes
+
+For production workflows, validate converted outputs against trusted Alteryx outputs. PlaidCloud validation focuses on schema, row count, and row values, and ignores row order unless the workflow explicitly depends on ordered data.
+
+Specialized operations such as spatial processing, fuzzy matching, machine learning, OCR, NLP, and reporting may run through managed job executors. These routes keep the converted workflow cloud-native while covering capabilities that are not best expressed as a single SQL transform.

--- a/src/content/docs/reference/index.mdx
+++ b/src/content/docs/reference/index.mdx
@@ -14,6 +14,11 @@ Reference material — search-driven rather than browse-driven. Use the search b
 		description="Every step type — import, export, table ops, allocations, notifications, document handling, SAP integrations, and more."
 	/>
 	<LinkCard
+		title="Alteryx Conversion Matrix"
+		href="/reference/alteryx-conversion-matrix/"
+		description="How Alteryx tools convert to PlaidCloud workflow steps, macros, variables, artifacts, and managed executors."
+	/>
+	<LinkCard
 		title="Expressions"
 		href="/reference/expressions/"
 		description="SQL functions for Lakehouse v1 and v2 — array, string, datetime, aggregate, window, geo, and others."


### PR DESCRIPTION
## Summary
- add a flagship Alteryx migration guide set covering migration, readiness, dependency packaging, validation, converted apps, spatial workflows, report/artifact validation, tuning, and MCP orchestration
- add a user-facing Alteryx conversion matrix with coverage levels and PlaidCloud equivalents
- link the migration docs from the workflow guide index, reference index, and MCP getting-started guide

## Validation
- npm run build (passed with network access for generated Open Graph font fetch)