### PR TITLE
docs(ai-assistant): document multi-step requests and file import

### DIFF
--- a/src/content/docs/guides/ai-assistant/using-ai-assistant.mdx
+++ b/src/content/docs/guides/ai-assistant/using-ai-assistant.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using the AI Assistant
-description: Chat with the PlaidCloud AI Assistant — manage conversations, see token usage, and ask the assistant to draft expressions for workflow steps.
+description: Chat with the PlaidCloud AI Assistant — ask multi-step questions about your data, import files, draw diagrams, draft expressions, and manage conversations.
 sidebar:
   order: 1
 ---
@@ -49,9 +49,33 @@ Every AI response shows the token usage for that turn — input tokens, output t
 
 ## Automatic Tool Selection
 
-The assistant decides on its own which tools to call and which documents to consult for each question. There are no toggles to choose what's used; tool selection happens behind the scenes by scoring the available tools against your prompt.
+The assistant decides on its own which tools to call and which documents to consult for each question. There are no toggles to choose what's used; tool selection happens behind the scenes, based on your prompt and the conversation so far.
 
 If the answer doesn't use the tool you expected, rephrase the question or include the table, project, or document name explicitly.
+
+
+## Multi-Step Requests
+
+You don't have to split a task into separate messages. Ask for the whole thing at once and the assistant works through the steps in order, carrying the result of each into the next:
+
+- "Find a table with cost data, then show me a few rows from it" — locates the table, then queries it
+- "Which tables have margin data? Show me the rows where margin is negative" — finds the table, then filters it
+- "Import the sales file from the Demo Data account and chart the monthly totals" — imports the file, then draws the chart
+
+The assistant also remembers the conversation, so you can follow up without repeating yourself. After it shows a table, "now show only the negative rows" or "draw that as a chart" continues from what's already there.
+
+Before it does anything significant — importing a file, or creating or changing a resource — the assistant tells you what it's about to do and waits for your go-ahead rather than guessing.
+
+
+## Importing a File
+
+The assistant can load a file from one of your project's document accounts into a new table, without building a workflow step. Tell it the account, the file path, and a name for the new table:
+
+- "Import /imports/customers.csv from the Demo Data account into a new table called Customers"
+
+It first inspects the file and shows you the columns it detected, then waits for you to confirm before importing — your chance to catch a wrong file or an unexpected schema. Confirm, and it loads the table and reports the new table's id, column count, and row count.
+
+<Aside>For a re-runnable import that lives in a workflow so it can be executed again later, ask the assistant to "create an import step" in a named workflow instead — it builds the step rather than doing a one-shot load.</Aside>
 
 
 ## Diagrams


### PR DESCRIPTION
## Summary

Documents the AI Assistant's orchestrator behaviour for end users — extending the existing **Using the AI Assistant** guide:

- **Multi-Step Requests** — ask for a whole task in one message (find a table → query it; import a file → chart it); the assistant chains the steps and remembers context across turns.
- **Importing a File** — the conversational one-shot import flow (name the document account + path + table → it inspects, shows the detected columns, waits for your confirmation → imports), plus an aside pointing to "create an import step" for the re-runnable workflow variant.
- Softened the **Automatic Tool Selection** wording: the old text described the router's "score the tools against your prompt" mechanism; the orchestrator decides in-loop, so it now reads "based on your prompt and the conversation so far" (accurate either way).

## Stacking & timing

- **Stacked on #160** (`docs/ai-chat-diagrams` — the diagram-docs draft). Based on that branch so the diff is just the orchestrator commit; retarget to `main` once #160 merges.
- **Lands with B1 (orchestrator prod enablement).** It documents orchestrator behaviour (reliable multi-step chaining). Until `PLAID_AI_ORCHESTRATOR_ENABLED` is on in prod, live behaviour is still the router, which can stall on exactly these multi-step asks — so don't merge ahead of the flag flip.

## Validation

MDX is clean (no brace/JSX gotchas; only the already-imported `<Aside>`). Local Astro build not run (`node_modules` absent) — relying on the Cloudflare Workers Builds preview check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)