### PR TITLE
Touch content to validate IndexNow ping (post-#196)

### DIFF
--- a/src/content/docs/guides/ai-assistant/fixing-workflow-errors.mdx
+++ b/src/content/docs/guides/ai-assistant/fixing-workflow-errors.mdx
@@ -88,3 +88,4 @@ change is reversible by re-running the assistant or editing the step directly.</
 - If the assistant says the cause is outside the step's configuration (bad data,
   an upstream failure, a permissions problem), that is the answer — fix it where
   it actually lives rather than asking the assistant to edit the step anyway.
+


### PR DESCRIPTION
Trivial trailing-newline change to `guides/ai-assistant/fixing-workflow-errors.mdx` — no rendered change.

Purpose: produce a push to `main` that matches the IndexNow workflow's `paths:` filter so the `Submit to IndexNow` step actually runs after the SyntaxError fix in #196 (that fix only touched the workflow file, which is outside the filter, so it never triggered a run). On merge, the resolver should derive exactly `https://docs.plaidcloud.com/guides/ai-assistant/fixing-workflow-errors/` and the ping should return HTTP 200/202.

Safe to revert afterward if you'd prefer the newline gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)