### PR TITLE
docs(releases): June 2026 notes + expand Jan–Apr 2026 with product features

### DIFF
--- a/src/content/docs/releases/2026-01.mdx
+++ b/src/content/docs/releases/2026-01.mdx
@@ -1,6 +1,6 @@
 ---
 title: January 2026
-description: Maintenance and infrastructure updates shipped to PlaidCloud tenants in January 2026.
+description: Retrieval-grounded AI answers, a Databricks connection type, faster AI responses, and more robust file imports.
 ---
 
 ## Releases Shipped
@@ -13,14 +13,17 @@ description: Maintenance and infrastructure updates shipped to PlaidCloud tenant
 | v5.5.1 | 2026-01-20 |
 | v5.5.2 | 2026-01-22 |
 
-Tenants received 5 updates this month. Work this month was primarily internal — infrastructure hardening, platform stability, and operational improvements.
+## Added
 
-## Notable Themes
+- **Retrieval-grounded AI answers** — the AI assistant now uses retrieval-augmented generation, drawing on your own content to give more accurate, better-grounded responses.
+- **Databricks connection** — connect to Databricks as a data source.
 
-- Lakehouse v2 (StarRocks) work
-- Secrets management and security hardening
-- Database operations
-- Superset (dashboards backend) updates
-- Access controls
+## Changed
 
-For specifics on a particular release, contact your account team.
+- **Faster, non-blocking AI** — AI tasks now run in the background and reuse cached context, so the assistant responds more quickly and the interface stays responsive while it works.
+- **More robust file imports** — improved handling of large CSV files and empty or malformed files makes imports more reliable.
+- **Improved password reset** — a smoother self-service password reset experience.
+
+## Platform
+
+- Continued Lakehouse v2 (StarRocks) work, secrets-management and security hardening, database-operations improvements, dashboard-backend updates, and access-control refinements shipped at the platform level.

--- a/src/content/docs/releases/2026-02.mdx
+++ b/src/content/docs/releases/2026-02.mdx
@@ -1,6 +1,6 @@
 ---
 title: February 2026
-description: Maintenance and infrastructure updates shipped to PlaidCloud tenants in February 2026.
+description: A per-project AI tab, import from Documents into a table, OneDrive integration, and UDF utility scripts.
 ---
 
 ## Releases Shipped
@@ -9,13 +9,18 @@ description: Maintenance and infrastructure updates shipped to PlaidCloud tenant
 |---|---|
 | v5.5.3 | 2026-02-15 |
 
-Tenants received 1 update this month. Work this month was primarily internal — infrastructure hardening, platform stability, and operational improvements.
+## Added
 
-## Notable Themes
+- **AI tab in every project** — each project now has a dedicated AI tab, so the assistant is available right where you work.
+- **Import Documents straight into a table** — turn a file stored in Documents into a table without a separate upload step.
+- **OneDrive integration** — connect OneDrive as a document storage account.
+- **UDF utility scripts** — helper scripts for working with user-defined functions.
 
-- Lakehouse engine (Databend) stability
-- Database operations
-- Superset (dashboards backend) updates
-- Tenant-specific customizations
+## Fixed
 
-For specifics on a particular release, contact your account team.
+- **QuickReport to Excel dates** — date values now export correctly to Excel.
+- **More reliable project import** — fixes to project slug handling and partial imports.
+
+## Platform
+
+- Lakehouse engine (Databend) stability, database-operations work, dashboard-backend updates, and tenant-specific customizations shipped at the platform level.

--- a/src/content/docs/releases/2026-03.mdx
+++ b/src/content/docs/releases/2026-03.mdx
@@ -1,6 +1,6 @@
 ---
 title: March 2026
-description: Maintenance and infrastructure updates shipped to PlaidCloud tenants in March 2026.
+description: Alteryx .yxdb import, export dashboards to PDF, Sage trial-balance import, and access-control hardening.
 ---
 
 ## Releases Shipped
@@ -9,11 +9,22 @@ description: Maintenance and infrastructure updates shipped to PlaidCloud tenant
 |---|---|
 | v5.5.4 | 2026-03-31 |
 
-Tenants received 1 update this month. Work this month was primarily internal — infrastructure hardening, platform stability, and operational improvements.
+## Added
 
-## Notable Themes
+- **Alteryx file import** — import Alteryx `.yxdb` data files into PlaidCloud, the first step toward bringing Alteryx work onto the platform.
+- **Export dashboards to PDF** — render a dashboard to PDF and save it straight to Documents.
+- **Sage trial-balance import** — import and post Sage trial-balance data.
 
-- Lakehouse engine (Databend) stability
-- Superset (dashboards backend) updates
+## Changed
 
