### PR TITLE
docs(panel-apps): document theme control (light/dark/toggle)

### DIFF
--- a/src/content/docs/guides/panel-apps/creating.md
+++ b/src/content/docs/guides/panel-apps/creating.md
@@ -81,6 +81,57 @@ PlaidCloud installs these with `pip` when it builds the image.
 > - **The app runs as a non-root user on a read-only filesystem.** Only `/tmp` is writable, so write any temporary files there (most libraries already honor `$TMPDIR`).
 > - **Don't hardcode the port, URL prefix, or host.** PlaidCloud assigns them and injects them at deploy time — just call `.servable()`.
 
+### Set the Theme: Light, Dark, or a Toggle
+
+Server apps render in PlaidCloud's modern **Fast** design by default — a clean, Fluent-style look applied platform-wide, so you get it with no code. What you control, in your app, is the **theme**: light, dark, or a switch the viewer can flip.
+
+The theme is a property of the **template** you serve. The Fast templates — `FastListTemplate` (a single column) and `FastGridTemplate` (a responsive grid) — take two settings for it:
+
+- **`theme`** — `"default"` for light or `"dark"`. Setting it pins the app to that theme, even if a viewer adds `?theme=dark` to the URL.
+- **`theme_toggle`** — `True` shows a light/dark switch in the header; `False` hides it. It defaults to `True`, so set it explicitly when you want a fixed theme.
+
+Pick the pattern that fits your app.
+
+**Light only** — best for dense reports and financial tables, which are usually hand-styled for a light background:
+
+```python
+import panel as pn
+
+pn.extension("tabulator")
+
+pn.template.FastListTemplate(
+    title="Sales Dashboard",
+    theme="default",      # light
+    theme_toggle=False,   # hide the switch
+    main=[...],
+).servable()
+```
+
+**Dark only:**
+
+```python
+pn.template.FastListTemplate(
+    title="Ops Monitor",
+    theme="dark",
+    theme_toggle=False,
+    main=[...],
+).servable()
+```
+
+**Let the viewer choose** — defaults to light, with a switch in the header. Omit `theme` so it follows the toggle:
+
+```python
+pn.template.FastListTemplate(
+    title="Explorer",
+    theme_toggle=True,
+    main=[...],
+).servable()
+```
+
+> **If you allow dark, make your tables dark-aware.** A `Tabulator` pinned to a light table theme (`theme="bootstrap"`), or custom CSS with hardcoded light colors like `background: #fff`, renders as an unreadable white block on a dark page. Use a table theme that follows the app — `pn.widgets.Tabulator(..., theme="fast")` — and avoid hardcoded light colors. If a report is heavily hand-styled for light, pin it to light instead (the first pattern above).
+
+A plain app with no template — `pn.Column(...).servable()` — follows Panel's default and isn't affected by these settings; reach for a template when you want explicit control.
+
 Your repository must be reachable through a **git connection** in PlaidCloud. If you don't have one yet, create it under **Tools > Connections** before publishing.
 
 ### Publish the App

--- a/src/content/docs/guides/panel-apps/creating.md
+++ b/src/content/docs/guides/panel-apps/creating.md
@@ -88,7 +88,7 @@ Server apps render in PlaidCloud's modern **Fast** design by default — a clean
 The theme is a property of the **template** you serve. The Fast templates — `FastListTemplate` (a single column) and `FastGridTemplate` (a responsive grid) — take two settings for it:
 
 - **`theme`** — `"default"` for light or `"dark"`. Setting it pins the app to that theme, even if a viewer adds `?theme=dark` to the URL.
-- **`theme_toggle`** — `True` shows a light/dark switch in the header; `False` hides it. It defaults to `True`, so set it explicitly when you want a fixed theme.
+- **`theme_toggle`** — `True` shows a light/dark switch in the header; `False` hides it. It defaults to `True`. Hiding the switch doesn't fix the theme on its own — pin it with `theme` (above); set `theme_toggle=False` once you have, so viewers don't see a switch that can't change anything.
 
 Pick the pattern that fits your app.
 

--- a/src/content/docs/releases/2026-06.mdx
+++ b/src/content/docs/releases/2026-06.mdx
@@ -57,7 +57,7 @@ description: Multi-agent AI assistant, 140+ data connectors, table snapshots, a 
 - **Smoother dashboards and user sync** — dashboard rendering fixes and tighter synchronization of users and roles with the analytics layer.
 - **More resilient connections** — self-healing for the caching layer and background-processing fixes reduce stalls and improve overall responsiveness.
 - **A loading screen for server Panel apps** — opening a server-side Panel app that has gone idle now shows a branded PlaidCloud loading screen while it spins up, instead of a blank tab, and turns into a clear "This app didn’t start" message with a retry if it can't launch.
-- **Consistent light theme for server Panel apps** — server Panel apps now always display in the light theme, so the app and its loading screen look consistent for every viewer. Dark mode isn't supported yet, so build and test your app against a light background.
+- **A modern look and theme control for server Panel apps** — server Panel apps now use a modern Fast design by default, and you set the theme in your app — light, dark, or a light/dark toggle viewers can flip — through the template you serve. Tables and custom styling built for a light background should stay on light.
 
 ## Fixed
 


### PR DESCRIPTION
Adds a **Set the Theme** section to the Creating a Panel App guide: the per-app template settings (`theme` + `theme_toggle`) with copy-paste light-only / dark-only / toggle patterns, plus the dark-table caveat (hardcoded light `Tabulator`/CSS renders unreadable on dark).

Also updates the June What's New entry — server Panel apps are no longer force-light; the modern Fast design + per-app theme control shipped, so the old 'always light / dark not supported' note was stale.

Built locally: `npm run build` ✓ (1508 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)