### PR TITLE
docs(releases): add June 2026 What's New page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,8 @@ The `astro-migration` branch is retained for safety until the new deployment has
 
 ### A new monthly release page
 
+**Keep the current month's What's New entry current as part of shipping a change — don't leave it for later.** Whenever a customer-facing feature is added or updated, or a customer-facing bug is fixed, add a matching entry to the current month's `src/content/docs/releases/YYYY-MM.mdx` (under `## Added` / `## Changed` / `## Fixed` / `## Security`) and, when the page is new, create it from the previous month's structure — a `## Releases Shipped` version table plus those sections — and add its `<LinkCard>` to `releases/index.mdx`. Do this alongside the feature's guide/reference docs in the same change, not as a separate pass. The What's New area is how we showcase what shipped, so anything of significance belongs here. Keep entries customer-facing: plain-language outcomes only — no internal symbols, file names, SQL, version-control detail, or other implementation specifics.
+
 The PR template (`.github/pull_request_template.md`) has a "User-facing change?" checkbox and a customer summary field. Future monthly notes should be writable directly from the squash-merge commit body — no excavation needed.
 
 For the current corpus, monthly pages were generated from `plaid-tenant-infrastructure` tag history via:

--- a/src/content/docs/releases/2026-06.mdx
+++ b/src/content/docs/releases/2026-06.mdx
@@ -1,0 +1,71 @@
+---
+title: June 2026
+description: Multi-agent AI assistant, 140+ data connectors, table snapshots, a rebuilt project report, Forecast and Solver workflow steps, and a collaborative Visual Workflow Designer.
+---
+
+## Releases Shipped
+
+| Version | Released |
+|---|---|
+| v5.7.1 | 2026-06-03 |
+| v5.8.0 | 2026-06-03 |
+| v5.9.0 | 2026-06-09 |
+| v5.9.1 | 2026-06-10 |
+| v5.10.0 | 2026-06-17 |
+| v5.10.1 | 2026-06-21 |
+| v5.10.2 | 2026-06-22 |
+
+## Added
+
+- **Multi-agent AI assistant** — the assistant now coordinates specialized sub-agents behind a single orchestrator, producing more accurate, better-reasoned answers to your data questions.
+- **Visual explanations in chat** — the assistant can generate diagrams and inline charts to illustrate its answers, so complex results are easier to understand at a glance.
+- **AI (LLM) workflow step** — call a large language model directly as a step in your workflow, with multiple providers and access levels supported.
+- **Generate a SQL Extract from a description** — describe the result you want in plain language and the assistant writes the query for you, even choosing the relevant source tables; the generated SQL and detected columns stay fully editable before you save.
+- **Export a table with the assistant** — ask the assistant to export a table and it builds a re-runnable export step for you, with the file format following the extension you choose (CSV, TSV, Excel, Parquet, JSON, or XML).
+- **AI assistant on mobile** — talk to the assistant from the PlaidCloud mobile app.
+- **140+ new data connectors** — a major expansion of supported data sources, with guided connection setup and automatic discovery of the streams available to import.
+- **Incremental, resumable syncs** — syncs pick up where they left off and merge new records by key, so you only move what's changed.
+- **Faster Snowflake imports** — server-side unload speeds up large imports from Snowflake.
+- **REST Request workflow step** — call any endpoint from a connection's catalog, send a test request, and capture the response into a table — or into workflow variables to branch on.
+- **Multi-table Join step with a visual join designer** — draw joins between table columns on a visual graph, with undo/redo and diagram export.
+- **Forecast workflow step** — run forecasting directly as a workflow step.
+- **Solver workflow step** — run optimization (linear and mixed-integer) as a workflow step, writing solution, constraint, and summary tables.
+- **Concurrent macro execution** — macro steps can run work in parallel for faster processing.
+- **Collaborative Visual Workflow Designer** — a visual view of your workflow with step color-coding, a redesigned canvas, and live collaboration so teammates can work on a workflow together.
+- **Workflow run history and heatmap** — a new run-history view with an activity heatmap to spot patterns and problem runs at a glance.
+- **Scheduled events calendar** — see upcoming scheduled runs in Week, Month, and Agenda views, with overlap detection and a filter across schedule, workflow, and project.
+- **Table snapshots and point-in-time restore** — view a table as it was at an earlier saved point, and restore it in place when you need to roll back.
+- **Rebuilt project report** — a thoroughly redesigned report that documents every workflow step, opens each workflow with a generated flow diagram, and includes an executive summary and audit inventories (connections, tables and their lineage, source files, and exports). Produce it as a polished, branded PDF or as an interactive HTML companion with collapsible detail and a clickable table of contents; a progress dialog tracks generation workflow by workflow.
+- **Compare and merge projects** — see the differences between two projects and safely merge changes between them.
+- **"Where Used" impact analysis** — quickly see where agents and external data connections are used before you change them.
+- **Allocation root-cause tracing** — new lineage and tracing tools make it easier to understand and troubleshoot how allocation results were produced.
+
+## Changed
+
+- **More relevant AI answers** — improved retrieval pulls in the right supporting context when the assistant answers, and expression-authoring help is now checked against what the engine actually runs, so mistakes are caught earlier.
+- **The assistant can fix a failing step** — when a workflow step errors, the assistant can propose a corrected configuration and, once you approve it, apply the fix — not just explain what went wrong.
+- **Clearer AI activity** — a processing indicator shows while the assistant works on longer queries instead of leaving you with silent dead air, and conversations are now organized by project.
+- **Faster table previews** — the table explorer can show a quick random sample instead of always the first rows, and column value profiles now cap long-running queries (with a "timed out" badge) so the explorer stays responsive on very large tables.
+- **Larger dimensions scale further** — very large hierarchies can now be stored in the project's datastore as an alternative to the in-memory store, so they persist and scale without slowing things down.
+- **Visual Workflow Designer enhancements** — deep-linkable project and canvas URLs with working browser back and forward, breakpoints on advanced-workflow nodes, and groupable node containers that enable or disable as a unit.
+- **More robust file imports** — improved Parquet handling and clearer, more reliable error reporting for problem files, including malformed XML and tricky text encodings.
+- **Smoother dashboards and user sync** — dashboard rendering fixes and tighter synchronization of users and roles with the analytics layer.
+- **More resilient connections** — self-healing for the caching layer and background-processing fixes reduce stalls and improve overall responsiveness.
+
+## Fixed
+
+- **No more "stuck refreshing"** — fixed a case where the app could repeatedly reload itself when the server briefly couldn't confirm the current version.
+- **Join type now sticks** — selecting a Right or Full Outer join now persists instead of silently reverting to a Left join.
+- **Reliable table exports** — fixed table exports to Parquet, Avro, and XML that could fail, including uncompressed Parquet on some projects.
+- **Interrupted steps recover** — import and export steps no longer appear to run forever when the worker handling them is interrupted; the work is picked up and finished by another worker.
+- **CSV import default** — fixed an imported CSV step that could fail to run because of a missing "null as" default.
+- **Panel app permissions in older workspaces** — the Panel app read and write permissions now appear, and can be assigned, in workspaces created before the feature shipped.
+- **Documents browser** — fixed folders showing empty on first open, a folder-move path error, and an occasional crash when refreshing a folder that had just been moved or deleted.
+
+## Security
+
+- **Passwordless access for the PlaidCloud support team** — all support team members now sign in without usernames and passwords, eliminating password-based credentials as an attack vector for support access to the platform.
+- **Stronger per-tenant isolation** — each tenant now uses its own dedicated signing secrets for sessions and workflow steps.
+- **Cross-site scripting (XSS) hardening** — dialog content and on-screen notifications are safely escaped by default, with HTML allowed only where explicitly intended.
+- **Hardened file imports** — malformed uploads are handled safely instead of surfacing confusing errors.
+- **Continuous vulnerability scanning** — application images are automatically scanned for known security vulnerabilities as part of every build.

