### PR TITLE
docs(panel-apps): document the server-app cold-start loading screen

### DIFF
--- a/src/content/docs/guides/panel-apps/using.md
+++ b/src/content/docs/guides/panel-apps/using.md
@@ -24,7 +24,9 @@ Click the **Open** icon at the start of a ready app's row to launch it in a new 
 - A server app is served at `https://<your-tenant-host>/serve/<slug>/`.
 - The **Open** icon appears only once a server app is **Ready**.
 
-> A server app scales to zero when idle. The first request after an idle period spins it up — expect roughly a 15-second wait on that first open, then it responds normally until it goes idle again.
+A server app scales to zero when idle to save resources, so the first open after an idle period has to spin it up. While that happens you see a **PlaidCloud loading screen** — your app's name, a progress indicator, and your workspace details — instead of a blank tab. The app appears on its own as soon as it is ready (usually a few seconds, up to about a minute on a cold start), and then responds normally until it next goes idle.
+
+> If an app can't start, the loading screen turns into a **"This app didn't start"** message with a **Try Again** button rather than spinning forever. If that keeps happening, edit the app to check its entry point and branch and republish, or contact your PlaidCloud administrator.
 
 ## Editing an App
 

--- a/src/content/docs/releases/2026-06.mdx
+++ b/src/content/docs/releases/2026-06.mdx
@@ -51,6 +51,7 @@ description: Multi-agent AI assistant, 140+ data connectors, table snapshots, a 
 - **More robust file imports** — improved Parquet handling and clearer, more reliable error reporting for problem files, including malformed XML and tricky text encodings.
 - **Smoother dashboards and user sync** — dashboard rendering fixes and tighter synchronization of users and roles with the analytics layer.
 - **More resilient connections** — self-healing for the caching layer and background-processing fixes reduce stalls and improve overall responsiveness.
+- **A loading screen for server Panel apps** — opening a server-side Panel app that has gone idle now shows a branded PlaidCloud loading screen while it spins up, instead of a blank tab, and turns into a clear "this app didn't start" message with a retry if it can't launch.
 
 ## Fixed
 


### PR DESCRIPTION
Documents the new branded loading screen shown when a server-side Panel app spins up from idle (shipped to beta via plaid #6356 / PlaidClient #1726 / infra #720).

- **guides/panel-apps/using.md** — "Opening an App" now describes the PlaidCloud loading screen (app name + progress + workspace details) that replaces the old blank tab during cold start, plus the bounded "this app didn't start" + Try Again failure state.
- **releases/2026-06.mdx** — What's New entry under ## Changed.