### PR TITLE
docs(ai-assistant): document Save as PDF export

### DIFF
--- a/src/content/docs/guides/ai-assistant/using-ai-assistant.mdx
+++ b/src/content/docs/guides/ai-assistant/using-ai-assistant.mdx
@@ -42,6 +42,17 @@ The history list on the left of the **AI** tab shows every conversation in this 
 <Aside>Deleting a conversation also closes its chat tab if one is open.</Aside>
 
 
+## Save a Conversation as PDF
+
+You can export the current chat — your prompts and the assistant's replies, including tables, code blocks, and diagrams — to a PDF.
+
+1. Right-click anywhere in the conversation and choose `Save as PDF`
+2. Your browser's print dialog opens with the conversation laid out as a printable page
+3. Choose `Save as PDF` as the destination and save the file
+
+<Aside>The option is available once the conversation has at least one exchange. The export uses the responses exactly as rendered on screen, so any diagrams are included as drawn.</Aside>
+
+
 ## Token Usage
 
 Every AI response shows the token usage for that turn — input tokens, output tokens, and a running total for the conversation. Use this to keep an eye on cost as you work.


### PR DESCRIPTION
Adds a **Save a Conversation as PDF** section to the AI Assistant usage guide, covering the new right-click export shipping in PlaidClient ([PlaidClient#1694](https://github.com/PlaidCloud/PlaidClient/pull/1694)).

The section explains right-clicking the conversation, the browser print dialog, and notes that the export uses the responses exactly as rendered (so diagrams are included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)