### PR TITLE
docs: Export to Portable Format — purpose-neutral wording (drop RFP)

### DIFF
--- a/src/content/docs/guides/projects/export-to-portable-format.mdx
+++ b/src/content/docs/guides/projects/export-to-portable-format.mdx
@@ -1,13 +1,13 @@
 ---
 title: Export to Portable Format
-description: Export a PlaidCloud project to a standalone Python + DuckDB package that runs outside the platform, for demonstrations, RFPs, and offline review.
+description: Export a PlaidCloud project to a standalone Python + DuckDB package that runs offline, outside PlaidCloud.
 sidebar:
   order: 9
 ---
 
 import { Aside } from '@astrojs/starlight/components';
 
-**Export to Portable Format** packages a project's workflows as a self-contained Python program that runs on [DuckDB](https://duckdb.org) with no connection to PlaidCloud. It is meant for demonstrating that a project *could* run off-platform — for RFP responses, security reviews, or sharing a reproducible slice of logic with someone who doesn't have a PlaidCloud account.
+**Export to Portable Format** packages a project's workflows as a self-contained Python program that runs on [DuckDB](https://duckdb.org) with no connection to PlaidCloud. It produces a portable copy of the project's logic and data that runs offline, on its own.
 
 It is a one-way export. The generated package is a point-in-time snapshot; it does not sync back, and re-exporting after changes produces a fresh package.
 


### PR DESCRIPTION
Follow-up to #189: reword the guide's description and intro to be purpose-neutral — a portable format that runs offline from PlaidCloud — instead of the RFP/demonstration framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)