### PR TITLE
Add control plane administration docs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -187,6 +187,7 @@ export default defineConfig({
 								{ label: 'Advanced (SSO/SAML)',     collapsed: true, items: [{ autogenerate: { directory: 'administration/access/advanced' } }] },
 							],
 						},
+						{ label: 'Control plane', collapsed: true, items: [{ autogenerate: { directory: 'administration/control-plane' } }] },
 						{ label: 'Scheduled events', collapsed: true, items: [{ autogenerate: { directory: 'administration/scheduled-events' } }] },
 					],
 				},

--- a/src/content/docs/administration/control-plane/index.mdx
+++ b/src/content/docs/administration/control-plane/index.mdx
@@ -1,0 +1,53 @@
+---
+title: Control Plane
+description: Use the PlaidCloud control plane to manage organizations, workspaces, access, workspace services, branding, and maintenance windows.
+sidebar:
+  label: Control Plane
+  order: 1
+---
+
+import { CardGrid, LinkCard, Aside } from '@astrojs/starlight/components';
+
+The PlaidCloud control plane is for partner administrators and customer administrators who manage organizations and workspaces. Use it to create workspaces, assign workspace ownership, choose release behavior, enable workspace services, configure branding, and manage organization-level access.
+
+<Aside type="note">
+	The PlaidAdmin area is for PlaidCloud operations staff. This guide covers the partner and customer administration areas only.
+</Aside>
+
+## What You Can Manage
+
+<CardGrid>
+	<LinkCard
+		title="Organizations"
+		href="/administration/control-plane/organizations/"
+		description="Configure organization identity, billing metadata, SSO behavior, and organization administrators."
+	/>
+	<LinkCard
+		title="Workspace Configuration"
+		href="/administration/control-plane/workspace-configuration/"
+		description="Review every workspace setting available in the control plane, including services, release channels, branding, lakehouse access, and maintenance."
+	/>
+</CardGrid>
+
+## Navigation
+
+After you sign in, use the left navigation:
+
+1. Open **Organizations** to view or edit organizations you administer.
+2. Open **Workspaces** to view, create, edit, pause, unpause, or bulk-update workspaces you can manage.
+3. Use your profile menu to update your account profile or sign out.
+
+The actions you see depend on your organization roles. For example, a user with workspace access can manage workspaces for an organization, while a user with security access can manage invitations and roles.
+
+## Roles
+
+Organization access is controlled by these roles:
+
+| Role | What It Allows |
+| --- | --- |
+| Admin | Edit organization settings and manage organization-level administration. |
+| Workspace | Create, edit, pause, unpause, delete, and version workspaces in the organization. |
+| Security | Invite users, remove users, and edit organization roles. |
+| Billing | View billing information when billing access is enabled. |
+
+Roles are assigned from the organization access dialog. A pending invitation becomes active after the invited person accepts it.

