### PR TITLE
docs(connections): Create-and-Manage guide + Generic REST reference

### DIFF
--- a/src/content/docs/guides/connections/create-connection.mdx
+++ b/src/content/docs/guides/connections/create-connection.mdx
@@ -1,0 +1,89 @@
+---
+title: Create and Manage a Connection
+description: Create, edit, test, and control access to PlaidCloud connections for databases, ERPs, REST APIs, cloud storage, and Git, per environment.
+sidebar:
+  order: 1
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+A **connection** is a saved configuration that lets PlaidCloud reach an external system — a database, data lake, ERP, REST API, cloud service, or Git provider. Workflow steps reference the connection by name, so endpoint details and credentials live in one place and are reused across every step and project that needs them.
+
+Connections are managed from **Tools > Connections**.
+
+## Create a Connection
+
+1. Open **Tools > Connections**
+2. Click `New Connection` in the toolbar and choose the system you want to connect to from the menu
+3. Fill in the connection form (the tabs and fields vary by type — see [Connection Form](#connection-form) below)
+4. Click `Create` to save
+
+The new connection appears in the list, owned by you.
+
+<Aside type="note">The list of connection types and the fields each one needs are cataloged in the [Connectors reference](/reference/connectors/). For a service without a dedicated connector, use the [Generic REST Connection](/reference/connectors/rest/generic-rest/).</Aside>
+
+## Connection Form
+
+Most connections open a multi-tab form. The exact tabs depend on the type, but you'll commonly see:
+
+- **Connection Config** (or **Connection Details** for REST) — the connection `Name`, an optional `Memo`, the host/port/database (or host/auth type for REST), the `Usage` toggle (`Active`), and the `Security Model`. On a database connection the credentials sit here in an **Auth Credentials** group; on a REST connection they get their own **Authentication** tab.
+- **SSL Config** — `Use SSL` plus the SSL mode and optional client/root certificates for an encrypted connection.
+- **SSH Config** — `Use SSH` plus the bastion host, port, user, and key to tunnel the connection through an SSH jump host.
+
+Password and token fields are write-only: they show blank when you reopen a saved connection, and leaving them blank on save keeps the stored secret. Retype a value only when you want to change it.
+
+Required fields are validated on save; if something is missing, the form switches to the tab holding the first invalid field and flags it.
+
+## Security Model
+
+The `Security Model` on a connection controls who in the workspace can use it:
+
+| Option | Who can use the connection |
+|---|---|
+| Private (Only Owners) | Just the owners. |
+| Specific Members Only | Owners plus an explicit list of members. |
+| Specific Security Groups Only | Owners plus members of named security groups. |
+| All Workspace Members | Everyone in the workspace. |
+
+When you choose `Specific Members Only` or `Specific Security Groups Only`, grant the access from the list's `Actions` menu — `Members`, `Groups`, `Agents`, and `Owners` each open a dual-list picker for adding and removing access.
+
+## Environments
+
+A connection can hold a different configuration per **environment** (for example a development host and a production host under one connection name). The environment selector in the toolbar chooses which environment's configuration you are viewing and editing.
+
+- `New Environment` — add a connection environment
+- `Edit Environment` — rename the selected environment
+- `Delete Environment` — remove the selected environment
+
+The `Available` column in the list shows whether the selected connection is configured for the chosen environment.
+
+<Aside type="note">Saving a configuration merges into the stored one for that environment, so blank write-only secrets are never overwritten with empty values.</Aside>
+
+## Edit a Connection
+
+1. Select the connection in the list
+2. Click `Edit` in the toolbar (or right-click the row)
+3. Change the fields and click `Update`
+
+## Test a Connection
+
+How you test depends on the type:
+
+- Database connections with SSH expose a test for the SSH tunnel in the `SSH Config` tab.
+- The [Generic REST Connection](/reference/connectors/rest/generic-rest/) has a `Testing` tab that fires an ad-hoc request through the saved connection.
+
+Save the connection before testing — tests run against the stored configuration.
+
+## Clone, Delete, and Trace Usage
+
+- **Clone** — duplicate a connection's configuration as the basis for a new one. See [Clone a Connection](/guides/connections/clone-connection/).
+- **Delete** — remove the selected connection from the toolbar (you are asked to confirm).
+- **Where Used…** — list the workflow steps that reference the connection, so you can see the impact before editing or deleting it.
+
+<Aside type="caution">`Edit`, `Clone`, and `Delete` are only available on connections you own. If those actions are greyed out for the selected row, you are not an owner — ask an owner to make the change or to add you via `Owners`.</Aside>
+
+## Related
+
+- [Connectors reference](/reference/connectors/) — the full catalog of supported systems and their fields.
+- [Clone a Connection](/guides/connections/clone-connection/)
+- [Singer Sources](/guides/connections/singer-sources/)

--- a/src/content/docs/guides/connections/index.md
+++ b/src/content/docs/guides/connections/index.md
@@ -7,6 +7,7 @@ A **connection** is a saved configuration that lets PlaidCloud reach an external
 
 ## Guides
 
+- [Create and Manage a Connection](/guides/connections/create-connection/) — create, edit, test, and control access to a connection, and configure it per environment.
 - [Clone a Connection](/guides/connections/clone-connection/) — duplicate an existing connection for a new environment or tenant.
 - [Singer Sources](/guides/connections/singer-sources/) — connect to sources such as Stripe, GitHub, Slack, and BigQuery with Singer taps, then import their data into project tables.
 

--- a/src/content/docs/reference/connectors/rest/generic-rest.mdx
+++ b/src/content/docs/reference/connectors/rest/generic-rest.mdx
@@ -1,0 +1,105 @@
+---
+title: Generic REST Connection
+description: "Configure the generic PlaidCloud REST connector for any HTTP API: None, Basic, API Key, Bearer, or OAuth 2.0 auth, headers, and request testing."
+sidebar:
+  label: Generic REST
+  order: 2
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+The **generic REST connection** connects PlaidCloud to any HTTP/REST service that doesn't have a dedicated connector. It supports the common authentication patterns (None, Basic, API Key, Bearer token, OAuth 2.0), default request headers, fine-grained redirect and transport handling, and an in-form request tester.
+
+## Configuration
+
+The form has four tabs.
+
+### Connection Details
+
+| Field | Type | Description |
+|---|---|---|
+| Connection Name | Text | Display name for this connection. |
+| Memo | Text (multi-line) | Optional notes about the connection. |
+| Host or IP Address | Text | Base host the requests target. |
+| Active (Allow Access) | Toggle | Whether the connection is enabled. Disable to pause without deleting. |
+| Authentication Type | Select | `None`, `Basic`, `API Key`, `Bearer Token`, or `OAuth 2.0`. Selecting a type enables the matching group on the **Authentication** tab. |
+| Security Model | Select | Who can use the connection — Private, Specific Members, Specific Security Groups, or All Workspace Members. |
+
+#### Connection Settings
+
+| Setting | Default | Description |
+|---|---|---|
+| Enable SSL certificate verification | Off | Verify SSL certificates when sending a request. Verification failures abort the request. |
+| Automatically follow redirects | On | Follow HTTP 3xx responses as redirects. |
+| Follow original HTTP Method | Off | Redirect with the original HTTP method instead of the default of redirecting with GET. |
+| Follow Authorization Header | Off | Retain the authorization header when a redirect happens. |
+| Remove referer header on redirect | Off | Remove the referer header when a redirect happens. |
+| Enabled strict HTTP parser | Off | Reject responses with invalid HTTP headers. |
+| Encode URL automatically | On | Encode the URL's path, query parameters, and authentication fields. |
+| Disable cookie jar | Off | Don't store this request's cookies in the cookie jar, and don't send stored cookies as headers. |
+| Use server cipher suite during handshake | Off | Use the server's cipher suite order instead of the client's during the handshake. |
+| Maximum number of redirects | 10 | Cap on the number of redirects to follow. |
+
+### Authentication
+
+Only the group matching the selected `Authentication Type` is shown. With `None`, the tab is disabled.
+
+**Basic**
+
+| Field | Type | Description |
+|---|---|---|
+| User | Text | Basic-auth username. |
+| Password | Password | Basic-auth password (write-only). |
+
+**API Key**
+
+| Field | Type | Description |
+|---|---|---|
+| Key | Text | API key field name. |
+| Value | Text | API key value. |
+
+**Bearer Token**
+
+| Field | Type | Description |
+|---|---|---|
+| Token | Password | Bearer token (write-only). |
+
+**OAuth 2.0**
+
+| Field | Type | Description |
+|---|---|---|
+| Add auth data to | Select | Send the auth data in the `Request Headers` or the `Request URL`. |
+| Header Prefix | Text | Prefix for the authorization header value (defaults to `Bearer`). |
+| Auth URL | Text | Authorization endpoint. |
+| Access Token URL | Text | Token endpoint. |
+| Client ID | Text | OAuth client identifier. |
+| Client Secret | Text | OAuth client secret. |
+| Refresh Token URL | Text | Endpoint used to refresh the token. |
+| Initial Refresh Token | Text | Seed refresh token for the first exchange. |
+| Additional Token Request Parameters | Table | Extra body parameters sent on token requests (Enabled, Name, Value, Description). |
+| Additional Token Request Headers | Table | Extra headers sent on token requests (Enabled, Name, Value, Description). |
+
+### Default Headers
+
+A table of headers sent on every request through this connection. Each row has `Enabled`, `Header Name`, `Value`, and `Description`. Use the row buttons to add, insert, and delete headers.
+
+### Testing
+
+Fire an ad-hoc request through the saved connection to confirm it works.
+
+| Field | Type | Description |
+|---|---|---|
+| Testing Endpoint | Text | Full URL to call (for example `https://example.com/rest/test/validate`). |
+| Method | Select | `GET`, `PUT`, `POST`, `DELETE`, `HEAD`, or `OPTIONS`. |
+| Payload | Code | Request body. Supports Django/Jinja-style template tokens. |
+| Send Test Request | Button | Sends the request and shows the response (or the error). |
+
+<Aside type="caution">Save the connection before sending a test request — the test runs against the stored configuration, so an unsaved connection is rejected.</Aside>
+
+<Aside type="note">Password and token fields are write-only. They show blank when you reopen a saved connection, and leaving them blank on save keeps the stored secret. Retype a value only to change it.</Aside>
+
+## Related
+
+- [REST connectors](/reference/connectors/rest/) — dedicated connectors for Salesforce, NetSuite, Workday, and other REST services.
+- [Create and Manage a Connection](/guides/connections/create-connection/)
+- [REST Request workflow step](/guides/workflows/rest-request-step/)

--- a/src/content/docs/reference/connectors/rest/index.md
+++ b/src/content/docs/reference/connectors/rest/index.md
@@ -7,6 +7,10 @@ PlaidCloud connects to REST API services using standard authentication patterns 
 
 For any REST service that doesn't have a dedicated connector, PlaidCloud provides a generic REST connector configurable to most authentication and response-parsing patterns.
 
+## Generic Connector
+
+- [Generic REST Connection](/reference/connectors/rest/generic-rest/) — configure any HTTP API: None/Basic/API Key/Bearer/OAuth 2.0 auth, default headers, redirect handling, and request testing.
+
 ## CRM and Sales
 
 - [Salesforce](/reference/connectors/rest/salesforce/)


### PR DESCRIPTION
## What

Two docs gaps surfaced while converting the analyze **Tools → Connections** forms from YAML blueprints to native windows (PlaidClient #1703 / plaid #6317):

1. **`guides/connections/create-connection`** — a "Create and Manage a Connection" task guide. The connections guide index and the connectors index both linked to a create/manage walkthrough that didn't exist (only Clone and Singer did). Covers: the New Connection menu, the connection form tabs, the Security Model options, per-environment configuration, access control via the Actions menu, edit/test, and clone/delete/where-used with owner-only behavior.
2. **`reference/connectors/rest/generic-rest`** — the generic REST connector reference. `rest/index` referenced "a generic REST connector" but had no page, and the fields were only present as auto-generated placeholders (empty descriptions) on per-provider pages. Documents the four-tab form (Connection Details + the nine transport flags, Authentication for None/Basic/API Key/Bearer/OAuth 2.0, Default Headers, Testing) with real descriptions taken from the shipped UI.

Both are linked from their category indexes.

## Notes

- Field labels, tab names, auth types, transport-flag defaults/descriptions, and Security Model options were taken verbatim from the native window source, not guessed.
- The underlying connection conversion is behavior-preserving, so the existing per-connector reference pages stay accurate — this PR fills the two genuine gaps rather than rewriting the catalog.
- `astro build` passes locally (1505 pages); both new routes emit and all internal links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)