### PR TITLE
Add the spatial geometry workflow step reference pages

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -261,6 +261,12 @@
 /docs/workflow-steps/tables/table-lookup/   /reference/workflow-steps/tables/table-lookup/   301
 /docs/workflow-steps/spatial/spatial-find-nearest/   /reference/workflow-steps/spatial/spatial-find-nearest/   301
 /docs/workflow-steps/spatial/spatial-match/   /reference/workflow-steps/spatial/spatial-match/   301
+/docs/workflow-steps/spatial/spatial-buffer/   /reference/workflow-steps/spatial/spatial-buffer/   301
+/docs/workflow-steps/spatial/spatial-trade-area/   /reference/workflow-steps/spatial/spatial-trade-area/   301
+/docs/workflow-steps/spatial/spatial-generalize/   /reference/workflow-steps/spatial/spatial-generalize/   301
+/docs/workflow-steps/spatial/spatial-smooth/   /reference/workflow-steps/spatial/spatial-smooth/   301
+/docs/workflow-steps/spatial/spatial-process/   /reference/workflow-steps/spatial/spatial-process/   301
+/docs/workflow-steps/spatial/spatial-poly-build/   /reference/workflow-steps/spatial/spatial-poly-build/   301
 /docs/workflow-steps/tables/table-melt/   /reference/workflow-steps/tables/table-melt/   301
 /docs/workflow-steps/tables/table-multi-table-join/   /reference/workflow-steps/tables/table-multi-table-join/   301
 /docs/workflow-steps/tables/table-outer-join/   /reference/workflow-steps/tables/table-outer-join/   301

--- a/src/content/docs/reference/workflow-steps/spatial/spatial-buffer.mdx
+++ b/src/content/docs/reference/workflow-steps/spatial/spatial-buffer.mdx
@@ -1,0 +1,26 @@
+---
+title: Spatial Buffer
+description: Grow each geometry in a column by a fixed distance, in a PlaidCloud workflow step.
+sidebar:
+  order: 3
+---
+
+## Description
+
+The **Spatial Buffer** step grows each geometry in a column by a fixed
+distance, writing the buffered geometry to an output column. It is the
+equivalent of the Alteryx *Buffer* tool, and runs in the workflow engine
+(the geometry work is not expressible in SQL).
+
+## Source & Options
+
+- **Source Table** / **Output Table** — the input geometries and where the
+  result is written.
+- **Geometry column** — the WKT geometry column to buffer.
+- **Buffer distance** — how far to grow each geometry, in the geometry's own
+  coordinate units.
+
+## Columns
+
+The **Columns** tab maps the input columns to pass through onto the output; the
+buffered geometry column is appended automatically.

--- a/src/content/docs/reference/workflow-steps/spatial/spatial-generalize.mdx
+++ b/src/content/docs/reference/workflow-steps/spatial/spatial-generalize.mdx
@@ -1,0 +1,24 @@
+---
+title: Spatial Generalize
+description: Simplify each geometry in a column to a tolerance, in a PlaidCloud workflow step.
+sidebar:
+  order: 5
+---
+
+## Description
+
+The **Spatial Generalize** step simplifies each geometry to a
+tolerance, reducing the number of vertices. It is the equivalent of the Alteryx
+*Generalize* tool and runs in the workflow engine.
+
+## Source & Options
+
+- **Source Table** / **Output Table** — the input geometries and where the
+  result is written.
+- **Geometry column** — the WKT geometry column to simplify.
+- **Tolerance** — the simplification tolerance; larger values produce coarser
+  geometry. Topology is preserved.
+
+## Columns
+
+The **Columns** tab maps the input columns to pass through onto the output.

--- a/src/content/docs/reference/workflow-steps/spatial/spatial-poly-build.mdx
+++ b/src/content/docs/reference/workflow-steps/spatial/spatial-poly-build.mdx
@@ -1,0 +1,27 @@
+---
+title: Spatial Poly-Build
+description: Build a polygon or convex hull per group from point geometries, in a PlaidCloud workflow step.
+sidebar:
+  order: 8
+---
+
+## Description
+
+The **Spatial Poly-Build** step builds a polygon (or convex hull) per
+group from point geometries. It is the equivalent of the Alteryx *Poly-Build*
+tool and runs in the workflow engine.
+
+## Source & Options
+
+- **Source Table** / **Output Table** — the input points and where the result is
+  written.
+- **Point geometry** — the WKT point geometry column to build from.
+- **Group by** — an optional column that groups the points into separate output
+  polygons; leave blank to build a single polygon from all points.
+- **Build type** — **Sequence** dissolves the grouped points into a polygon;
+  **Convex hull** builds the convex hull of the points.
+- **Output column** — the name of the output geometry column.
+
+## Columns
+
+The **Columns** tab maps the input columns to pass through onto the output.

