### PR TITLE
Add AI fix-assistant usage guide

### DIFF
--- a/src/content/docs/guides/ai-assistant/fixing-workflow-errors.mdx
+++ b/src/content/docs/guides/ai-assistant/fixing-workflow-errors.mdx
@@ -1,0 +1,90 @@
+---
+title: Fixing Workflow Errors with AI
+description: When a workflow step fails, the AI fix assistant diagnoses the error and — once you approve — applies a corrected configuration to that step.
+sidebar:
+  order: 2
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## Description
+
+When a workflow step fails or logs a warning, the AI fix assistant reads that
+error, works out what caused it, and — when the cause is a misconfiguration of
+the step itself — proposes a corrected configuration and applies it once you
+approve. It goes beyond explaining the error: it can make the change for you.
+
+It is part of the PlaidCloud [AI Assistant](/guides/ai-assistant/using-ai-assistant/)
+and opens from the project's **Log** viewer, already pointed at the step that
+failed.
+
+## Opening the Fix Assistant
+
+The fix assistant lives in the project's **Log** tab, beside the raw log entry:
+
+1. Open the project and click the **Log** tab.
+2. In the log list, select the entry for the step that failed. Its full message
+   — including any traceback — opens in the panel on the right under the **Log
+   Message** tab.
+3. Switch that panel to the **AI Analysis** tab.
+
+The **AI Analysis** chat opens already pointed at the workflow and step the
+selected log entry came from, so it starts diagnosing straight away — you don't
+have to tell it which step failed. You can read the raw error under **Log
+Message** and chat with the assistant under **AI Analysis** side by side.
+
+## How It Works
+
+1. **Diagnoses** — it reads the failing step's configuration and the tables and
+   columns it touches, and checks its claims against your data rather than
+   guessing from the error text alone.
+2. **Proposes** — if it finds a genuine misconfiguration, it shows you the
+   corrected step configuration and explains plainly what it changed and why.
+   Nothing is saved at this point.
+3. **You approve** — it waits for your go-ahead.
+4. **Applies** — once you approve, it writes the corrected configuration to the
+   step, through the same path the step editor uses.
+5. **Re-run** — it tells you to re-run the step to confirm the fix.
+
+<Aside>The assistant never changes your step without approval. It shows the
+proposed configuration first and applies it only after you explicitly confirm
+that change — an ambiguous reply isn't taken as approval.</Aside>
+
+## What It Can Fix
+
+The assistant repairs the configuration of the one step the error came from —
+for example a mistyped column or function name, an invalid expression, a wrong
+data type or cast, or malformed SQL. It changes the least that fixes the error:
+one failure, one targeted change, with the rest of the configuration left as it
+was.
+
+## What It Won't Do
+
+Its only lever is that step's configuration, and it is upfront when the problem
+lies elsewhere rather than bending an edit to look like a solution.
+
+- It edits **one step's configuration** and nothing else — it won't create,
+  delete, or reorder steps, create tables, edit a different step, or change your
+  data.
+- Many failures aren't configuration problems: missing or malformed source
+  data, an upstream step that failed first, a transient or infrastructure error,
+  a permissions issue, broken logic inside a transform or UDF, a missing file in
+  a document account, or a resource or timeout limit. For these it explains what
+  it found and points you to where the real fix lives.
+- Warnings are often benign and need no change — it will say so plainly rather
+  than invent an edit.
+- When it isn't certain a change will work, it says so and names what it's unsure
+  about instead of presenting a guess as a certainty.
+
+<Aside type="note">The fix runs with your own permissions on the current
+project, so it can only change a step you could already edit yourself — and any
+change is reversible by re-running the assistant or editing the step directly.</Aside>
+
+## Tips
+
+- The diagnosis is grounded in your live step configuration and table metadata,
+  so it reflects the project as it is now — not a cached or assumed shape.
+- After a fix is applied, re-run the step to confirm the error is resolved.
+- If the assistant says the cause is outside the step's configuration (bad data,
+  an upstream failure, a permissions problem), that is the answer — fix it where
+  it actually lives rather than asking the assistant to edit the step anyway.


### PR DESCRIPTION
End-user guide for the **workflow-error AI fix assistant** (backend feature in PlaidCloud/plaid#6135).

Covers:
- Opening it from the project **Log** tab → select the failed entry → **AI Analysis** panel
- The diagnose → propose → approve → apply → re-run flow
- The confirm-before-write gate (nothing changes without explicit approval)
- What it can fix (one step's config) and what it won't (no create/delete, no data; honest when the cause is upstream/data/permissions)
- Note that it runs with the user's own permissions and changes are reversible

New page under `guides/ai-assistant/` (auto-added to the sidebar). Astro build validated locally — 1459 pages, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)