### PR TITLE
docs(releases): note multi-schema external-table metadata fix (June 2026)

### DIFF
--- a/src/content/docs/releases/2026-06.mdx
+++ b/src/content/docs/releases/2026-06.mdx
@@ -61,6 +61,7 @@ description: Multi-agent AI assistant, 140+ data connectors, table snapshots, a 
 - **CSV import default** — fixed an imported CSV step that could fail to run because of a missing "null as" default.
 - **Panel app permissions in older workspaces** — the Panel app read and write permissions now appear, and can be assigned, in workspaces created before the feature shipped.
 - **Documents browser** — fixed folders showing empty on first open, a folder-move path error, and an occasional crash when refreshing a folder that had just been moved or deleted.
+- **Multi-schema external database imports** — fixed "Retrieve Metadata" and "Inspect Source Database" on the Import and Export External Database Tables steps failing with an "unexpected error" when the selected source tables come from more than one schema; multi-schema selections now refresh correctly, and a connection or metadata problem reports a clear message instead of a generic error.
 
 ## Security
 


### PR DESCRIPTION
Adds a **Fixed** entry to the June 2026 What's New page for the external-database-tables multi-schema metadata fix.

Backs plaid #6346 (merged to `master`) / #6348 (beta-202606 cherry-pick): the Import/Export External Database Tables steps' "Retrieve Metadata" / "Inspect Source Database" actions failed with a generic error when the selected source tables spanned more than one schema. Plain-language, customer-facing; no internal symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)