### PR TITLE
docs(projects): match Compare & Merge guide to the shipped dialog

### DIFF
--- a/src/content/docs/guides/projects/compare-and-merge-projects.mdx
+++ b/src/content/docs/guides/projects/compare-and-merge-projects.mdx
@@ -29,7 +29,7 @@ Name matching is what makes a QA-to-Production comparison useful, since the two 
 2. Select **Projects** from the top menu bar
 3. Right-click the project you want to start from (or use its actions menu) and choose **Compare to…**
 4. In the **Compare Projects** window, the project you started from is filled in as the **Source**
-5. Enter the **Target** project id — the project you want to compare against
+5. Choose the **Target** project from the dropdown — the project you want to compare against
 6. Click **Compare**
 
 <Aside>Use **Swap** to reverse the Source and Target before comparing — the direction matters, because a merge copies *from* Source *into* Target.</Aside>
@@ -47,7 +47,7 @@ Each item is badged with its status:
 - **Deleted** — present in Target but not in Source
 - **Unchanged** — identical on both sides (hidden by default)
 
-Select any item to see its details on the right: a field-by-field **Config diff** and the full text difference. If an item's diff is very large it's truncated — click **Expand full diff** to load the complete version.
+Select a changed item to see its details on the right: a **Field / Source / Target** table of what changed, with the full **Config diff** beneath it. If an item's diff is very large it's truncated — click **Expand full diff** to load the complete version.
 
 ### Focusing the List
 


### PR DESCRIPTION
## What

Updates the **Compare and Merge Projects** guide to match the shipped dialog after the recent UI fixes (PlaidClient #1620 / #1621 / #1627):

- **"Opening a Comparison" step 5** — the target is now **chosen from a project dropdown**, not typed in as a project id (the old free-text field was replaced with a picker).
- **"Reading the Comparison"** — the detail pane is described accurately: a **Field / Source / Target** table plus the full **Config diff** beneath it (selecting an item now actually renders this).

## Scope

Two text lines in `guides/projects/compare-and-merge-projects.mdx`. No frontmatter, link, or structural changes; no MDX expressions introduced; "dropdown" matches the corpus's house term. Verified the entry-point label ("Compare to…") and field behavior against the current `plaid.ui.analyze.ProjectCompare` / `Projects.js` source.

CI (CF Workers build + lychee + Vale) is the authoritative gate; a full local build was skipped as disproportionate for a plain-text edit that can't affect the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
