### PR TITLE
Outer Join: document the Left / Right / Full Outer join-type control

### DIFF
--- a/src/content/docs/reference/workflow-steps/tables/table-outer-join.mdx
+++ b/src/content/docs/reference/workflow-steps/tables/table-outer-join.mdx
@@ -1,6 +1,6 @@
 ---
 title: Table Outer Join
-description: Perform an outer join between two tables in a PlaidCloud workflow step to combine records and include unmatched rows from both.
+description: Join two tables in a PlaidCloud workflow step with a left, right, or full outer join, keeping unmatched rows according to the join type you choose.
 sidebar:
   order: 14
 ---
@@ -14,10 +14,10 @@ import SnippetCommonDataFilter from '@snippets/common-data-filter.mdx';
 ## Description
 
 
-Use, as you might have expected, to perform a **full** outer join operation on 2 data tables, combining them into a single data table based upon the join key(s) specified.
+Use to perform an outer join on 2 data tables, combining them into a single data table based upon the join key(s) specified. The **Join Type** control selects which unmatched rows to keep — a **Left**, **Right**, or **Full Outer** join. The default is a left join (every row from Table A, with Table B's columns filled in where the keys match).
 
 
-For more details on outer join methodology, see here: [Wikipedia SQL Full Outer Join](http://en.wikipedia.org/wiki/Join_%28SQL%29#Full_outer_join)
+For more details on outer join methodology, see here: [Wikipedia SQL Join](http://en.wikipedia.org/wiki/Join_%28SQL%29)
 
 
 
@@ -41,6 +41,14 @@ For more details on outer join methodology, see here: [Wikipedia SQL Full Outer 
 ### Join Map
 
 <SnippetCommonTableJoinMap />
+
+### Join Type
+
+Choose how unmatched rows are kept:
+
+- **Left Join** — keep every row from Table A; Table B's columns are filled in only where the join keys match. This is the default.
+- **Right Join** — keep every row from Table B; Table A's columns are filled in only where the join keys match.
+- **Full Outer Join** — keep every row from both tables, whether or not it has a match on the other side.
 
 ### Target Output Columns
 
@@ -104,7 +112,7 @@ Next, specify parameters for **Table 2 Data Selection.** Once again, the source 
 
 
 
-Finally, the join conditions are set in the **Table Output** tab. Using the **Guess** button, Analyze properly identifies the *Mfg_ID* column to use as the **Join Key**. Lastly, the 
+Finally, the join conditions are set in the **Table Output** tab. Using the **Guess** button, Analyze properly identifies the *Mfg_ID* column to use as the **Join Key**. Because this example keeps unmatched rows from both tables, set the **Join Type** to **Full Outer Join**. Lastly, the 
 
 
 **Target Output Columns** are specified automatically using the **Propagate** button. This effectively includes all columns from all tables, with any join columns obviously only being included a single time. Note that the columns are sorted alphabetically, first by *Manufacturer* and next by *ModelName*.


### PR DESCRIPTION
Updates the Table Outer Join reference page to match the shipped behavior: the step now has a Join Type control (Left / Right / Full Outer, default Left) that is actually executed, instead of always performing a full outer join.

- Corrected the description (was "always a full outer join")
- Added a **Join Type** section describing the three options
- Updated the worked example to select Full Outer Join
- Refreshed the frontmatter description

Companion to the workflow-runner / PlaidCloud / PlaidClient change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)