--- a/src/content/docs/administration/control-plane/organizations.mdx
+++ b/src/content/docs/administration/control-plane/organizations.mdx
@@ -1,0 +1,79 @@
+---
+title: Organizations
+description: Manage PlaidCloud organization settings, billing metadata, SSO requirements, and administrator access in the control plane.
+sidebar:
+  order: 2
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+An organization is the administrative boundary for related PlaidCloud workspaces. Organization settings control the name shown in the control plane, billing metadata, SSO behavior, and who can administer the organization.
+
+## Organization List
+
+The **Organizations** page shows the organizations you can access. From the table you can:
+
+1. Search organizations by visible table fields.
+2. Refresh the organization list.
+3. View organization details.
+4. Edit organization settings when you have admin access.
+5. Open organization access management when you have security access.
+6. Open billing records when you have billing access.
+
+## Organization Settings
+
+| Setting | Description |
+| --- | --- |
+| Name | Display name for the organization. |
+| ID | Stable organization identifier. It is set when the organization is created. |
+| Memo | Internal note or description shown in the control plane. |
+| Plan | Commercial plan: Enterprise, Team, or Free. |
+| Tax ID | Tax identifier used for billing records. |
+| Active | Whether the organization is active. |
+| Locked | Prevents normal organization changes while enabled. |
+| Require SSO | Requires members to sign in through the organization's single sign-on configuration. |
+
+## Billing Metadata
+
+Billing fields describe how the organization is billed. They do not grant product access by themselves.
+
+| Setting | Options |
+| --- | --- |
+| Billing cycle | Monthly, Quarterly, Semi-Annual, Annual |
+| Billing price | Numeric billing amount for the selected cycle. |
+| Payment type | PO Invoiced, Free Trial, Free, Scheduled Payment |
+
+## SSO Behavior
+
+| Setting | Description |
+| --- | --- |
+| Dynamic group assignment | Allows SSO group information to drive organization role assignment. |
+| Dynamic user creation | Allows SSO sign-in to create users automatically when the identity provider sends an accepted user. |
+| SSO dynamic group assignment name | The SSO group name used for dynamic assignment. |
+
+<Aside type="note">
+	SSO provider setup is documented separately in the Access management guides. These control-plane settings determine how the organization uses the SSO configuration after it exists.
+</Aside>
+
+## Manage Access
+
+Use **Manage Access** to invite people to the organization and assign organization roles.
+
+1. Open **Organizations**.
+2. Select the organization.
+3. Open **Manage Access**.
+4. Click **Invite User** to invite one or more email addresses.
+5. Select the roles each person should receive.
+6. Add an optional custom message.
+7. Send the invitation.
+
+You can edit roles for accepted users, remove accepted users, or cancel pending invitations. Pending users cannot be edited until they accept the invitation.
+
+## Organization Roles
+
+| Role | Use It For |
+| --- | --- |
+| Admin | Organization settings and administrator-level changes. |
+| Workspace | Workspace creation, configuration, release, pause, and unpause actions. |
+| Security | Invitations and organization role management. |
+| Billing | Billing record access. |