--- a/src/content/docs/reference/workflow-steps/spatial/spatial-process.mdx
+++ b/src/content/docs/reference/workflow-steps/spatial/spatial-process.mdx
@@ -1,0 +1,30 @@
+---
+title: Spatial Process
+description: Combine two geometry columns (intersect, union, or cut) into a result geometry, in a PlaidCloud workflow step.
+sidebar:
+  order: 7
+---
+
+## Description
+
+The **Spatial Process** step combines two geometry columns on each row
+into a single result geometry. It is the equivalent of the Alteryx *Spatial
+Process* tool and runs in the workflow engine.
+
+## Source & Options
+
+- **Source Table** / **Output Table** — the input geometries and where the
+  result is written.
+- **First geometry** / **Second geometry** — the two WKT geometry columns to
+  combine.
+- **Action** — how to combine them:
+  - **Intersect** — the overlap of the two geometries.
+  - **Union** — the combination of the two geometries.
+  - **Cut first from second** — the second geometry with the first erased.
+  - **Cut second from first** — the first geometry with the second erased.
+- **Drop empty result geometries** — skip rows whose result is empty.
+- **Output column** — the name of the output geometry column.
+
+## Columns
+
+The **Columns** tab maps the input columns to pass through onto the output.

--- a/src/content/docs/reference/workflow-steps/spatial/spatial-smooth.mdx
+++ b/src/content/docs/reference/workflow-steps/spatial/spatial-smooth.mdx
@@ -1,0 +1,23 @@
+---
+title: Spatial Smooth
+description: Smooth each geometry in a column over a number of passes, in a PlaidCloud workflow step.
+sidebar:
+  order: 6
+---
+
+## Description
+
+The **Spatial Smooth** step smooths each geometry over a number of
+passes. It is the equivalent of the Alteryx *Smooth* tool and runs in the
+workflow engine.
+
+## Source & Options
+
+- **Source Table** / **Output Table** — the input geometries and where the
+  result is written.
+- **Geometry column** — the WKT geometry column to smooth.
+- **Passes** — the number of smoothing passes to apply.
+
+## Columns
+
+The **Columns** tab maps the input columns to pass through onto the output.

--- a/src/content/docs/reference/workflow-steps/spatial/spatial-trade-area.mdx
+++ b/src/content/docs/reference/workflow-steps/spatial/spatial-trade-area.mdx
@@ -1,0 +1,34 @@
+---
+title: Spatial Trade Area
+description: Build a fixed-radius trade area (concentric buffers in real-world units) around each geometry, in a PlaidCloud workflow step.
+sidebar:
+  order: 4
+---
+
+## Description
+
+The **Spatial Trade Area** step builds a trade area — one or more
+concentric buffers, sized in real-world units — around each geometry. It is the
+equivalent of the Alteryx *Trade Area* tool's fixed-radius mode and runs in the
+workflow engine.
+
+## Source & Options
+
+- **Source Table** / **Output Table** — the input geometries and where the
+  result is written.
+- **Geometry column** — the WKT geometry column to build around.
+- **Radii** — a single radius, or comma-separated concentric radii (e.g.
+  `5,10,25`).
+- **Units** — the real-world unit the radii are expressed in (miles, km, meters,
+  feet).
+- **Output column** — the name of the output geometry column.
+
+## Columns
+
+The **Columns** tab maps the input columns to pass through onto the output.
+
+## Notes
+
+The radii are converted from the chosen real-world unit to an approximate
+degree radius before buffering (a planar approximation), so a ground circle
+reads as a mild ellipse far from the equator.


### PR DESCRIPTION
## What

Reference pages for the six new spatial geometry steps — Buffer, Trade Area, Generalize, Smooth, Spatial Process, Poly-Build — under `reference/workflow-steps/spatial/`, with `/docs → /reference` redirects.

## Companion PRs (co-deploy)

- plaid (converter + schema): https://github.com/PlaidCloud/plaid/pull/6211
- workflow-runner (runtime): https://github.com/PlaidCloud/workflow-runner/pull/1061
- PlaidClient (forms): https://github.com/PlaidCloud/PlaidClient/pull/1638

🤖 Generated with [Claude Code](https://claude.com/claude-code)