### PR TITLE
docs(ai-assistant): generating SQL Extract steps with AI (sc-21457)

### DIFF
--- a/src/content/docs/guides/ai-assistant/generate-sql-extract.mdx
+++ b/src/content/docs/guides/ai-assistant/generate-sql-extract.mdx
@@ -1,0 +1,81 @@
+---
+title: Generating SQL Extract Steps with AI
+description: Describe the result you want and let the AI Assistant write the SELECT for a SQL Extract workflow step — choosing the source tables for you when you don't.
+sidebar:
+  order: 3
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## Description
+
+The **Extract SQL** workflow step runs a read-only `SELECT` against your project's
+data and writes the result into a new table. Writing that query by hand means
+knowing the source tables, their columns, and the SQL to shape them.
+
+The step editor can write the query for you. Describe the output you want in
+plain language and the AI Assistant produces the `SELECT` — and if you don't tell
+it which tables to read from, it examines the project's tables and picks the
+relevant ones itself. The generated SQL and detected columns are shown for
+review and stay fully editable before you save the step.
+
+<Aside type="note">
+This uses your workspace's configured AI agent (LLM connection). If no agent is
+configured, the **Generate SQL** button reports that none is set — an admin can
+configure one under the workspace's Default AI Agent settings.
+</Aside>
+
+## Opening the step
+
+From a workflow's **Steps** view, click **Create Step** and choose either:
+
+- **Tables → Extract SQL**, or
+- **AI → SQL Extract (AI Assisted)**
+
+Both open the same Extract SQL step editor, which now includes a **Generate SQL
+with AI** panel at the top of the SQL Extract Parameters page.
+
+## Generating the query
+
+1. **(Optional) Choose source tables.** In the **Source Tables** list, select one
+   or more tables the query should read from. Leave the list empty to let the
+   Assistant examine the project and choose the relevant tables for you.
+2. **Describe what you want.** In the **Describe** box, write the outcome in plain
+   language — for example, *"classify each ledger account into an activity pool
+   based on its account number range"*.
+3. **Click Generate SQL.** The Assistant writes a single read-only `SELECT`,
+   validates it by running it, and fills in:
+   - the **SQL Select Query** editor with the generated statement, and
+   - the **Table Data Selection** mapping page with the detected columns.
+
+   If you left the source list empty, the tables the Assistant chose are
+   selected back in the list so you can see what it used and adjust.
+
+## Reviewing and saving
+
+The generated SQL is a starting point, not a black box:
+
+- **Edit it freely.** The SQL editor is fully editable — refine the query, add a
+  join, or change the column list before saving. (To join several tables, you can
+  select multiple source tables, or simply edit the generated query.)
+- **Pick a target table.** Choose or name the **Target Table** the step writes
+  its result into.
+- **Save the step.** It is saved as an ordinary Extract SQL step and runs as part
+  of the workflow like any other.
+
+<Aside type="tip">
+If the Assistant returns a query that doesn't run, the editor still shows the SQL
+along with the error so you can correct it — or adjust your description and
+generate again.
+</Aside>
+
+## Notes and limits
+
+- The Assistant only writes **read-only** `SELECT` statements; it never produces
+  `INSERT`, `UPDATE`, `DELETE`, or other data-changing SQL.
+- Generation **does not create or run** the step — it only drafts the query and
+  previews the columns. The step is created when you save it, and runs when the
+  workflow runs.
+- Source tables are referenced by their internal identifiers in the generated
+  SQL, matching how PlaidCloud stores them; the display names are shown in the
+  picker for your convenience.

--- a/src/content/docs/guides/ai-assistant/generate-sql-extract.mdx
+++ b/src/content/docs/guides/ai-assistant/generate-sql-extract.mdx
@@ -20,9 +20,9 @@ relevant ones itself. The generated SQL and detected columns are shown for
 review and stay fully editable before you save the step.
 
 <Aside type="note">
-This uses your workspace's configured AI agent (LLM connection). If no agent is
-configured, the **Generate SQL** button reports that none is set — an admin can
-configure one under the workspace's Default AI Agent settings.
+This uses the same built-in model the AI Assistant uses — there is **nothing to
+set up**. You don't need to configure a per-workspace AI agent or LLM connection
+for it.
 </Aside>
 
 ## Opening the step
@@ -76,6 +76,8 @@ generate again.
 - Generation **does not create or run** the step — it only drafts the query and
   previews the columns. The step is created when you save it, and runs when the
   workflow runs.
-- Source tables are referenced by their internal identifiers in the generated
-  SQL, matching how PlaidCloud stores them; the display names are shown in the
-  picker for your convenience.
+- The generated query reads in your tables' **display names** — each table is
+  bound once at the top of the query under its name (so the columns, joins, and
+  filters all read in plain names rather than internal `analyzetable_…` ids).
+  The real identifiers are restored automatically when you save, so the query
+  runs unchanged. A table whose name isn't unique keeps its identifier.

--- a/src/content/docs/guides/ai-assistant/index.md
+++ b/src/content/docs/guides/ai-assistant/index.md
@@ -7,3 +7,5 @@ sidebar:
 ---
 
 The PlaidCloud AI Assistant is the in-app chat experience for asking questions about your data, generating workflow expressions, and performing operations in natural language. It is separate from the [AI Agents (MCP)](/integrations/ai-coding-agents/) area, which covers connecting external AI clients to your tenant.
+
+AI assistance also appears directly in some workflow steps — for example, [generating a SQL Extract step's query](/guides/ai-assistant/generate-sql-extract/) from a plain-language description.


### PR DESCRIPTION
## What

Documents the new **"Generate SQL with AI"** panel in the Extract SQL step editor (sc-21457): describe the desired output, optionally pick source tables (or leave the picker empty to let the Assistant choose them), review the generated `SELECT` and detected columns, then save.

- New guide: `guides/ai-assistant/generate-sql-extract.mdx` (sidebar order 3).
- Pointer added from the AI Assistant index.

## Companion PRs

- Backend: PlaidCloud/plaid#6289
- Client: PlaidCloud/PlaidClient#1691

## Note

Opened as **draft** per the batch request; docs PRs here are conventionally non-draft — mark ready when the feature lands. The real gate is the Cloudflare "Workers Builds" preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)