### PR TITLE
Find Nearest docs: 0 also means no max-distance limit

### DIFF
--- a/src/content/docs/reference/workflow-steps/spatial/spatial-find-nearest.mdx
+++ b/src/content/docs/reference/workflow-steps/spatial/spatial-find-nearest.mdx
@@ -30,7 +30,7 @@ representation the other PlaidCloud spatial helpers produce and consume.
 - **Nearest count (N)** — how many nearest universe rows to keep per target row
   (default 1).
 - **Max distance** — optional. When set, universe rows farther than this from the
-  target are excluded before ranking. Leave blank for no limit.
+  target are excluded before ranking. Leave blank (or 0) for no limit.
 - **Distance units** — the unit the `Distance` output and *Max distance* are
   expressed in: miles, kilometers, meters, or feet.
 - **Ignore zero-distance matches** — skip universe rows that sit exactly on the


### PR DESCRIPTION
Follow-up to #168 from a Sonnet review: clarify that a max distance of 0 (not just blank) means no limit, matching the step form and converter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)