### PR TITLE
Document the Visual Workflow Designer minimap

### DIFF
--- a/src/content/docs/guides/workflows/advanced-workflows.mdx
+++ b/src/content/docs/guides/workflows/advanced-workflows.mdx
@@ -47,6 +47,16 @@ Each step is a node, and the connections between nodes define the order steps ru
 - **Pan tool** — when active, dragging pans the canvas instead of selecting. Middle-click drag and Space+drag pan regardless of the toggle.
 - **Snap to grid** rounds node positions to a fixed grid when you drop them, for tidy alignment.
 
+### Minimap
+
+For large workflows that don't fit on screen, toggle the **Minimap** to dock an overview panel in the bottom-right corner. It shows the whole workflow's steps and connections in miniature, with a rectangle marking the part of the canvas you're currently viewing.
+
+- The viewport rectangle moves live as you pan and zoom, so you always know where you are in the larger diagram.
+- **Click or drag** anywhere in the panel to jump the canvas to that part of the workflow.
+- While a workflow runs, each step in the minimap is **color-coded by its run state** (running, done, error, and so on), so the panel doubles as an at-a-glance health overview.
+
+<Aside type="tip">Whether the minimap is open is remembered between sessions, so you can leave it on for the workflows where you find it useful.</Aside>
+
 ### Lay Out
 
 - **Tidy Layout** (auto-arrange) re-runs the automatic left-to-right layout. It overwrites the current positions but preserves connections, notes, and highlights.


### PR DESCRIPTION
## Summary

Documents the new **Minimap** in the Visual Workflow Designer, shipped in PlaidClient PR #1614.

Adds a **Minimap** subsection to the *Advanced Workflows (Visual Workflow Designer)* guide, under "The Canvas" alongside the other navigation aids (Navigate / Lay Out). It covers:

- The toolbar **Minimap** toggle and the bottom-right overview panel (whole workflow's steps and connections in miniature).
- The viewport rectangle that tracks pan/zoom live.
- **Click/drag-to-pan** to jump the canvas to a part of the workflow.
- **Run-state color coding** of steps during a run (health overview).
- That the open/closed state is remembered between sessions.

## Notes

- Placed in the existing guide rather than a new page — the minimap is a canvas navigation feature, not a workflow step, so no `reference/workflow-steps/` page applies.
- Uses the existing `<Aside>` import; no new components or `{}` MDX tokens. Relying on the Cloudflare Workers Builds preview check for the Astro build (no local `node_modules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
