### PR TITLE
docs(ai-assistant): document asking the assistant for diagrams

### DIFF
--- a/src/content/docs/guides/ai-assistant/using-ai-assistant.mdx
+++ b/src/content/docs/guides/ai-assistant/using-ai-assistant.mdx
@@ -54,6 +54,21 @@ The assistant decides on its own which tools to call and which documents to cons
 If the answer doesn't use the tool you expected, rephrase the question or include the table, project, or document name explicitly.
 
 
+## Diagrams
+
+The assistant can draw a simple diagram to explain a process, a data flow, or how things relate — handy when a picture is clearer than a paragraph. Ask in plain language:
+
+- "Draw a flowchart of an ETL: extract, transform, load"
+- "Diagram how an order, a customer, and a line item relate"
+- "Show the approval steps as a sequence diagram"
+
+The diagram renders inline in the response as a picture, and the picture *is* the answer — there's no separate written explanation alongside it. Supported styles are flowcharts, sequence diagrams, entity-relationship diagrams, class diagrams, pie charts, and bar / trend charts; the assistant picks whichever fits the request.
+
+<Aside type="caution">The diagram assistant has no tools and cannot read your project's tables or data — it draws only from what you describe in the chat. To diagram real tables or lineage, describe them in your message, or ask a discovery question first and then say "draw that as a diagram" (the conversation carries over).</Aside>
+
+If a diagram can't be drawn, the response shows the underlying diagram text along with a brief "Couldn't render this diagram." note — rephrase or simplify your request and ask again.
+
+
 ## Expression AI
 
 The Expression Editor — used by Project Table, Calculate, Filter, and any other step that takes expressions — has the AI Assistant built in as a side panel.

--- a/src/content/docs/guides/ai-assistant/using-ai-assistant.mdx
+++ b/src/content/docs/guides/ai-assistant/using-ai-assistant.mdx
@@ -64,7 +64,7 @@ You don't have to split a task into separate messages. Ask for the whole thing a
 
 The assistant also remembers the conversation, so you can follow up without repeating yourself. After it shows a table, "now show only the negative rows" or "draw that as a chart" continues from what's already there.
 
-Before it does anything significant — importing a file, or creating or changing a resource — the assistant tells you what it's about to do and waits for your go-ahead rather than guessing.
+Before importing a file — or running a destructive operation such as dropping or deleting data — the assistant tells you what it's about to do and waits for your go-ahead rather than guessing.
 
 
 ## Importing a File
@@ -86,7 +86,7 @@ The assistant can draw a simple diagram to explain a process, a data flow, or ho
 - "Diagram how an order, a customer, and a line item relate"
 - "Show the approval steps as a sequence diagram"
 
-The diagram renders inline in the response as a picture, and the picture *is* the answer — there's no separate written explanation alongside it. Supported styles are flowcharts, sequence diagrams, entity-relationship diagrams, class diagrams, pie charts, and bar / trend charts; the assistant picks whichever fits the request.
+The diagram renders inline in the response as a picture, with a short plain-language description alongside it. The assistant draws a wide range of types and picks whichever fits the request — flowcharts, sequence and state diagrams, entity-relationship and class diagrams, pie charts, bar and trend charts, sankey flows, quadrant charts, gantt and timeline schedules, user journeys, mind maps, and more.
 
 <Aside type="caution">The diagram assistant has no tools and cannot read your project's tables or data — it draws only from what you describe in the chat. To diagram real tables or lineage, describe them in your message, or ask a discovery question first and then say "draw that as a diagram" (the conversation carries over).</Aside>
 

--- a/src/content/docs/guides/ai-assistant/using-ai-assistant.mdx
+++ b/src/content/docs/guides/ai-assistant/using-ai-assistant.mdx
@@ -86,7 +86,7 @@ The assistant can draw a simple diagram to explain a process, a data flow, or ho
 - "Diagram how an order, a customer, and a line item relate"
 - "Show the approval steps as a sequence diagram"
 
