### PR TITLE
docs(panel-apps): hello-world walkthrough + new form sections

### DIFF
--- a/src/content/docs/guides/panel-apps/creating.md
+++ b/src/content/docs/guides/panel-apps/creating.md
@@ -98,7 +98,7 @@ Your repository must be reachable through a **git connection** in PlaidCloud. If
 
      > Fewer resources (lower CPU / memory) let the app schedule and cold-start faster.
 
-   - **Idle (minutes)** — how long the app stays warm with no traffic before it scales back to zero. The default is 30 minutes.
+   - **Idle (minutes)** — how long the app stays warm with no traffic before it scales back to zero. The default is 5 minutes.
    - **Allow Public Access** — tick to allow unauthenticated access; otherwise viewers must sign in to your tenant.
 5. Under **Advanced (Embedded Serving)** — optional. By default the app serves only from your PlaidCloud tenant. To embed it in another site, click **Add Domain** and enter each domain allowed to load it, one per row — a host only, no scheme or path (for example, `example.com` or `app.example.com:8443`). Leave the list empty unless you're embedding the app elsewhere.
 6. Click **Publish**.

--- a/src/content/docs/guides/panel-apps/creating.md
+++ b/src/content/docs/guides/panel-apps/creating.md
@@ -1,6 +1,6 @@
 ---
 title: Creating a Panel App
-description: Publish a server-side HoloViz Panel app from a git repository, or a static WASM app from a file, on the My Panel Apps screen in PlaidCloud.
+description: Publish a server-side HoloViz Panel app from a git repository (with a hello-world example), or a static WASM app from a file, in PlaidCloud.
 sidebar:
   order: 2
 ---