-For specifics on a particular release, contact your account team.
+- **Clearer allocation alerts** — allocations now alert you about value columns used in numerator and denominator positions.
+- **More predictable CSV imports** — CSV type auto-detection is no longer applied on StarRocks, giving more consistent column typing.
+
+## Security
+
+- **Safer project-folder deletion** — removing a project folder now verifies you have access to every project it contains.
+- **No credentials in logs** — cloud storage credentials are no longer written to logs when a query fails.
+
+## Platform
+
+- Lakehouse engine (Databend) stability and dashboard-backend updates shipped at the platform level.

--- a/src/content/docs/releases/2026-04.mdx
+++ b/src/content/docs/releases/2026-04.mdx
@@ -1,6 +1,6 @@
 ---
 title: April 2026
-description: MCP ingress routes prepared, StarRocks 4.1 testing, Swagger UI moved into tenants.
+description: New platform REST API and MCP server, Alteryx workflow migration, Monday.com import, and per-tenant Swagger UI.
 ---
 
 ## Releases Shipped
@@ -19,5 +19,18 @@ description: MCP ingress routes prepared, StarRocks 4.1 testing, Swagger UI move
 
 ## Added
 
-- **Foundation for AI coding agent support** — initial ingress wiring for `/mcp` and `/.well-known/oauth-*` paths landed this month, enabling the MCP integrations that became user-facing in May.
+- **New platform REST API** — a modern REST API now spans the platform — projects and analysis, dashboards and documents, identity, and organization — with interactive documentation served per-tenant.
+- **MCP server for AI coding agents** — a Model Context Protocol server built on the new REST API lays the groundwork for connecting AI coding agents to PlaidCloud (the integration that became user-facing in May).
+- **Alteryx workflow migration** — convert Alteryx workflows into PlaidCloud workflows — including steps, tables, Excel-tab imports, and formula-to-expression conversion — launched right from the tools menu.
+- **Monday.com import** — pull data in from Monday.com as a workflow step.
 - **StarRocks 4.1 (Lakehouse v2) testing** — the next-generation Lakehouse engine is now being validated against real workloads. No customer-visible changes yet; opt-in migrations coming later.
+
+## Changed
+
+- **OneDrive drive and site browsing** — once you enter credentials, OneDrive now lists your available drives and sites to pick from.
+- **Clearer dashboard errors** — dashboard error messages now surface properly instead of being hidden behind a generic failure.
+
+## Security
+
+- **Automated security scanning in code review** — a static application security testing (SAST) tool now runs on code changes before they ship.
+- **Groundwork for passwordless accounts** — added the account-management capability to remove passwords, paving the way for passwordless sign-in.

--- a/src/content/docs/releases/2026-06.mdx
+++ b/src/content/docs/releases/2026-06.mdx
@@ -1,0 +1,48 @@
+---
+title: June 2026
+description: Multi-agent AI assistant, 140+ data connectors, Forecast and Solver workflow steps, collaborative Visual Workflow Designer, and passwordless support-team access.
+---
+
+## Releases Shipped
+
+| Version | Released |
+|---|---|
+| v5.7.1 | 2026-05-28 |
+
+:::note
+This page is being updated as June tenant releases are cut; the table above will grow as additional versions ship.
+:::
+
+## Added
+
+- **Multi-agent AI assistant** — the assistant now coordinates specialized sub-agents behind a single orchestrator, producing more accurate, better-reasoned answers to your data questions.
+- **Visual explanations in chat** — the assistant can generate diagrams and inline charts to illustrate its answers, so complex results are easier to understand at a glance.
+- **AI workflow step** — call a large language model directly as a step in your workflow, with multiple providers and access tiers supported.
+- **Chat on mobile** — talk to the AI assistant from the mobile app.
+- **140+ new data connectors** — a major expansion of supported data sources, with guided connection setup and automatic source discovery.
+- **Incremental, resumable syncs** — syncs pick up where they left off and merge new records by key, so you only move what's changed.
+- **Faster Snowflake imports** — server-side unload speeds up large imports from Snowflake.
+- **Forecast workflow step** — launch forecasting directly as a workflow step.
+- **Solver workflow step** — run optimization logic as part of a workflow.
+- **Concurrent macro execution** — macro steps can run work in parallel for faster processing.
+- **Compare and merge projects** — see the differences between two projects and safely merge changes between them.
+- **"Where Used" impact analysis** — quickly see where agents and external data connections are used before you change them.
+- **Allocation root-cause tracing** — new lineage and tracing tools make it easier to understand and troubleshoot how allocation results were produced.
+- **Workflow run history and heatmap** — a new run-history view with an activity heatmap to spot patterns and problem runs at a glance.
+- **Collaborative Visual Workflow Designer** — a visual view of your workflow with step color-coding, a redesigned canvas, and live collaboration so teammates can work on a workflow together.
+
+## Changed
+
+- **More relevant AI answers** — improved retrieval pulls in the right supporting context when the assistant answers, and expression-authoring help is now validated against the real runtime to catch mistakes earlier.
+- **Clearer AI activity** — a processing indicator shows while the assistant works on longer queries instead of leaving you with silent dead air, and conversations are now organized by project.
+- **More robust file imports** — improved Parquet handling and clearer, more reliable error reporting for problem files, including malformed XML and tricky text encodings.
+- **Smoother dashboards and user sync** — dashboard rendering fixes and tighter synchronization of users and roles with the analytics layer.
+- **More resilient connections** — self-healing for the caching layer and background-processing fixes reduce stalls and improve overall responsiveness.
+
+## Security
+
+- **Passwordless access for the PlaidCloud support team** — all support team members now sign in without usernames and passwords, eliminating password-based credentials as an attack vector for support access to the platform.
+- **Stronger per-tenant isolation** — each tenant now uses its own dedicated signing secrets for sessions and workflow steps.
+- **Cross-site scripting (XSS) hardening** — dialog content and on-screen notifications are safely escaped by default, with HTML allowed only where explicitly intended.
+- **Hardened file imports** — malformed uploads are handled safely instead of surfacing confusing errors.
+- **Continuous vulnerability scanning** — application images are automatically scanned for known security vulnerabilities as part of every build.

