### PR TITLE
docs(data): restore snapshot to a new table

### DIFF
--- a/src/content/docs/guides/data/table-snapshots.mdx
+++ b/src/content/docs/guides/data/table-snapshots.mdx
@@ -31,11 +31,14 @@ There are two ways to view a table's data at an earlier point in time. Both open
 
 <Aside>The historical view is read-only — it's a window into the past, not an editable copy. Use **Revert** or **Restore** (below) if you want to bring old data back into a table.</Aside>
 
-## Reverting a Table to a Snapshot
+## Reverting or Restoring a Snapshot
 
-To replace a table's current data with an earlier snapshot, select the snapshot, click **Revert to Snapshot**, and type the table's name to confirm. Because the revert is destructive, before the data is replaced PlaidCloud automatically captures a **pre-revert safety snapshot** of the current state (on storage engines that support pinning), so you can always get back to where you were.
+Select a snapshot and click **Revert / Restore**. The dialog offers two choices:
 
-<Aside type="caution">Reverting overwrites the table's current data. The typed confirmation and the automatic pre-revert safety snapshot are there to protect you — read the dialog before confirming. Revert is blocked while the project is locked.</Aside>
+- **Revert this table in place** (default) — replaces the table's current data with the snapshot. Because this is destructive, you type the table's name to confirm. Before the data is replaced, PlaidCloud automatically captures a **pre-revert safety snapshot** of the current state (on storage engines that support pinning), so you can always get back to where you were.
+- **Restore the snapshot to a new table** — leaves the original table untouched and creates a new table (you give it a name and folder) populated from the snapshot, with the same columns as the source.
+
+<Aside type="caution">Reverting in place overwrites the table's current data. The typed confirmation and the automatic pre-revert safety snapshot are there to protect you — read the dialog before confirming. Revert is blocked while the project is locked.</Aside>
 
 ## Naming, Pinning, and Retention
 


### PR DESCRIPTION
## Document restore-snapshot-to-new-table

The snapshot revert dialog now offers reverting in place **or** restoring the snapshot to a new table. Updates the Table Snapshots guide's revert section accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
