### PR TITLE
docs(table-explorer): document Top/Random row selection

### DIFF
--- a/src/content/docs/guides/data/table-explorer.mdx
+++ b/src/content/docs/guides/data/table-explorer.mdx
@@ -37,6 +37,18 @@ The rows shown along with the total size of the dataset are shown at the bottom 
 <Aside type="caution">Be careful not to disable the row limit functionality when viewing larger (e.g. millions of rows) because this could cause your browser to run slow. Try using filters to find the data instead.</Aside>
 
 
+### Choosing Top or Random Rows
+
+Next to the row limit is a **Top / Random** selector that controls *which* rows fill the grid:
+
+ * **Top** (the default) returns the first rows of the table — the fastest option, and the right choice when you just want a quick look.
+ * **Random** returns a fast, approximate random sample drawn from across the whole table, so the preview reflects the full range of your data rather than just the beginning. This is useful for spot-checking data quality on a large table where the first rows aren't representative.
+
+Random sampling uses your storage engine's built-in sampling, so it stays quick even on very large tables. Because it samples a percentage of the data, the result is close to, but not exactly, the requested row count, and you get a different sample each time you refresh. The selector applies to the grid preview only; it has no effect on saved views, extracts, downloads, or the reported row counts. Random requires the row limit to be enabled.
+
+<Aside type="note">Sorting by a column header sorts only the rows currently retrieved, so a sort combined with Random orders just the sampled rows, not the whole table.</Aside>
+
+
 ### Sorting Locally Versus Globally
 
 The Grid view provides the ability to click on the column header and sort the data based on that column.  However, this method is only sorting the dataset


### PR DESCRIPTION
Documents the new **Top / Random** grid selector in the Table Explorer guide (new "Choosing Top or Random Rows" section): what each mode does, that Random is approximate / preview-only (no effect on views, extracts, downloads, or row counts), and that it stays fast on large tables via native engine sampling.

Companions: PlaidCloud/plaid#6325, PlaidCloud/PlaidClient (UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)