### PR TITLE
docs(panel-apps): document server-side Panel apps

### DIFF
--- a/src/content/docs/guides/panel-apps/creating.md
+++ b/src/content/docs/guides/panel-apps/creating.md
@@ -1,9 +1,41 @@
 ---
-title: Creating and Registering Panel Apps in Plaidcloud
-description: Create, load, and register Holoviz Panel applications in PlaidCloud for interactive data visualization and custom tool deployment.
+title: Creating a Panel App
+description: Publish a server-side HoloViz Panel app from a git repository, or a static WASM app from a file, on the My Panel Apps screen in PlaidCloud.
 sidebar:
   order: 2
 ---
 
-## Description
-Documentation coming soon...
+Open **My Panel Apps**. The toolbar offers two ways to publish, one per [runtime](/guides/panel-apps/):
+
+- **New Server App** — build and run an app from a git repository.
+- **Add WASM App** — publish a static, in-browser app from a file.
+
+## Creating a Server App
+
+A server app is built from a git repository and served at `https://<your-tenant-host>/serve/<slug>/`.
+
+1. Click **New Server App** to open the **Publish Server Panel App** dialog.
+2. Enter an **App Name** — the display name shown in the list.
+3. Enter a **URL Slug**. The slug is both the app's URL and its internal name, so it must be a valid DNS label: lowercase letters, digits, and hyphens, starting with a letter, 40 characters or fewer (for example, `sales-dashboard`). The dialog checks this before you publish.
+4. Pick the **Git Connection** that holds your app's repository, then the **Branch**, then the **Entry Point** — the `.py` file Panel should serve.
+5. Set the **CPU** and **Memory** the app's container should request.
+
+   > Fewer resources (lower CPU / memory) let the app schedule and cold-start faster.
+
+6. Set **Idle (minutes)** — how long the app stays warm with no traffic before it scales back to zero. The default is 30 minutes.
+7. Optionally tick **Public** to allow unauthenticated access, add **Allowed Origins** (comma-separated; defaults to this tenant), and a **Memo**.
+8. Click **Publish**.
+
+After you publish, the app **builds** — its **Status** shows in the list and updates automatically. See [Using a Panel App](/guides/panel-apps/using/) for what the statuses mean and how to open the app once it is ready.
+
+> The app's URL works only once its build status is **Ready**, and the first request after it has been idle spins it up (~15 seconds).
+
+## Creating a WASM App
+
+A WASM app runs in the browser from a pre-built HTML file.
+
+1. Click **Add WASM App** to open the **Publish Serverless Panel App** dialog.
+2. Enter an **App Name** and **Version**.
+3. Choose the **App HTML Location** — the HTML file in a document account.
+4. Enter an **App URL Slug** and an optional **Memo**.
+5. Click **Publish**. A WASM app has no build step and is served immediately.

--- a/src/content/docs/guides/panel-apps/index.md
+++ b/src/content/docs/guides/panel-apps/index.md
@@ -1,8 +1,27 @@
 ---
 title: Panel Apps
-description: Build and deploy interactive Holoviz Panel data applications natively within PlaidCloud for custom dashboards and data tools.
+description: Build and deploy interactive HoloViz Panel data applications in PlaidCloud — either as static in-browser apps or as server-side apps built from a git repository.
 sidebar:
   label: Panel Apps
 ---
 