-The diagram renders inline in the response as a picture, with a short plain-language description alongside it. The assistant draws a wide range of types and picks whichever fits the request — flowcharts, sequence and state diagrams, entity-relationship and class diagrams, pie charts, bar and trend charts, sankey flows, quadrant charts, gantt and timeline schedules, user journeys, mind maps, and more.
+The diagram renders inline in the response as a picture, with a short plain-language description alongside it. The assistant draws a wide range of types and picks whichever fits the request — flowcharts, sequence and state diagrams, entity-relationship and class diagrams, pie charts, bar and trend charts, sankey flows, quadrant charts, gantt and timeline schedules, user journeys, mind maps, and more. The assistant won't restyle a diagram (custom colours, fonts, themes, or branding) — for styled, shareable visuals, build a [Dashboard](/guides/dashboards/) instead.
 
 <Aside type="caution">The diagram assistant has no tools and cannot read your project's tables or data — it draws only from what you describe in the chat. To diagram real tables or lineage, describe them in your message, or ask a discovery question first and then say "draw that as a diagram" (the conversation carries over).</Aside>
 

--- a/src/content/docs/guides/ai-assistant/using-ai-assistant.mdx
+++ b/src/content/docs/guides/ai-assistant/using-ai-assistant.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using the AI Assistant
-description: Chat with the PlaidCloud AI Assistant — manage conversations, see token usage, and ask the assistant to draft expressions for workflow steps.
+description: Chat with the PlaidCloud AI Assistant — ask multi-step questions about your data, import files, draw diagrams, draft expressions, and manage conversations.
 sidebar:
   order: 1
 ---
@@ -49,9 +49,33 @@ Every AI response shows the token usage for that turn — input tokens, output t
 
 ## Automatic Tool Selection
 
-The assistant decides on its own which tools to call and which documents to consult for each question. There are no toggles to choose what's used; tool selection happens behind the scenes by scoring the available tools against your prompt.
+The assistant decides on its own which tools to call and which documents to consult for each question. There are no toggles to choose what's used; tool selection happens behind the scenes, based on your prompt and the conversation so far.
 
 If the answer doesn't use the tool you expected, rephrase the question or include the table, project, or document name explicitly.
+
+
+## Multi-Step Requests
+
+You don't have to split a task into separate messages. Ask for the whole thing at once and the assistant works through the steps in order, carrying the result of each into the next:
+
+- "Find a table with cost data, then show me a few rows from it" — locates the table, then queries it
+- "Which tables have margin data? Show me the rows where margin is negative" — finds the table, then filters it
+- "Import the sales file from the Demo Data account and chart the monthly totals" — imports the file, then draws the chart
+
+The assistant also remembers the conversation, so you can follow up without repeating yourself. After it shows a table, "now show only the negative rows" or "draw that as a chart" continues from what's already there.
+
+Before it does anything significant — importing a file, or creating or changing a resource — the assistant tells you what it's about to do and waits for your go-ahead rather than guessing.
+
+
+## Importing a File
+
+The assistant can load a file from one of your project's document accounts into a new table, without building a workflow step. Tell it the account, the file path, and a name for the new table:
+
+- "Import /imports/customers.csv from the Demo Data account into a new table called Customers"
+
+It first inspects the file and shows you the columns it detected, then waits for you to confirm before importing — your chance to catch a wrong file or an unexpected schema. Confirm, and it loads the table and reports the new table's id, column count, and row count.
+
+<Aside>For a re-runnable import that lives in a workflow so it can be executed again later, ask the assistant to "create an import step" in a named workflow instead — it builds the step rather than doing a one-shot load.</Aside>
 
 
 ## Diagrams


### PR DESCRIPTION
## Summary

Adds a **Diagrams** section to the AI Assistant guide covering the new tool-less diagram sub-agent: how to ask for one in plain language, the six supported diagram styles (flowchart, sequence, ER, class, pie, bar / trend), the data-blindness caveat (no tools — draws only from the chat), and the raw-text-plus-note fallback when a diagram can't be drawn.

Content verified against the backend prompt and the front-end renderer so the supported-type list and fallback wording match what users will actually see.

## Paired PRs

- Backend: PlaidCloud/plaid#6084 — `feat(ai-chat): tool-less diagram sub-agent (Mermaid)`
- Frontend: `PlaidCloud/PlaidClient` branch `feat/ai-diagram-mermaid` (PR pending) — renders the emitted ` ```mermaid ` blocks as inline SVG

## Test plan

- [ ] Cloudflare "Workers Builds" preview check passes (the MDX compile gate)
- [ ] Vale advisory output reviewed
- [ ] Preview renders the new "Diagrams" section correctly, including the `<Aside type="caution">` callout