### PR TITLE
Note the project-copy progress dialog

### DIFF
--- a/src/content/docs/guides/projects/managing-projects.mdx
+++ b/src/content/docs/guides/projects/managing-projects.mdx
@@ -151,6 +151,8 @@ To duplicate **without** updating project references:
 4. Click the “Actions” button
 5. Select the “Duplicate without project reference updates” option
 
+<Aside>Copying runs in the background. A progress dialog shows the copy advancing through its stages; you can click **Run in Background** to dismiss it and keep working — the project list updates automatically and you're notified when the copy finishes.</Aside>
+
 ## Viewing the Project Report
 
 When a project or workflow is dynamic, maintaining detailed documentation becomes a challenge. To help solve this problem, PlaidCloud provides the ability to generate a project-level report that gives detailed documentation of workflows, workflow steps, user defined transforms, variables, and tables. This report is generated on-demand and reflects the current state of the project.


### PR DESCRIPTION
Adds a note to **Managing Projects → Cloning a Project** that copying now runs in the background with a progress dialog ("Run in Background" to dismiss), matching the behavior shipped in plaid#6151 + PlaidClient#1610.

Project/warehouse **delete** progress (PlaidClient#1609, plaid#6154) have no existing guide pages to update; flagged for a future docs pass if delete/warehouse guides are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)