### PR TITLE
Document the Clone Workflow(s) progress dialog

### DIFF
--- a/src/content/docs/guides/workflows/duplicate-a-workflow.mdx
+++ b/src/content/docs/guides/workflows/duplicate-a-workflow.mdx
@@ -34,6 +34,8 @@ Use this when you want to copy workflows into another project — for example, p
 4. In the dialog, pick the **Target Project** (defaults to the current project)
 5. Click `Clone Workflow(s)`
 
+A progress dialog opens while the clone runs, showing an overall bar (workflow N of M) and a per-step bar for the workflow currently being copied. You can click `Run in Background` to dismiss the dialog and keep working — the clone keeps running and a notification appears when it finishes.
+
 Cloned workflows have " copy" appended to their names so they don't collide with anything already in the target project.
 
 <Aside>Cloning copies the workflow definition and step configuration. Project-scoped resources referenced by the workflow (tables, dimensions, connections) must already exist in the target project, or you must clone them separately.</Aside>


### PR DESCRIPTION
Updates the **Duplicate or Clone a Workflow** guide to describe the new progress dialog: an overall (workflow N of M) bar plus a per-step bar, and the **Run in Background** option that dismisses the dialog while the clone keeps running, with a notification on completion.

Documents the behavior shipped in PlaidCloud/plaid#6144 (https://github.com/PlaidCloud/plaid/pull/6144) and PlaidCloud/PlaidClient#1606 (https://github.com/PlaidCloud/PlaidClient/pull/1606).

🤖 Generated with [Claude Code](https://claude.com/claude-code)