### PR TITLE
docs(projects): name Export/Import Project Archive menu items in archive guide

### DIFF
--- a/src/content/docs/guides/projects/archive-a-project.md
+++ b/src/content/docs/guides/projects/archive-a-project.md
@@ -28,7 +28,7 @@ To archive a project:
 
 1. Open Analyze
 2. Select the “Projects” tab
-3. Select the project, then choose **Export Project Archive** from the **Actions** menu (or right-click the project)
+3. Select the project, then choose **Export Project Archive** from the **Actions** menu (or right-click the project and choose **Export Project Archive**)
 
 ## Restoring an Archive
 

--- a/src/content/docs/guides/projects/archive-a-project.md
+++ b/src/content/docs/guides/projects/archive-a-project.md
@@ -28,6 +28,7 @@ To archive a project:
 
 1. Open Analyze
 2. Select the “Projects” tab
+3. Select the project, then choose **Export Project Archive** from the **Actions** menu (or right-click the project)
 
 ## Restoring an Archive
 
@@ -41,6 +42,7 @@ To restore an archive:
 
 1. Open Analyze
 2. Select the “Projects” tab
+3. Choose **Import Project Archive** from the **Actions** menu (or the toolbar) and select the archive to restore
 
 ## Archiving Schedule
 


### PR DESCRIPTION
## What

Updates the **Archive a Project** guide so the archive/restore steps name the actual menu items in the renamed Projects actions menu:

- Creating an archive → **Export Project Archive** (Actions menu / right-click).
- Restoring an archive → **Import Project Archive** (Actions menu / toolbar).

Companion to PlaidCloud/PlaidClient#1718, which renames and regroups those menu items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)