### PR TITLE
docs(table-explorer): random returns the requested row count

### DIFF
--- a/src/content/docs/guides/data/table-explorer.mdx
+++ b/src/content/docs/guides/data/table-explorer.mdx
@@ -42,9 +42,9 @@ The rows shown along with the total size of the dataset are shown at the bottom 
 Next to the row limit is a **Top / Random** selector that controls *which* rows fill the grid:
 
  * **Top** (the default) returns the first rows of the table — the fastest option, and the right choice when you just want a quick look.
- * **Random** returns a fast, approximate random sample drawn from across the whole table, so the preview reflects the full range of your data rather than just the beginning. This is useful for spot-checking data quality on a large table where the first rows aren't representative.
+ * **Random** returns a fast random sample drawn from across the whole table, so the preview reflects the full range of your data rather than just the beginning. This is useful for spot-checking data quality on a large table where the first rows aren't representative.
 
-Random sampling uses your storage engine's built-in sampling, so it stays quick even on very large tables. Because it samples a percentage of the data, the result is close to, but not exactly, the requested row count, and you get a different sample each time you refresh. The selector applies to the grid preview only; it has no effect on saved views, extracts, downloads, or the reported row counts. Random requires the row limit to be enabled.
+Random sampling uses your storage engine's built-in sampling, so it stays quick even on very large tables. It returns the number of rows you asked for — drawn at random from across the table, or all of them if the table holds fewer rows than your limit — and you get a different sample each time you refresh. The selector applies to the grid preview only; it has no effect on saved views, extracts, downloads, or the reported row counts. Random requires the row limit to be enabled.
 
 <Aside type="note">Sorting by a column header sorts only the rows currently retrieved, so a sort combined with Random orders just the sampled rows, not the whole table.</Aside>
 


### PR DESCRIPTION
Follow-up to #199. Random sampling now returns the requested number of rows (the backend oversamples then trims), so the guide no longer says the count is approximate. Companion to PlaidCloud/plaid fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)