### PR TITLE
docs(ai-agents): correct filtered-allocation behaviour in the trace guide

### DIFF
--- a/src/content/docs/integrations/ai-coding-agents/tracing-allocations.mdx
+++ b/src/content/docs/integrations/ai-coding-agents/tracing-allocations.mdx
@@ -64,8 +64,16 @@ The analyst gets a complete answer — the size of the change, the accounts behi
 
 ## Good to Know
 
-<Aside type="note" title="Filtered allocations are analysed as a slice">
-When an allocation's source rows are restricted (for example to a set of accounts), the agent explains a **slice** of the result — pick a dimension such as entity or account so it can read the result table directly. If you ask for a whole-pool explanation on such a step, the agent tells you which filter to add.
+<Aside type="note" title="Filtered allocations get a clean, whole-pool answer">
+When an allocation's source rows are restricted (for example to a set of P&L accounts), the agent applies that filter automatically and still gives a clean, whole-pool attribution — you don't need to add anything.
+</Aside>
+
+<Aside type="caution" title="Dimension allocations">
+For an allocation driven by a **dimension hierarchy** — for example, splitting a cost centre across a reporting structure — the agent reports the correct totals and per-member movements but flags the precise cause as partial. Attributing it needs point-in-time hierarchy history, which is a later release.
+</Aside>
+
+<Aside type="caution" title="Cascaded allocations need a slice">
+When one allocation feeds another — a cascade — a project-wide "why" would mix the wrong rows, so the agent asks you to scope the question to a slice (a specific region, product, or cost centre) and then explains it.
 </Aside>
 
 <Aside type="caution" title="What-if estimates are upper bounds">


### PR DESCRIPTION
## What

Fixes a now-incorrect note in **Tracing Allocations with an MCP-Connected AI Agent** (`integrations/ai-coding-agents/tracing-allocations.mdx`).

The "Good to Know" section claimed filtered allocations are *analysed as a slice* and that you must *add a filter* to get a whole-pool answer. Since the source-filter (`source_where`) is now compiled into the attribution query, a source-filtered allocation (e.g. scoped to a set of P&L accounts) gets a **clean, whole-pool attribution automatically** — no extra step.

## Changes

- Reworded the filtered-allocation note to match the shipped behaviour ("clean, whole-pool answer").
- Added the two cases that genuinely need handling, so the slice behaviour is described where it actually applies:
  - **Dimension allocations** — partial; precise cause needs point-in-time hierarchy history.
  - **Cascaded allocations** — scope the question to a slice.

This brings the MCP-agent guide in line with the in-product guide (*Analyzing allocations with the AI Assistant*), which already describes all three correctly.

## Verification

- `astro build` passes locally (1499 pages, no errors).
- Content-only change; no new imports (the `Aside` component is already imported).