### PR TITLE
Add Export to Portable Format guide

### DIFF
--- a/src/content/docs/guides/projects/export-to-portable-format.mdx
+++ b/src/content/docs/guides/projects/export-to-portable-format.mdx
@@ -1,0 +1,63 @@
+---
+title: Export to Portable Format
+description: Export a PlaidCloud project to a standalone Python + DuckDB package that runs outside the platform, for demonstrations, RFPs, and offline review.
+sidebar:
+  order: 9
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+**Export to Portable Format** packages a project's workflows as a self-contained Python program that runs on [DuckDB](https://duckdb.org) with no connection to PlaidCloud. It is meant for demonstrating that a project *could* run off-platform — for RFP responses, security reviews, or sharing a reproducible slice of logic with someone who doesn't have a PlaidCloud account.
+
+It is a one-way export. The generated package is a point-in-time snapshot; it does not sync back, and re-exporting after changes produces a fresh package.
+
+<Aside type="caution" title="Best-effort fidelity">
+The export reproduces SQL-based transform steps exactly. Proprietary and side-effecting operations — allocations, dimension loads, notifications, document and report steps, scripts — are exported as **stubs**: their original configuration is preserved and, where the output table was materialized, its data is bundled as a snapshot, but the step itself does not re-run. Each step's fidelity is recorded in `COVERAGE.md` inside the package. For guaranteed, fully-recomputed results, run the project in PlaidCloud.
+</Aside>
+
+## Exporting a Project
+
+1. Open **Analyze** and select the **Projects** tab.
+2. Select a single project.
+3. Open the **Actions** menu (or right-click the project) and choose **Export to Portable Format** — it sits beside **Export Project**.
+4. In the dialog:
+   - **Document Account** — the document account the package is written to.
+   - **Folder Path** — the folder within that account, for example `/exports`.
+   - **Include data** — when checked (the default), source and snapshot tables are bundled as Parquet so the package runs without any external data. Uncheck it to ship only the code and schema contracts, which you then populate yourself.
+5. Click **Export**. When it finishes, a message confirms where the package was written and how many tables were snapshotted.
+
+The action requires access to the project and to read its tables — the same level of access needed to export table data today.
+
+## What's in the Package
+
+The export is a `.zip` containing:
+
+- `pipeline_<workflow>.py` — one script per workflow, with the steps in execution order.
+- `config.py` — engine selection (DuckDB by default) and the project schema name.
+- `_runtime.py` — a small engine shim; the only dependency beyond DuckDB.
+- `stubs.py` — no-op functions for non-portable operations, each carrying the original step configuration.
+- `data/` — Parquet snapshots of source and frozen tables (when **Include data** was checked).
+- `requirements.txt` — the Python dependencies (just `duckdb`).
+- `README.md`, `COVERAGE.md`, `RUN_ORDER.md` — how to run it, per-step fidelity, and the order to run the workflow scripts in.
+
+## Running the Package
+
+1. Unzip the package and create a Python environment:
+
+   ```bash
+   python -m venv .venv && source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. Run each workflow script, in the order listed in `RUN_ORDER.md`:
+
+   ```bash
+   python pipeline_<workflow>.py
+   ```
+
+Each script builds its tables in a local DuckDB database (`export.duckdb` by default). SQL transform steps are recomputed live; stubbed steps print a notice and leave their snapshotted output in place. To point the package at your own warehouse instead of DuckDB, set `ENGINE` in `config.py`.
+
+## Related
+
+- [Archive a project](/guides/projects/archive-a-project/) — a full, restorable backup that stays within PlaidCloud
+- [Manage tables and views](/guides/projects/managing-tables-and-views/) — the data layer the export snapshots

--- a/src/content/docs/guides/projects/index.md
+++ b/src/content/docs/guides/projects/index.md
@@ -19,6 +19,7 @@ Most teams start with one project per analytical area: a project for headcount c
 - [View the project log](/guides/projects/viewing-the-project-log/) — audit trail of changes
 - [Archive a project](/guides/projects/archive-a-project/) — preserve completed work without deleting
 - [Compare and merge projects](/guides/projects/compare-and-merge-projects/) — diff two projects and selectively copy changes between them
+- [Export to portable format](/guides/projects/export-to-portable-format/) — package a project as a standalone Python + DuckDB program that runs off-platform
 
 ## Related
 


### PR DESCRIPTION
Documents the new **Export to Portable Format** project-list action (PlaidClient #1693 / plaid #6301): exporting a project to a standalone Python + DuckDB package that runs off-platform, for RFPs / demos / offline review.

Covers: how to export (Document Account, Folder Path, Include data), what's in the package (`pipeline_<workflow>.py`, `config.py`, `_runtime.py`, `stubs.py`, `data/`, README/COVERAGE/RUN_ORDER), how to run it, and the best-effort fidelity model (SQL transform steps recomputed exactly; proprietary/side-effecting ops exported as stubs with config + frozen-data snapshots preserved).

New page `guides/projects/export-to-portable-format.mdx`, linked from the Projects section index. Matches the shipped UI labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)