### PR TITLE
docs(guides): add PlaidCloud Git user guide

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -141,6 +141,7 @@ export default defineConfig({
 						},
 						{ label: 'Email',             collapsed: true, items: [{ autogenerate: { directory: 'guides/email' } }] },
 						{ label: 'Panel apps',        collapsed: true, items: [{ autogenerate: { directory: 'guides/panel-apps' } }] },
+						{ label: 'PlaidCloud Git',    collapsed: true, items: [{ autogenerate: { directory: 'guides/git' } }] },
 						{ label: 'Projects',          collapsed: true, items: [{ autogenerate: { directory: 'guides/projects' } }] },
 						{ label: 'Sandbox',           collapsed: true, items: [{ autogenerate: { directory: 'guides/sandbox' } }] },
 						{ label: 'Workflows',         collapsed: true, items: [{ autogenerate: { directory: 'guides/workflows' } }] },

--- a/src/content/docs/guides/git/index.md
+++ b/src/content/docs/guides/git/index.md
@@ -1,0 +1,26 @@
+---
+title: PlaidCloud Git
+description: Host, version, and collaborate on Git repositories inside PlaidCloud — with issues, pull requests, project boards, releases, and wikis, and single sign-on built in.
+sidebar:
+  label: Overview
+  order: 0
+---
+
+PlaidCloud Git is a private Git service built into your workspace. Each workspace gets its own Git server for storing code, configuration, notebooks, and any other versioned files — together with the issues, pull requests, and project boards your team uses to collaborate on them.
+
+You sign in with your PlaidCloud account, so there's no separate username or password to set up. Open **Git** from your workspace and you're already signed in. New repositories are private by default, visible only to members you grant access.
+
+## What's in This Section
+
+- [Repositories](/guides/git/repositories/) — create a repository, then clone, commit, and push your work
+- [Issues](/guides/git/issues/) — track tasks, bugs, and ideas with labels, milestones, and assignees
+- [Pull Requests](/guides/git/pull-requests/) — propose changes on a branch and review them before they merge
+- [Project Boards](/guides/git/projects/) — organize issues and pull requests on a Kanban board
+- [Releases and Tags](/guides/git/releases-and-tags/) — mark and publish versioned snapshots of a repository
+- [Wikis](/guides/git/wikis/) — keep long-form documentation next to your code
+- [Packages](/guides/git/packages/) — publish and install build artifacts from the repository registry
+- [Searching Code](/guides/git/searching-code/) — find code, issues, and pull requests across your repositories
+
+## Related
+
+- [Access Management](/administration/access/) — how workspace membership and security groups govern who can see and edit repositories

--- a/src/content/docs/guides/git/issues.mdx
+++ b/src/content/docs/guides/git/issues.mdx
@@ -1,0 +1,61 @@
+---
+title: Issues
+description: Track tasks, bugs, and ideas in PlaidCloud Git using issues with labels, milestones, assignments, and links to code.
+sidebar:
+  order: 2
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Issues give your team a shared place to track bugs, plan features, and capture anything that needs attention — all linked directly to the code in your repository.
+
+## Create an Issue
+
+1. Open your repository and select the **Issues** tab.
+2. Select **New Issue**.
+3. Enter a concise **Title** that describes the problem or task.
+4. Write a **Description** using Markdown — include reproduction steps, acceptance criteria, screenshots, or code blocks as needed.
+5. Select **Submit New Issue** to publish it.
+
+<Aside>A repository can define reusable issue templates under **Settings → Issue Templates**. When templates are configured, opening a new issue presents a picker so contributors start from a consistent form rather than a blank page.</Aside>
+
+## Organize with Labels and Milestones
+
+**Labels** categorize and prioritize issues. Apply one or more labels from the right-hand sidebar when viewing an issue, or directly from the issue list using the **Label** filter. Common conventions are type labels (`bug`, `enhancement`) alongside priority labels (`high`, `low`), but you can create any labels that fit your workflow under **Issues → Labels**.
+
+**Milestones** group issues toward a shared target — a release date, a sprint, or a feature goal. Create milestones under **Issues → Milestones**, then assign an issue to a milestone from its sidebar. The milestone view shows progress as issues close.
+
+## Assign and Discuss
+
+- **Assignees** — use the **Assignees** field in the sidebar to indicate who is responsible. Any workspace member with repository access can be assigned.
+- **Comments** — add context, decisions, or status updates in the comment thread below the issue description.
+- **@mentions** — type `@username` anywhere in a comment or description to notify that person directly.
+- **Reactions** — use emoji reactions on comments to acknowledge a point without adding a reply.
+
+## Link Issues to Code
+
+Referencing issues from commits and pull requests keeps your history traceable.
+
+- **Reference by number** — type `#12` in a commit message, pull request description, or comment to create a clickable link to issue 12 in the same repository.
+- **Auto-close on merge** — include a closing keyword in a pull request description (for example, `Closes #12`, `Fixes #34`, or `Resolves #56`). When the pull request merges into the default branch, the referenced issues close automatically.
+- **Cross-reference other issues** — use `#number` freely in any issue comment to link related issues; each referenced issue displays a back-link so the connection is visible from both sides.
+
+## Find Issues
+
+The issue list supports several filters you can combine:
+
+| Filter | What It Does |
+|---|---|
+| **State** | Show open or closed issues |
+| **Label** | Narrow to one or more labels |
+| **Milestone** | Show issues assigned to a milestone |
+| **Assignee** | Show issues assigned to a specific person |
+| **Author** | Show issues opened by a specific person |
+
+Select the appropriate column in the filter bar above the issue list to apply each filter. To search across issue titles and bodies with keywords, see [Searching Code](/guides/git/searching-code/).
+
+## Next Steps
+
+- [Collaborate with Pull Requests](/guides/git/pull-requests/)
+- [Organize Work with Project Boards](/guides/git/projects/)
+- [Search Code and Content](/guides/git/searching-code/)

--- a/src/content/docs/guides/git/packages.mdx
+++ b/src/content/docs/guides/git/packages.mdx
@@ -1,0 +1,93 @@
+---
+title: Packages
+description: Publish and install versioned artifacts through the PlaidCloud Git package registry, and track large binary files with Git LFS.
+sidebar:
+  order: 7
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+PlaidCloud Git includes a built-in package registry for distributable artifacts and Git Large File Storage (LFS) for large binary files inside your repositories.
+
+## About the Package Registry
+
+The package registry is per-owner and supports a wide range of ecosystem formats — npm, PyPI, Maven, NuGet, RubyGems, container images, and more. Packages are private to your workspace and accessible only to authenticated members.
+
+Each package type has its own endpoint under:
+
+```
+https://git.example.plaidcloud.com/api/packages/you/<type>
+```
+
+where `<type>` is the ecosystem identifier (for example, `npm`, `pypi`, or `maven`).
+
+## Authenticate to the Registry
+
+Package manager operations use your PlaidCloud Git username and a personal access token as the password. See [Repositories](/guides/git/repositories/) for how to create a token.
+
+## Publish a Package
+
+The steps vary by ecosystem, but the pattern is the same: point your package manager at the registry URL and run its standard publish command.
+
+For npm, add a `.npmrc` to your project to scope packages to the registry:
+
+```ini
+@you:registry=https://git.example.plaidcloud.com/api/packages/you/npm/
+//git.example.plaidcloud.com/api/packages/you/npm/:_authToken=YOUR_TOKEN
+```
+
+Then publish as usual:
+
+```bash
+npm publish
+```
+
+For PyPI, Maven, NuGet, and other ecosystems, configure the tool's repository or source setting to the matching registry URL and use that tool's standard publish command (for example, `twine upload`, `mvn deploy`, or `dotnet nuget push`).
+
+## Install a Package
+
+Point your package manager at the same registry URL and install as usual. With the `.npmrc` above in place:
+
+```bash
+npm install @you/my-package
+```
+
+For other ecosystems, add the registry as an additional source in your tool's configuration and use its standard install command.
+
+## Large Files with Git LFS
+
+Git LFS keeps your repository fast by replacing large or binary files in history with lightweight pointers and storing the file data separately. LFS is enabled for every PlaidCloud Git repository.
+
+1. Install the LFS client once on your machine:
+
+   ```bash
+   git lfs install
+   ```
+
+2. Tell LFS which file patterns to track, from inside your repository:
+
+   ```bash
+   git lfs track "*.parquet"
+   ```
+
+   This creates or updates `.gitattributes`. Commit that file:
+
+   ```bash
+   git add .gitattributes
+   git commit -m "Track Parquet files with LFS"
+   ```
+
+3. Add and push as normal — matching files upload to LFS automatically:
+
+   ```bash
+   git add data/large-dataset.parquet
+   git commit -m "Add dataset"
+   git push origin main
+   ```
+
+<Aside type="tip">Git LFS is for large files that live inside a repository's history and are retrieved with `git clone` or `git pull`. The package registry is for versioned, distributable artifacts that consumers install with a package manager. If teammates will `npm install` or `pip install` it, use the registry; if they need it as part of a checkout, use LFS.</Aside>
+
+## Next Steps
+
+- [Work with Repositories](/guides/git/repositories/)
+- [Publish Releases and Tags](/guides/git/releases-and-tags/)

--- a/src/content/docs/guides/git/projects.mdx
+++ b/src/content/docs/guides/git/projects.mdx
@@ -1,0 +1,46 @@
+---
+title: Project Boards
+description: Organize issues and pull requests into a Kanban board in PlaidCloud Git so your team can see work in progress at a glance.
+sidebar:
+  order: 4
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+A project board arranges issues and pull requests into columns that represent stages of your workflow, giving the whole team a shared view of what's in progress, what's blocked, and what's done.
+
+## Create a Board
+
+1. Open the repository and select the **Projects** tab.
+2. Select **New Project**.
+3. Enter a name for the board.
+4. Choose a starting template — a basic **To Do / In Progress / Done** layout is a good default — or select an empty board to build the layout from scratch.
+5. Select **Create Project** to open the board.
+
+<Aside>A board created from a repository's **Projects** tab belongs to that repository. Boards that span multiple repositories across your workspace are created by an administrator from the organization-level Projects area.</Aside>
+
+## Set Up Columns
+
+1. To add a column, select **Add Column**, enter a label, and save.
+2. To rename a column, open its settings and choose **Edit**.
+3. Drag column headers left or right to reorder them.
+4. Mark one column as the default from its settings — any card added without a specific target lands there.
+
+## Add and Move Cards
+
+- To add an existing issue or pull request, open a column's menu and select **Add an item**, then search for it by title or number.
+- To create a new issue directly on the board, select **+** inside a column. The issue is saved to the repository and appears as a card immediately.
+- Drag a card to a different column as work progresses. The card's position reflects its current status; it doesn't change the issue's labels or assignees on its own.
+
+## Track Work
+
+The board gives you an at-a-glance picture of your team's workload without opening individual issues. Keep it current by:
+
+- Closing an issue or merging a pull request — the card moves to a done column or leaves the board, depending on your board's automation settings.
+- Pairing the board with **Milestones** when you want a time-boxed goal alongside the Kanban view. Milestones track a due date and completion percentage; the board tracks flow.
+
+## Next Steps
+
+- [Open and Manage Issues](/guides/git/issues/)
+- [Review Pull Requests](/guides/git/pull-requests/)
+- [Work with Repositories](/guides/git/repositories/)

--- a/src/content/docs/guides/git/pull-requests.mdx
+++ b/src/content/docs/guides/git/pull-requests.mdx
@@ -1,0 +1,62 @@
+---
+title: Pull Requests
+description: Open a pull request in PlaidCloud Git to propose merging changes from one branch into another and collect team review before merging.
+sidebar:
+  order: 3
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+A pull request proposes merging the changes on one branch into another — usually the default branch — and gives your team a place to review, discuss, and approve them before the merge happens.
+
+## Create a Branch
+
+Work on a new branch so your changes stay separate from the default branch until they're ready.
+
+**In the UI:**
+
+1. Open your repository and select the branch selector near the top-left (it shows the current branch name).
+2. Type a new branch name in the search box and select **Create Branch**.
+
+**Locally:**
+
+1. Create and switch to the branch: `git checkout -b feature-x`
+2. Make your changes, then stage and commit them: `git add .` then `git commit -m "Describe what changed"`
+3. Push the branch to PlaidCloud Git: `git push -u origin feature-x`
+
+## Open a Pull Request
+
+1. Open your repository and select the **Pull Requests** tab, then **New Pull Request**.
+2. Set the **compare** branch to your feature branch and the **base** branch to the target (usually `main` or `master`).
+3. Write a clear title and a description that explains what changed and why.
+4. To link related issues, add a closing keyword in the description — for example, `Closes #12` — so the issue closes automatically when the pull request merges.
+5. Assign reviewers if needed, then select **Create Pull Request**.
+
+## Review Changes
+
+Reviewers work through the pull request without merging anything:
+
+1. Open the pull request and select **Files Changed** to read the diff.
+2. Select any line in the diff to leave an inline comment on that specific change.
+3. When finished, submit an overall verdict: **Approve** to sign off, or **Request Changes** to ask for revisions first.
+4. The author pushes more commits to the same branch to address feedback — the pull request updates automatically, with no need to open a new one.
+5. Reviewers mark individual comment threads as resolved once each concern is addressed.
+
+<Aside>A repository administrator can enable branch protection on the default branch to require a minimum number of approvals before a pull request can be merged.</Aside>
+
+## Merge
+
+Once the pull request is approved:
+
+1. Choose a merge method from the dropdown next to the **Merge** button:
+   - **Create a merge commit** — preserves the full branch history with a merge commit.
+   - **Squash and merge** — combines all commits on the branch into a single commit on the target branch.
+   - **Rebase and merge** — replays the branch's commits onto the target branch without a merge commit.
+2. Select **Merge** to complete it.
+3. Optionally select **Delete Branch** to clean up the feature branch once it's no longer needed.
+
+## Next Steps
+
+- [Work with Repositories](/guides/git/repositories/)
+- [Track Work with Issues](/guides/git/issues/)
+- [Organize Work with Project Boards](/guides/git/projects/)

--- a/src/content/docs/guides/git/releases-and-tags.mdx
+++ b/src/content/docs/guides/git/releases-and-tags.mdx
@@ -1,0 +1,77 @@
+---
+title: Releases and Tags
+description: Tag a specific commit in PlaidCloud Git, then publish a release with notes and downloadable files so others can find and retrieve versioned artifacts.
+sidebar:
+  order: 5
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+A tag marks a commit as significant — typically a version like `v1.2.0`. A release builds on a tag by adding human-readable notes and optional file attachments so users can browse and download specific versions from the web UI.
+
+## Create a Tag
+
+You can create a tag from the UI or from your local clone.
+
+**From the UI:**
+
+1. Open your repository and select **Releases**, then **Tags**.
+2. Select **Create Tag**.
+3. Enter a tag name (for example, `v1.2.0`), choose the target branch or commit, and select **Create Tag**.
+
+**From the command line:**
+
+```bash
+git tag v1.2.0
+git push origin v1.2.0
+```
+
+To tag a specific past commit, pass its commit ID instead of relying on `HEAD`:
+
+```bash
+git tag v1.2.0 abc1234
+git push origin v1.2.0
+```
+
+## Publish a Release
+
+1. Open your repository and select **Releases**.
+2. Select **New Release**.
+3. In the **Tag Name** field, choose an existing tag or type a new name to create one at the current default branch tip.
+4. Enter a **Release Title** and write release notes in the Markdown body — changelogs, upgrade instructions, and known issues all belong here.
+5. Select **This is a pre-release** if the version isn't ready for general use, or **Save Draft** to finish it later without publishing.
+6. Select **Publish Release** when it's ready.
+
+<Aside>Draft releases are visible only to repository members with write access. A pre-release is visible to everyone with access but is excluded from the "Latest" designation on the repository overview.</Aside>
+
+## Attach Files
+
+Uploaded files appear on the release page as named download links alongside the auto-generated source archive.
+
+1. On the new or edit release form, go to the **Attach Files** section.
+2. Drag files onto the upload area, or select it to browse — built binaries, compressed archives, checksums, and signatures are all common choices.
+3. Repeat for each file, then publish or update the release.
+
+Keep individual files reasonable in size so downloads stay fast for your team.
+
+<Aside type="tip">For installable packages — npm modules, container images, PyPI wheels, and similar — the [package registry](/guides/git/packages/) is a better fit than release attachments. It understands version resolution, dependency metadata, and client tooling (`npm`, `pip`, `docker pull`) in ways a plain file download doesn't.</Aside>
+
+## View and Download Releases
+
+1. Select **Releases** to see the full list, newest first.
+2. The latest non-prerelease is highlighted with a **Latest** badge.
+3. Each entry shows the tag name, release title, notes, and links to:
+   - **Source code** — auto-generated `zip` and `tar.gz` archives of the tagged commit.
+   - **Assets** — any files you attached when publishing the release.
+4. Select a file link to download it directly, or copy the URL to share it.
+
+To compare two releases, open their tag names as a compare URL:
+
+```bash
+https://git.example.plaidcloud.com/you/my-repo/compare/v1.1.0...v1.2.0
+```
+
+## Next Steps
+
+- [Publish Packages](/guides/git/packages/)
+- [Work with Repositories](/guides/git/repositories/)

--- a/src/content/docs/guides/git/repositories.mdx
+++ b/src/content/docs/guides/git/repositories.mdx
@@ -1,0 +1,67 @@
+---
+title: Repositories
+description: Create a repository in PlaidCloud Git, then clone it, commit changes, and push them back over HTTPS using a personal access token.
+sidebar:
+  order: 1
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+A repository holds the files, branches, and history for one project. This guide walks through creating a repository and connecting to it from your computer.
+
+## Create a Repository
+
+1. Open **Git** from your workspace.
+2. Select the **+** menu in the top-right corner, then **New Repository**.
+3. Enter a name, and optionally a short description.
+4. Choose the visibility. New repositories are **Private** by default — only members you grant access can see them.
+5. Optionally select **Initialize Repository** to add a README, a `.gitignore`, and a license.
+6. Select **Create Repository**.
+
+## Generate a Personal Access Token
+
+Because you sign in through PlaidCloud, your account has no separate Git password. To clone or push over HTTPS from the command line, create a personal access token and use it in place of a password.
+
+1. Select your avatar in the top-right corner, then **Settings**.
+2. Open the **Applications** tab.
+3. Under **Manage Access Tokens**, enter a name that describes where you'll use the token (for example, `laptop`).
+4. Select the repository **read** and **write** scopes so the token can clone and push.
+5. Select **Generate Token**.
+6. Copy the token and store it somewhere safe. You won't be able to view it again.
+
+<Aside type="caution">Treat the token like a password — anyone who has it can act as you in Git. Generate a separate token per machine so you can revoke one without disrupting the others.</Aside>
+
+## Clone a Repository
+
+1. Open the repository in PlaidCloud Git.
+2. Select **Code**, then copy the **HTTPS** clone URL.
+3. In a terminal, run `git clone` with that URL:
+
+   ```bash
+   git clone https://git.example.plaidcloud.com/you/my-repo.git
+   ```
+
+4. When Git prompts for credentials, enter your **PlaidCloud username** and paste the **access token** as the password.
+
+<Aside>To avoid re-entering the token on every push, let your operating system's Git credential helper store it: run `git config --global credential.helper store` (or `osxkeychain` on macOS) before your first push.</Aside>
+
+## Commit and Push Changes
+
+From inside a cloned repository:
+
+1. Stage your changes: `git add .`
+2. Record them with a message: `git commit -m "Describe what changed"`
+3. Send them to PlaidCloud Git: `git push`
+
+Your commits appear in the repository's **Commits** and **Activity** views, and on any branch or pull request that includes them.
+
+## Manage Access and Visibility
+
+Open a repository's **Settings** tab to rename it, change its visibility, or transfer ownership. To let other members contribute, use **Settings → Collaborators** and add them by username with a **Read**, **Write**, or **Administrator** role.
+
+<Aside>Repository access also follows your workspace membership and security groups. See [Access Management](/administration/access/) for how those map to who can see and edit a repository.</Aside>
+
+## Next Steps
+
+- [Track work with Issues](/guides/git/issues/)
+- [Propose changes with Pull Requests](/guides/git/pull-requests/)

--- a/src/content/docs/guides/git/searching-code.mdx
+++ b/src/content/docs/guides/git/searching-code.mdx
@@ -1,0 +1,57 @@
+---
+title: Searching Code
+description: Search code, issues, and pull requests across every repository you can access in PlaidCloud Git.
+sidebar:
+  order: 8
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+PlaidCloud Git lets you search code, files, issues, and pull requests across all repositories your workspace membership gives you access to.
+
+## Search Code
+
+1. Select the search box at the top of any page and type your query.
+2. Press **Enter** to see results across every repository you can access.
+3. Select a result to jump directly to the file at the matching line.
+4. Narrow results with the **Repository** and **Language** filters on the results page.
+
+<Aside>Code search indexes the default branch. To search a different branch, browse to that branch and use the in-repository search described below.</Aside>
+
+## Search Within a Repository
+
+1. Open a repository and select the **Code** tab.
+2. Press **T** (or select the file-finder box) to open the file finder.
+3. Type part of a filename or path — the list filters as you type.
+4. Select a file to open it, then use your browser's find-in-page (**⌘F** / **Ctrl+F**) to locate a specific line.
+
+<Aside type="tip">The file finder matches on path segments, so typing `util/auth` surfaces `src/util/auth.py`, `lib/util/auth_helper.go`, and similar paths.</Aside>
+
+## Filter Issues and Pull Requests
+
+On the **Issues** or **Pull Requests** list, combine keyword search with `key:value` filters:
+
+| Filter | Example |
+|---|---|
+| Open or closed state | `is:open`, `is:closed` |
+| Label | `label:bug`, `label:"needs review"` |
+| Assignee | `assignee:you` |
+| Author | `author:you` |
+| Milestone | `milestone:"v1.2"` |
+
+Type filters directly in the search box, combine them freely, and use the **Sort** menu to order by **Recently Updated**, **Most Commented**, **Newest**, or **Oldest**.
+
+<Aside>Wrap a label name in quotes when it contains spaces: `label:"needs review"`.</Aside>
+
+## Tips for Finding Things Faster
+
+- **Exact phrases** — wrap multi-word terms in quotes (`"connection pool"`) to avoid noisy partial matches.
+- **Scope to a repository** — open the repository before searching so results stay focused.
+- **Descriptive names pay off** — repositories and issues with clear, specific names surface in search far more reliably than generic ones like `misc`.
+- **Labels are searchable metadata** — a well-labeled issue is easier to filter than one buried in prose, so apply labels consistently.
+
+## Next Steps
+
+- [Work with Issues](/guides/git/issues/)
+- [Manage Pull Requests](/guides/git/pull-requests/)
+- [Browse Repositories](/guides/git/repositories/)

--- a/src/content/docs/guides/git/wikis.mdx
+++ b/src/content/docs/guides/git/wikis.mdx
@@ -1,0 +1,62 @@
+---
+title: Wikis
+description: Enable and maintain a per-repository wiki in PlaidCloud Git to document your project alongside the code.
+sidebar:
+  order: 6
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Each repository can host a wiki — a separate collection of Markdown pages for documentation that lives alongside the code without being mixed into it.
+
+## Enable the Wiki
+
+1. Open the repository and select **Settings**.
+2. Under **Features**, turn on **Wiki**.
+3. A **Wiki** tab appears in the repository navigation.
+
+## Create and Edit Pages
+
+1. Select the **Wiki** tab.
+2. If the wiki has no pages yet, select **Create the First Page**. Otherwise, select **New Page**.
+3. Enter a page title. The title becomes the page's URL, so choose something clear and stable.
+4. Write the content in Markdown, then select **Save Page**.
+
+The first page you create becomes the wiki's **Home** — the page visitors land on by default. To update an existing page, open it and select **Edit**. Every save records a new entry in the page's revision history.
+
+<Aside>The wiki is versioned just like your code. Open the **Revisions** view on any page to browse its history or revert to an earlier version.</Aside>
+
+## Organize the Wiki
+
+Two specially named pages control navigation across the whole wiki:
+
+- **\_Sidebar** — a custom sidebar shown on every page. Add links to your most important pages here.
+- **\_Footer** — a footer shown at the bottom of every page.
+
+Create either one from **New Page** using the exact name shown above. Link between wiki pages with standard Markdown, referencing the page slug:
+
+```md
+See the [Setup Guide](setup-guide) for installation steps.
+```
+
+Use descriptive page titles from the start: the title becomes the URL, and renaming a page later breaks any existing links to it.
+
+## Edit the Wiki Locally
+
+The wiki is itself a Git repository, available at the `.wiki.git` URL for your repository. Clone it, edit the Markdown files in your editor, and push the changes back.
+
+```bash
+git clone https://git.example.plaidcloud.com/you/my-repo.wiki.git
+cd my-repo.wiki
+# edit or add .md files
+git add .
+git commit -m "Expand the setup guide"
+git push
+```
+
+The same personal access token you use for the main repository works here. Each Markdown file becomes a wiki page; the filename (without the `.md` extension) is the page slug.
+
+## Next Steps
+
+- [Work with Repositories](/guides/git/repositories/)
+- [Track Work with Issues](/guides/git/issues/)


### PR DESCRIPTION
## What

Adds a **PlaidCloud Git** section under Guides (`src/content/docs/guides/git/`) documenting the user-facing Git features, plus a `PlaidCloud Git` group in the guides sidebar (between *Panel apps* and *Projects*).

| Page | Covers |
|---|---|
| Overview (`index`) | What PlaidCloud Git is, SSO sign-in, links to the rest |
| Repositories | Create, generate a personal access token, clone, commit, push, access |
| Issues | Create, labels, milestones, assignees, @mentions, linking to code |
| Pull Requests | Branches, open, review (approve / request changes), merge methods |
| Project Boards | Kanban boards, columns, cards, tracking |
| Releases and Tags | Tags, releases, notes, attachments, downloads |
| Wikis | Enable, create/edit pages, organize, edit locally |
| Packages | Package registry (npm example) + Git LFS |
| Searching Code | Code search, in-repo file finder, issue/PR filters |

## Adaptation notes

- **House style**: Title Case headings, second-person voice, task-oriented numbered steps, `<Aside>` notes — matched to the existing guides (e.g. `guides/projects/`).
- **No "Forgejo"/"Gitea"** anywhere — the product is referred to as **PlaidCloud Git** throughout (verified by grep).
- **No auth/account docs**: login, registration, passwords, 2FA, and SSH keys are omitted because sign-in is PlaidCloud SSO and SSH is disabled (Git is HTTPS-only). The one necessary exception is generating a **personal access token** for `git` over HTTPS — it's the only credential under SSO — documented briefly on the Repositories page (the Applications settings tab stays available).
- **No CI "Actions"** — that feature is disabled in our deployment.

## Verification

- Content sync + type generation pass (`astro build` content stage); no schema errors.
- New section is self-consistent: all internal `/guides/git/*` links resolve to created pages.
- A full local `npm ci && npm run build` is running to confirm the MDX renders; I'll confirm before marking ready. (CI also builds for the Lychee link check + Vale prose lint.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)