### PR TITLE
Fix IndexNow ping: illegal backslash in f-string [sc-22676]

### DIFF
--- a/.github/workflows/indexnow.yaml
+++ b/.github/workflows/indexnow.yaml
@@ -73,11 +73,12 @@ jobs:
           set -euo pipefail
           PAYLOAD=$(python3 -c '
           import json, os
+          key = os.environ["KEY"]
           urls = json.loads(os.environ["URLS"])
           payload = {
               "host": "docs.plaidcloud.com",
-              "key": os.environ["KEY"],
-              "keyLocation": f"https://docs.plaidcloud.com/{os.environ[\"KEY\"]}.txt",
+              "key": key,
+              "keyLocation": "https://docs.plaidcloud.com/" + key + ".txt",
               "urlList": urls,
           }
           print(json.dumps(payload))


### PR DESCRIPTION
## What

Fixes the `Submit to IndexNow` step in `.github/workflows/indexnow.yaml`, which has failed with a Python `SyntaxError` on every push to `main` that touches content.

## Root cause

`keyLocation` was built with an f-string containing backslash-escaped quotes:

```python
f"https://docs.plaidcloud.com/{os.environ[\"KEY\"]}.txt"
```

The script runs via `python3 -c '...'` inside bash single quotes, so the backslashes reach Python literally. A `\` inside an f-string expression is illegal in **every** Python 3 version (reproduced on 3.14: `unexpected character after line continuation character`). Result: the IndexNow re-crawl ping never fired — search engines only picked up changes on their normal crawl cycle.

## Fix

Bind the key once and concatenate — no f-string, and no inner quote that could break the bash wrapper:

```python
key = os.environ["KEY"]
...
"keyLocation": "https://docs.plaidcloud.com/" + key + ".txt",
```

## Verification

- Python extracted verbatim from the parsed YAML compiles and runs; emits correct JSON for single- and multi-URL payloads.
- No single-quote in the Python source (would otherwise terminate the bash `'...'` wrapper).
- Key file confirmed live: `https://docs.plaidcloud.com/5e5bfa9ab14622d2bdf8b8bfc3df225f.txt` → HTTP 200, so submissions are accepted once the syntax is valid.

Pure crash fix — output JSON is identical to the original author's intent.

Fixes [sc-22676](https://app.shortcut.com/plaidcloud/story/22676).

🤖 Generated with [Claude Code](https://claude.com/claude-code)