### PR TITLE
docs(releases): match exact UI string capitalization in the loading-screen note

### DIFF
--- a/src/content/docs/releases/2026-06.mdx
+++ b/src/content/docs/releases/2026-06.mdx
@@ -51,7 +51,7 @@ description: Multi-agent AI assistant, 140+ data connectors, table snapshots, a 
 - **More robust file imports** — improved Parquet handling and clearer, more reliable error reporting for problem files, including malformed XML and tricky text encodings.
 - **Smoother dashboards and user sync** — dashboard rendering fixes and tighter synchronization of users and roles with the analytics layer.
 - **More resilient connections** — self-healing for the caching layer and background-processing fixes reduce stalls and improve overall responsiveness.
-- **A loading screen for server Panel apps** — opening a server-side Panel app that has gone idle now shows a branded PlaidCloud loading screen while it spins up, instead of a blank tab, and turns into a clear "this app didn't start" message with a retry if it can't launch.
+- **A loading screen for server Panel apps** — opening a server-side Panel app that has gone idle now shows a branded PlaidCloud loading screen while it spins up, instead of a blank tab, and turns into a clear "This app didn’t start" message with a retry if it can't launch.
 
 ## Fixed
 


### PR DESCRIPTION
Post-merge nit from the Sonnet review of #206: the What's New bullet quoted the UI message as lowercase "this app didn't start" — the actual UI string is "This app didn't start" (capital T). One-character accuracy fix.