-Build custom interactive applications on top of PlaidCloud data using the Panel framework — parameterized inputs, live charts, and embedded data tables.
+Panel Apps let you publish interactive [HoloViz Panel](https://panel.holoviz.org/) applications — parameterized inputs, live charts, and embedded data tables — directly from PlaidCloud. You manage them from the **My Panel Apps** screen, which lists every app alongside its runtime, build status, and URL.
+
+There are two runtimes, shown in the **Runtime** column:
+
+- **WASM** — a static app that runs entirely in the browser (Pyodide). You publish a pre-built HTML file from a document account. There is no server process and nothing to scale; it is served immediately.
+- **Server** — an app built from a git repository and run server-side. On publish, PlaidCloud builds your repository into a container that idles at zero replicas, wakes on the first request to its URL, serves (including live updates), and scales back to zero when idle. This is the right choice for apps that need a Python runtime, server-side compute, or libraries that can't run in the browser.
+
+## Choosing a Runtime
+
+| | WASM | Server |
+|---|---|---|
+| Source | A published HTML file | A git repository (connection, branch, entry point) |
+| Runs | In the browser | Server-side, scale-to-zero |
+| Best for | Lightweight, self-contained dashboards | Apps needing server compute or full Python libraries |
+| Cold start | None | First request spins the app up (~15 seconds) |
+
+## Next Steps
+
+- [Creating a Panel App](/guides/panel-apps/creating/) — publish a server app from git, or a WASM app from a file.
+- [Using a Panel App](/guides/panel-apps/using/) — build status, opening the app, editing, and removing it.

--- a/src/content/docs/guides/panel-apps/using.md
+++ b/src/content/docs/guides/panel-apps/using.md
@@ -1,9 +1,37 @@
 ---
-title: Using Panel Apps in Plaidcloud
-description: Access and use deployed Holoviz Panel applications in PlaidCloud for interactive data exploration and custom analytics tools.
+title: Using a Panel App
+description: Track build status, open, edit, and remove published HoloViz Panel apps from the My Panel Apps screen in PlaidCloud.
 sidebar:
-  order: 2
+  order: 3
 ---
 
-## Description
-Documentation coming soon...
+Every published app appears on the **My Panel Apps** screen with its **Runtime**, **Status**, **Slug**, and timestamps. The leftmost column opens the app; the pencil and minus icons edit and remove it.
+
+## Build Status (Server Apps)
+
+A server app's **Status** column tracks its build, and the list refreshes on its own while a build is in progress:
+
+- **Building…** — PlaidCloud is building your repository into a container. The app has no URL yet.
+- **Ready** — the build succeeded. The app's URL is live and the **Open** icon appears on its row.
+- **Failed** — the build did not complete. Check the entry point and branch, then edit the app to republish.
+
+WASM apps have no build step and are available as soon as they are published.
+
+## Opening an App
+
+Click the **Open** icon at the start of a ready app's row to launch it in a new tab.
+
+- A server app is served at `https://<your-tenant-host>/serve/<slug>/`.
+- The **Open** icon appears only once a server app is **Ready**.
+
+> A server app scales to zero when idle. The first request after an idle period spins it up — expect roughly a 15-second wait on that first open, then it responds normally until it goes idle again.
+
+## Editing an App
+
+Click the **pencil** icon on an app's row to edit it. The edit form matches the app's runtime.
+
+For a **server** app you can change the name, slug, branch, entry point, CPU, memory, idle window, public flag, allowed origins, and memo. The **Git Connection** is fixed once the app is created and is shown read-only. Saving rebuilds the app — its status returns to **Building…** until the new build is ready.
+
+## Removing an App
+
+Click the **minus** icon on an app's row and confirm. Removing a server app tears down its build and deployment; removing a WASM app unpublishes the static file. The app's URL stops working immediately.


### PR DESCRIPTION
## Summary

Fills the `guides/panel-apps` stubs to document **server-side Panel apps** (the new build-from-git runtime) alongside the existing WASM/static apps.

- **index** — overview of the two runtimes (WASM vs server) and when to use each.
- **creating** — the **New Server App** flow (git connection → branch → entry point, CPU/memory, idle window, DNS-1035 slug) plus the WASM publish path.
- **using** — build status (Building / Ready / Failed), the `/serve/<slug>/` URL, cold start, editing, and removal.

Labels match the shipped PlaidClient UI. Pairs with PlaidCloud/PlaidClient#1672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