--- a/src/content/docs/administration/control-plane/workspace-configuration.mdx
+++ b/src/content/docs/administration/control-plane/workspace-configuration.mdx
@@ -1,0 +1,123 @@
+---
+title: Workspace Configuration
+description: Configure PlaidCloud workspace identity, release channel, services, branding, lakehouse access, invite links, and maintenance windows.
+sidebar:
+  order: 3
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+The **Workspaces** page lists the PlaidCloud workspaces you can manage. Use it to create a workspace, edit workspace settings, open the workspace, open dashboards, open the SQL console, view logs and metrics, or apply bulk actions to selected workspaces.
+
+<Aside type="caution">
+	Delete removes the workspace and its associated data. Confirm backups and retention requirements before deleting a workspace.
+</Aside>
+
+## Workspace List
+
+The workspace table includes name, unique ID, version, release channel, status, paused state, cluster, maintenance day, and maintenance time. The table supports search, refresh, row actions, and bulk actions.
+
+Available row actions include:
+
+| Action | Description |
+| --- | --- |
+| View | Open read-only workspace details. |
+| Edit | Change workspace configuration. |
+| Delete | Delete the workspace. |
+| Home | Open the workspace application. |
+| Dashboards | Open the workspace dashboard service. |
+| SQL | Open the workspace SQL console. |
+| Logs & Metrics | Open operational logs and metrics for the workspace. |
+
+## Bulk Actions
+
+Select one or more workspaces to use bulk actions.
+
+| Bulk Action | Description |
+| --- | --- |
+| Set Version | Pins selected workspaces to a chosen version. All selected workspaces must use the same release channel. |
+| Pause | Pauses selected workspaces. |
+| Unpause | Restores selected paused workspaces. |
+
+## Primary Settings
+
+Primary settings identify the workspace, assign ownership, and control release behavior.
+
+| Setting | Description |
+| --- | --- |
+| Name | Display name for the workspace. |
+| ID | Unique workspace identifier. This becomes part of the workspace identity and is set during creation. |
+| Memo | Optional description or administrative note. |
+| Organization | Organization that owns the workspace. |
+| Owner | Owner email for the workspace. |
+| Data Center (Cluster) | Data center or cluster where the workspace runs. |
+| Release | Release channel: Rapid, Regular, Stable, or No Release (pinned). |
+| Version | Specific deployed version. |
+| Active | Marks the workspace as active. |
+| Paused | Pauses workspace operation without deleting the workspace. |
+| Invite Link Lifespan | How long new-user invitation links remain valid. Options are 12 hours, 1 day, 2 days, 3 days, 5 days, 7 days, 10 days, and 14 days. |
+
+## Release Options
+
+| Release | Typical Use |
+| --- | --- |
+| Rapid | Receives updates earliest. Use for workspaces that can accept faster product change. |
+| Regular | Default update cadence for most workspaces. |
+| Stable | Slower cadence for workspaces that prioritize update stability. |
+| No Release (pinned) | Keeps the workspace on the selected version until an administrator changes it. |
+
+The maintenance window determines when automatic release updates are applied.
+
+## Theming
+
+Theming settings customize branding across workspace entry points.
+
+| Setting | Description |
+| --- | --- |
+| App Logo | Logo shown in the workspace application. |
+| Splash Screen Logo | Logo shown on the workspace splash or sign-in screen. |
+| Superset Logo | Logo shown in the dashboard service. |
+| Superset Custom Themes | Custom dashboard color themes available to the workspace. |
+
+## Services
+
+Service settings enable optional applications and supporting services inside the workspace.
+
+| Setting | Description |
+| --- | --- |
+| JupyterHub | Enables hosted notebook access for workspace users. |
+| Web SQL Console (CloudBeaver) | Enables browser-based SQL access. |
+| Dashboards (Apache Superset) | Enables the dashboard service. |
+| User Forms & Workflows (Forms Flow) | Enables forms and workflow app support. |
+| Changed Data Capture (Apache Flink) | Enables changed-data-capture processing. |
+| SFTP Access and Web UI | Enables SFTP access and the SFTP web interface. |
+| Use PlaidCloud Proxy Download | Routes downloads through the PlaidCloud proxy path. |
+| Activate Vector Database (Weaviate) | Enables vector database support. |
+| Activate Custom App Sandbox | Enables custom app sandbox support. |
+| Activate Project Management App | Enables the project management application. |
+
+Some services may require additional provisioning outside the control-plane form before users can use them.
+
+## Lakehouse
+
+Lakehouse settings control external database connectivity and extra database users.
+
+| Setting | Description |
+| --- | --- |
+| Enable External Database Access | Allows external clients to connect to the workspace lakehouse. |
+| Allowed CIDRs | Comma-separated CIDR ranges that are allowed to connect. Leave blank if no allow list is needed. |
+| Denied CIDRs | Comma-separated CIDR ranges that are denied. |
+| Additional Lakehouse Users | Extra lakehouse usernames and passwords for database access. |
+
+Use the narrowest CIDR ranges that support your users and integrations. Remove unused lakehouse users when access is no longer needed.
+
+## Maintenance
+
+Maintenance settings define the workspace's preferred update window.
+
+| Setting | Description |
+| --- | --- |
+| Day | Day of week for maintenance: Sunday through Saturday. |
+| Time | Time of day in 15-minute increments. |
+
+Release-channel upgrades use the workspace maintenance window. Pinned workspaces are skipped by automatic release-channel upgrades until an administrator selects a new version or channel.

--- a/src/content/docs/administration/index.mdx
+++ b/src/content/docs/administration/index.mdx
@@ -14,6 +14,11 @@ For workspace admins and security owners.
 		description="Organizations, workspaces, members, security groups, authentication, and single sign-on."
 	/>
 	<LinkCard
+		title="Control plane"
+		href="/administration/control-plane/"
+		description="Manage organizations, workspaces, services, branding, lakehouse access, and maintenance windows."
+	/>
+	<LinkCard
 		title="Scheduled events"
 		href="/administration/scheduled-events/"
 		description="Set up cron-based and event-driven workflow scheduling."


### PR DESCRIPTION
## Summary
- add a Control Plane section under Administration for partner and customer administrators
- document organization settings, billing metadata, SSO behavior, and organization access roles
- document workspace configuration options derived from the control-plane UI and REST models, excluding the internal Tenants area

## Validation
- npm run build