### PR TITLE
Add the XML Parse workflow step reference page

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -253,6 +253,7 @@
 /docs/workflow-steps/tables/table-cross-join/   /reference/workflow-steps/tables/table-cross-join/   301
 /docs/workflow-steps/tables/table-drop/   /reference/workflow-steps/tables/table-drop/   301
 /docs/workflow-steps/tables/table-extract/   /reference/workflow-steps/tables/table-extract/   301
+/docs/workflow-steps/tables/table-xml-parse/   /reference/workflow-steps/tables/table-xml-parse/   301
 /docs/workflow-steps/tables/table-faker/   /reference/workflow-steps/tables/table-faker/   301
 /docs/workflow-steps/tables/table-in-place-delete/   /reference/workflow-steps/tables/table-in-place-delete/   301
 /docs/workflow-steps/tables/table-in-place-update/   /reference/workflow-steps/tables/table-in-place-update/   301

--- a/src/content/docs/reference/workflow-steps/tables/table-xml-parse.mdx
+++ b/src/content/docs/reference/workflow-steps/tables/table-xml-parse.mdx
@@ -1,0 +1,48 @@
+---
+title: XML Parse
+description: Parse the XML held in a table column into rows, projecting each element's attributes and child values onto columns, in a PlaidCloud workflow step.
+sidebar:
+  order: 8
+---
+
+## Description
+
+The **XML Parse** step reads the XML held in one column of a source table and
+turns it into rows. For each input row it finds every occurrence of the element
+you name and emits one output row per match, projecting that element's
+attributes and child-tag values onto columns.
+
+It is the equivalent of the Alteryx *XML Parse* tool. The parsing runs in the
+workflow engine (databases cannot parse XML in SQL), so the step is native to
+PlaidCloud and has no SQL fallback.
+
+## Source & Options
+
+- **Source Table** — the table whose rows hold the XML to parse.
+- **Output Table** — the table the parsed rows are written to.
+- **XML Field** — the column holding the XML text.
+- **Element** — the element whose every occurrence becomes an output row. Leave
+  it blank to parse the top-level elements.
+- **Emit child element values as columns** — for each matched element, add a
+  column per child tag holding that child's value.
+- **Emit each child's outer XML** — additionally add a `<tag>_OuterXML` column
+  holding each child's serialized XML (useful when a child itself nests more XML
+  you parse in a later step).
+- **Skip rows whose XML cannot be parsed** — drop an input row whose value is not
+  well-formed XML instead of failing the step.
+
+## Columns
+
+The **Columns** tab is the standard data mapper for the *passthrough* columns —
+the source columns you want carried through onto each output row.
+
+The columns the parse discovers — an element's attributes and child tags — are
+added to the output automatically; you do not list them here. When an extracted
+name collides with a passthrough column (or an earlier extracted one), it is
+de-duplicated by appending a number (`id` → `id2` → `id3`), matching Alteryx.
+
+## Notes
+
+A chain of XML Parse steps works the way Alteryx's does: every incoming column
+is passed through, so a later step can re-parse a column an earlier step
+produced and reference the earlier step's extracted columns.


### PR DESCRIPTION
## What

Reference page for the new **XML Parse** workflow step (`xml_parse`), under `reference/workflow-steps/tables/table-xml-parse`, with the `/docs → /reference` redirect.

## Companion PRs (co-deploy)

- plaid (converter + schema): https://github.com/PlaidCloud/plaid/pull/6210
- workflow-runner (runtime): https://github.com/PlaidCloud/workflow-runner/pull/1060
- PlaidClient (form): https://github.com/PlaidCloud/PlaidClient/pull/1637

🤖 Generated with [Claude Code](https://claude.com/claude-code)