### PR TITLE
Add redirects for run-macro and macro-concurrent step Help links

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -285,6 +285,8 @@
 /docs/workflow-steps/workflow-control/raise-workflow-error/   /reference/workflow-steps/workflow-control/raise-workflow-error/   301
 /docs/workflow-steps/workflow-control/rename-workflow/   /reference/workflow-steps/workflow-control/rename-workflow/   301
 /docs/workflow-steps/workflow-control/run-workflow/   /reference/workflow-steps/workflow-control/run-workflow/   301
+/docs/workflow-steps/workflow-control/run-macro/   /reference/workflow-steps/workflow-control/run-macro/   301
+/docs/workflow-steps/workflow-control/macro-concurrent/   /reference/workflow-steps/workflow-control/macro-concurrent/   301
 /docs/workflow-steps/workflow-control/set-project-variable/   /reference/workflow-steps/workflow-control/set-project-variable/   301
 /docs/workflow-steps/workflow-control/set-workflow-variable/   /reference/workflow-steps/workflow-control/set-workflow-variable/   301
 /docs/workflow-steps/workflow-control/stop-workflow/   /reference/workflow-steps/workflow-control/stop-workflow/   301


### PR DESCRIPTION
## What

The **Run Macro** (`macro_run`) and **Concurrent Macro** (`macro_concurrent`) step **Help** buttons 404'd: their reference pages exist (`/reference/workflow-steps/workflow-control/run-macro/` and `.../macro-concurrent/`) but `public/_redirects` had no `/docs/…→/reference/…` line, so the in-app `/docs/...` URLs didn't resolve.

Adds the two missing `301` redirect lines.

## Verification

`npm run build` succeeds (1503 pages); both lines are present in `dist/_redirects`.

Companion PlaidClient `Constants.js` slug fix (for the Export to External/Project Table steps) is in PlaidCloud/PlaidClient#1704.

🤖 Generated with [Claude Code](https://claude.com/claude-code)