--- a/src/content/docs/releases/index.mdx
+++ b/src/content/docs/releases/index.mdx
@@ -11,6 +11,11 @@ Monthly summaries of changes shipped to PlaidCloud tenants. Months with substant
 
 <CardGrid>
 	<LinkCard
+		title="June 2026"
+		href="/releases/2026-06/"
+		description="v5.7.1 → v5.10.2 · Multi-agent AI assistant, 140+ connectors, table snapshots, rebuilt project report, Forecast & Solver steps, collaborative Workflow Designer."
+	/>
+	<LinkCard
 		title="May 2026"
 		href="/releases/2026-05/"
 		description="v5.6.4 → v5.7.0 · Personal Temp Drive, Stripe self-service signup, MCP integration, app interface consolidated."


### PR DESCRIPTION
## What

Adds the **June 2026** What's New page and keeps the area maintained going forward.

- **New page** `releases/2026-06.mdx` — the June 2026 monthly summary covering the tenant releases **v5.7.1 → v5.10.2** and a customer-facing rundown of features, improvements, and fixes (Added / Changed / Fixed / Security). Written for a public, non-technical audience — plain-language outcomes, no implementation detail.
- **Index** `releases/index.mdx` — adds the June 2026 `<LinkCard>` at the top of the 2026 timeline.
- **CLAUDE.md** — adds a rule that the What's New area must be updated alongside the docs whenever a customer-facing feature is added/updated or a customer-facing bug is fixed (in the same change, not a later pass).

## Highlights showcased

Multi-agent AI assistant, generate-a-SQL-Extract-from-a-description, 140+ data connectors, REST Request and multi-table Join steps, Forecast & Solver steps, table snapshots with point-in-time restore, a rebuilt Project Report (PDF + interactive HTML), the collaborative Visual Workflow Designer, run history & heatmap, scheduled-events calendar, plus the month's reliability and security hardening.

## Notes

- Built from the June tenant release range and the plaid / PlaidClient changelogs; intentionally curated to showcase significant customer-facing changes.
- Verified locally: frontmatter parses and the body is free of MDX brace pitfalls. Relying on the Cloudflare preview build + Vale/Lychee checks for the full validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