@@ -12,19 +12,96 @@ Open **My Panel Apps**. The toolbar offers two ways to publish, one per [runtime
 
 ## Creating a Server App
 
-A server app is built from a git repository and served at `https://<your-tenant-host>/serve/<slug>/`.
+A server app is built from a git repository and served at `https://<your-tenant-host>/serve/<slug>/`. You point PlaidCloud at a branch of a repository; it builds the code into a container, runs `panel serve` on it, and rebuilds automatically whenever you push to that branch.
 
-1. Click **New Server App** to open the **Publish Server Panel App** dialog.
-2. Enter an **App Name** — the display name shown in the list.
-3. Enter a **URL Slug**. The slug is both the app's URL and its internal name, so it must be a valid DNS label: lowercase letters, digits, and hyphens, starting with a letter, 40 characters or fewer (for example, `sales-dashboard`). The dialog checks this before you publish.
-4. Pick the **Git Connection** that holds your app's repository, then the **Branch**, then the **Entry Point** — the `.py` file Panel should serve.
-5. Set the **CPU** and **Memory** the app's container should request.
+### Prepare Your App Repository
 
-   > Fewer resources (lower CPU / memory) let the app schedule and cold-start faster.
+Your repository needs two things: an **entry point** — a Python file that builds a Panel app and marks it `.servable()` — and, optionally, a **`requirements.txt`** at the repository root listing any extra packages.
 
-6. Set **Idle (minutes)** — how long the app stays warm with no traffic before it scales back to zero. The default is 30 minutes.
-7. Optionally tick **Public** to allow unauthenticated access, add **Allowed Origins** (comma-separated; defaults to this tenant), and a **Memo**.
-8. Click **Publish**.
+```
+my-panel-app/
+├── app.py            # entry point — calls .servable()
+└── requirements.txt  # optional; extra dependencies, at the repo root
+```
+
+#### Hello World
+
+Create `app.py`:
+
+```python
+import panel as pn
+
+pn.extension()
+
+pn.pane.Markdown("# Hello, PlaidCloud 👋\n\nYour first server-side Panel app is running.").servable()
+```
+
+That's a complete app. The `.servable()` call is what PlaidCloud serves — anything you want rendered must be marked servable (directly, or by being inside a servable layout).
+
+#### A Slightly Richer Example
+
+Panel apps are interactive. This one adds a slider that updates a table live:
+
+```python
+import pandas as pd
+import panel as pn
+
+pn.extension()
+
+multiplier = pn.widgets.IntSlider(name="Multiplier", start=1, end=10, value=3)
+
+@pn.depends(multiplier)
+def times_table(m):
+    df = pd.DataFrame({"n": range(1, 6)})
+    df["result"] = df["n"] * m
+    return pn.pane.DataFrame(df, index=False)
+
+pn.Column(
+    "# Times Table",
+    multiplier,
+    times_table,
+).servable()
+```
+
+#### Add Dependencies
+
+This second example imports `pandas`, which isn't part of the base image, so add a `requirements.txt` at the repository root:
+
+```text
+pandas
+```
+
+PlaidCloud installs these with `pip` when it builds the image.
+
+> **What the platform provides — and expects.** Keep these assumptions in mind when you write your app:
+>
+> - **`panel` and `bokeh` are pre-installed** by the platform base image. Don't list them in `requirements.txt`, and avoid pinning an older Panel version — the live-update reconnect relies on a recent one.
+> - **`requirements.txt` must be at the repository root.** A file in a subdirectory is ignored, even if your entry point lives in one.
+> - **The app runs as a non-root user on a read-only filesystem.** Only `/tmp` is writable, so write any temporary files there (most libraries already honor `$TMPDIR`).
+> - **Don't hardcode the port, URL prefix, or host.** PlaidCloud assigns them and injects them at deploy time — just call `.servable()`.
+
+Your repository must be reachable through a **git connection** in PlaidCloud. If you don't have one yet, create it under **Tools > Connections** before publishing.
+
+### Publish the App
+
+1. Click **New Server App** to open the **Publish Server Panel App** dialog. Its settings are grouped into sections.
+2. Under **Directory Settings**:
+   - **App Name** — the display name shown in the list.
+   - **URL Slug** — both the app's URL and its internal name, so it must be a valid DNS label: lowercase letters, digits, and hyphens, starting with a letter, 40 characters or fewer (for example, `sales-dashboard`). The dialog checks this before you publish.
+   - **Memo** — an optional description.
+3. Under **Git Connection and Publish Watcher**:
+   - **Git Connection** — the connection that holds your app's repository.
+   - **Branch** — the branch to build from. Pushes to this branch rebuild and redeploy the app automatically.
+   - **Entry Point** — the `.py` file Panel should serve (your `app.py`).
+4. Under **Runtime**:
+   - **CPU** and **Memory** the app's container should request.
+
+     > Fewer resources (lower CPU / memory) let the app schedule and cold-start faster.
+
+   - **Idle (minutes)** — how long the app stays warm with no traffic before it scales back to zero. The default is 30 minutes.
+   - **Allow Public Access** — tick to allow unauthenticated access; otherwise viewers must sign in to your tenant.
+5. Under **Advanced (Embedded Serving)** — optional. By default the app serves only from your PlaidCloud tenant. To embed it in another site, click **Add Domain** and enter each domain allowed to load it, one per row — a host only, no scheme or path (for example, `example.com` or `app.example.com:8443`). Leave the list empty unless you're embedding the app elsewhere.
+6. Click **Publish**.
 
 After you publish, the app **builds** — its **Status** shows in the list and updates automatically. See [Using a Panel App](/guides/panel-apps/using/) for what the statuses mean and how to open the app once it is ready.
 

--- a/src/content/docs/guides/panel-apps/using.md
+++ b/src/content/docs/guides/panel-apps/using.md
@@ -30,7 +30,7 @@ Click the **Open** icon at the start of a ready app's row to launch it in a new 
 
 Click the **pencil** icon on an app's row to edit it. The edit form matches the app's runtime.
 
-For a **server** app you can change the name, slug, branch, entry point, CPU, memory, idle window, public flag, allowed origins, and memo. The **Git Connection** is fixed once the app is created and is shown read-only. Saving rebuilds the app — its status returns to **Building…** until the new build is ready.
+For a **server** app you can change the name, slug, branch, entry point, CPU, memory, idle window, public flag, embedded-serving domains, and memo. The **Git Connection** is fixed once the app is created and is shown read-only. Saving rebuilds the app — its status returns to **Building…** until the new build is ready.
 
 ## Removing an App
 


### PR DESCRIPTION
## What

Fills in the server-side Panel app guide so users can actually get started, and aligns it with the restructured publish form.

## Changes
- **Prepare Your App Repository** section: a hello-world `app.py`, an interactive slider→table example, a `requirements.txt`, the repo layout, and the platform assumptions (entry point must call `.servable()`; `requirements.txt` at repo root; panel/bokeh provided; non-root + read-only filesystem with `/tmp` writable; don't hardcode port/prefix/host).
- Form walkthrough updated to the new sections (Directory Settings; Git Connection and Publish Watcher; Runtime; Advanced (Embedded Serving)) and the add-a-row embedded-serving domains.
- `using.md` edit-field wording aligned to "embedded-serving domains."

## Companion PRs
- PlaidClient form: https://github.com/PlaidCloud/PlaidClient/pull/1692
- plaid backend: https://github.com/PlaidCloud/plaid/pull/6290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
