### PR TITLE
Docs: Spatial Find Nearest workflow step

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -258,6 +258,7 @@
 /docs/workflow-steps/tables/table-in-place-update/   /reference/workflow-steps/tables/table-in-place-update/   301
 /docs/workflow-steps/tables/table-inner-join/   /reference/workflow-steps/tables/table-inner-join/   301
 /docs/workflow-steps/tables/table-lookup/   /reference/workflow-steps/tables/table-lookup/   301
+/docs/workflow-steps/spatial/spatial-find-nearest/   /reference/workflow-steps/spatial/spatial-find-nearest/   301
 /docs/workflow-steps/tables/table-melt/   /reference/workflow-steps/tables/table-melt/   301
 /docs/workflow-steps/tables/table-multi-table-join/   /reference/workflow-steps/tables/table-multi-table-join/   301
 /docs/workflow-steps/tables/table-outer-join/   /reference/workflow-steps/tables/table-outer-join/   301

--- a/src/content/docs/reference/workflow-steps/spatial/spatial-find-nearest.mdx
+++ b/src/content/docs/reference/workflow-steps/spatial/spatial-find-nearest.mdx
@@ -1,0 +1,59 @@
+---
+title: Spatial Find Nearest
+description: For each row of a target table, find the N nearest rows of a universe table by distance between two geometry columns, in a PlaidCloud workflow step.
+sidebar:
+  order: 1
+---
+
+## Description
+
+The **Find Nearest** step pairs each row of a *target* table with the rows of a
+*universe* table that are geographically closest to it. For every target row it
+keeps the `N` nearest universe rows — measured as the distance between a geometry
+column on each side — and adds a computed `Distance` column.
+
+It is the SQL-native equivalent of the Alteryx *Find Nearest* tool: the work runs
+entirely in the database as a distance-ranked cross join, so it scales to large
+tables without pulling rows into the workflow engine.
+
+Both geometry columns hold geometries in **WKT** (well-known text) form, the same
+representation the other PlaidCloud spatial helpers produce and consume.
+
+## Sources and Options
+
+- **Target Table** — the rows you want neighbours *for*. Every qualifying target
+  row appears in the output (paired with its nearest universe rows).
+- **Universe Table** — the candidate neighbours that are searched.
+- **Output Table** — the table the results are written to.
+- **Target geometry / Universe geometry** — the WKT geometry column on each side
+  that distance is measured between.
+- **Nearest count (N)** — how many nearest universe rows to keep per target row
+  (default 1).
+- **Max distance** — optional. When set, universe rows farther than this from the
+  target are excluded before ranking. Leave blank for no limit.
+- **Distance units** — the unit the `Distance` output and *Max distance* are
+  expressed in: miles, kilometers, meters, or feet.
+- **Ignore zero-distance matches** — skip universe rows that sit exactly on the
+  target (distance 0), e.g. to avoid matching a point to itself when the target
+  and universe are the same dataset.
+
+## Target and Universe Mapping
+
+Each input has its own mapping tab that lists the columns available from that
+table, used both to drive the geometry pickers above and to make columns
+available to the output.
+
+## Output Columns
+
+Choose which columns to carry into the output and from which side (target or
+universe) each comes, renaming them as needed. The computed **Distance** column
+(the planar distance to the matched universe row, in the selected units) is added
+automatically; you can rename it or turn it off.
+
+## Notes
+
+Distances are planar (computed on the geometries' coordinates and scaled to the
+requested unit), consistent with the other PlaidCloud spatial steps. For
+lon/lat data this is an approximation that is accurate over the local distances
+typical of nearest-neighbour analysis (store catchments, service areas, and the
+like).


### PR DESCRIPTION
Reference page + `/docs`→`/reference` redirect for the new **Find Nearest** spatial step (`geo_find_nearest`), so the in-app Help link resolves.

Companion to:
- plaid (step + converter): https://github.com/PlaidCloud/plaid/pull/6164
- workflow-runner (SQL transform): https://github.com/PlaidCloud/workflow-runner/pull/1035
- PlaidClient (step form): https://github.com/PlaidCloud/PlaidClient/pull/1628

🤖 Generated with [Claude Code](https://claude.com/claude-code)