--- a/src/content/docs/releases/index.mdx
+++ b/src/content/docs/releases/index.mdx
@@ -11,6 +11,11 @@ Monthly summaries of changes shipped to PlaidCloud tenants. Months with substant
 
 <CardGrid>
 	<LinkCard
+		title="June 2026"
+		href="/releases/2026-06/"
+		description="v5.7.1 → · Multi-agent AI assistant, 140+ data connectors, Forecast & Solver steps, collaborative Workflow Designer, passwordless support access."
+	/>
+	<LinkCard
 		title="May 2026"
 		href="/releases/2026-05/"
 		description="v5.6.4 → v5.7.0 · Personal Temp Drive, Stripe self-service signup, MCP integration, app interface consolidated."
@@ -18,22 +23,22 @@ Monthly summaries of changes shipped to PlaidCloud tenants. Months with substant
 	<LinkCard
 		title="April 2026"
 		href="/releases/2026-04/"
-		description="v5.6.0 → v5.6.3 · MCP ingress foundation, Swagger UI moved into tenants, StarRocks 4.1 testing."
+		description="v5.6.0 → v5.6.3 · Platform REST API & MCP server, Alteryx workflow migration, Monday.com import, per-tenant Swagger UI."
 	/>
 	<LinkCard
 		title="March 2026"
 		href="/releases/2026-03/"
-		description="v5.5.4 · Maintenance update — internal infrastructure work only."
+		description="v5.5.4 · Alteryx .yxdb import, export dashboards to PDF, Sage trial-balance import, access-control hardening."
 	/>
 	<LinkCard
 		title="February 2026"
 		href="/releases/2026-02/"
-		description="v5.5.3 · Lakehouse stability and observability tuning."
+		description="v5.5.3 · Per-project AI tab, import Documents into a table, OneDrive integration, UDF utility scripts."
 	/>
 	<LinkCard
 		title="January 2026"
 		href="/releases/2026-01/"
-		description="v5.4.8 → v5.5.2 · ExternalSecrets rollout begins, Lakehouse stability work."
+		description="v5.4.8 → v5.5.2 · Retrieval-grounded AI answers, Databricks connection, faster AI, robust file imports."
 	/>
 </CardGrid>
 


### PR DESCRIPTION
## Summary

Backfills the monthly release notes with the user-facing product features that shipped, derived from `plaid` master merges. Previously the early-2026 pages were infrastructure-only stubs.

Mapping follows the established **one-month offset** (release page month ← prior month's development work), consistent with the existing May 2026 page (= April work).

| Page | Sourced from | Headline additions |
|---|---|---|
| **January 2026** | Dec 2025 dev | Retrieval-grounded AI answers, Databricks connection, faster non-blocking AI, robust file imports |
| **February 2026** | Jan 2026 dev | Per-project AI tab, import Documents into a table, OneDrive integration, UDF utility scripts |
| **March 2026** | Feb 2026 dev | Alteryx `.yxdb` import, export dashboards to PDF, Sage trial-balance import; access-control hardening |
| **April 2026** *(extended)* | Mar 2026 dev | Platform REST API + MCP server, Alteryx workflow migration, Monday.com import; SAST scanning, passwordless groundwork |
| **June 2026** *(new)* | May 2026 dev | Multi-agent AI assistant, 140+ connectors, Forecast/Solver steps, collaborative Workflow Designer, passwordless support access |

Index timeline cards updated to match.

## Notes

- Existing **version tables** were left untouched (already keyed to ship-month).
- Pure-internal commits (lint, dep bumps, CI plumbing, engine internals) were intentionally excluded.
- Some June items shipped **behind feature flags** in code, so rollout may be progressive.
- The June 2026 "Releases Shipped" table is seeded with `v5.7.1` and flagged WIP until June tenant releases are tagged.
- `npm run build` passes locally (1,430 pages, no errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)