### PR TITLE
Docs: Spatial Match workflow step

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -259,6 +259,7 @@
 /docs/workflow-steps/tables/table-inner-join/   /reference/workflow-steps/tables/table-inner-join/   301
 /docs/workflow-steps/tables/table-lookup/   /reference/workflow-steps/tables/table-lookup/   301
 /docs/workflow-steps/spatial/spatial-find-nearest/   /reference/workflow-steps/spatial/spatial-find-nearest/   301
+/docs/workflow-steps/spatial/spatial-match/   /reference/workflow-steps/spatial/spatial-match/   301
 /docs/workflow-steps/tables/table-melt/   /reference/workflow-steps/tables/table-melt/   301
 /docs/workflow-steps/tables/table-multi-table-join/   /reference/workflow-steps/tables/table-multi-table-join/   301
 /docs/workflow-steps/tables/table-outer-join/   /reference/workflow-steps/tables/table-outer-join/   301

--- a/src/content/docs/reference/workflow-steps/spatial/spatial-match.mdx
+++ b/src/content/docs/reference/workflow-steps/spatial/spatial-match.mdx
@@ -1,0 +1,56 @@
+---
+title: Spatial Match
+description: Pair each row of a target table with the rows of a universe table whose geometry intersects, is within, or contains it, in a PlaidCloud workflow step.
+sidebar:
+  order: 2
+---
+
+## Description
+
+The **Spatial Match** step pairs each row of a *target* table with the rows of a
+*universe* table whose geometry satisfies a chosen spatial relationship. For
+every target/universe pair that matches, it emits one output row with the columns
+you choose from each side.
+
+It is the SQL-native equivalent of the match path of the Alteryx *Spatial Match*
+tool: the work runs entirely in the database as a spatial predicate join, so it
+scales without pulling rows into the workflow engine.
+
+Both geometry columns hold geometries in **WKT** (well-known text) form, the same
+representation the other PlaidCloud spatial helpers produce and consume.
+
+## Sources and Options
+
+- **Target Table** — the rows you want matches *for*.
+- **Universe Table** — the candidate rows that are matched against.
+- **Output Table** — the table the matched pairs are written to.
+- **Target geometry / Universe geometry** — the WKT geometry column on each side
+  the relationship is tested between.
+- **Relationship** — how the target geometry must relate to the universe
+  geometry:
+  - **intersects** — the two geometries share any point.
+  - **within** — the target geometry lies inside the universe geometry.
+  - **contains** — the target geometry contains the universe geometry.
+
+A target row with no matching universe row is excluded from the output (this is a
+match, not a left join).
+
+## Target and Universe Mapping
+
+Each input has its own mapping tab that lists the columns available from that
+table, used both to drive the geometry pickers above and to make columns
+available to the output.
+
+## Output Columns
+
+Choose which columns to carry into the output and from which side (target or
+universe) each comes, renaming them as needed.
+
+## Notes
+
+The relationship is evaluated on the geometries' coordinates, consistent with the
+other PlaidCloud spatial steps.
+
+The Alteryx Spatial Match tool's *intersection object* output (the geometry of
+the overlap itself) and its *Unmatched* output (target rows with no match) are
+not produced by this step.


### PR DESCRIPTION
Reference page + /docs→/reference redirect for the new `geo_spatial_match` step. Companion to plaid/PlaidClient/workflow-runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)