### PR TITLE
docs(copilot): clear end-to-end Microsoft 365 Copilot workflow

### DIFF
--- a/src/content/docs/integrations/microsoft-365-copilot.mdx
+++ b/src/content/docs/integrations/microsoft-365-copilot.mdx
@@ -28,9 +28,9 @@ PlaidCloud publishes a small **agent** that plugs into Microsoft 365 Copilot. Wh
 Copilot a question about their data, the agent securely connects to your PlaidCloud workspace, runs
 the request under that person's own permissions, and Copilot explains the answer.
 
-- **Read-only by default.** A person's access starts at read-only — list and describe projects and
-  tables, read table data, list dimension members, and explain allocation results. It never invents
-  numbers; every answer comes from a real query against your data.
+- **Read-only for most people.** The common access level is read-only — list and describe projects
+  and tables, read table data, list dimension members, and explain allocation results. It never
+  invents numbers; every answer comes from a real query against your data.
 - **Each person sees only their own data.** Requests run as the signed-in user, bounded by the same
   PlaidCloud roles and access controls they already have. The agent can never reach credential,
   identity, or access-control settings.
@@ -48,7 +48,7 @@ hat. **Steps 1–5 install the agent; step 6 is what actually lets data flow.**
 | 1 | [Download the agent package](#step-1--download-the-agent-package) (`.zip`) | PlaidCloud workspace admin | PlaidCloud control plane → **Workspaces** |
 | 2 | [Allow custom apps](#step-2--allow-custom-apps) | Microsoft 365 / Teams admin | Teams admin center → **Setup policies** |
 | 3 | [Upload the package](#step-3--upload-the-package) | Microsoft 365 / Teams admin | Teams admin center → **Manage apps → Actions** |
-| 4 | [Add the agent in Copilot](#step-4--add-the-agent-in-copilot) | Each user (or pre-installed) | Microsoft 365 Copilot → **More agents** |
+| 4 | [Add the agent in Copilot](#step-4--add-the-agent-in-copilot) | Each user | Microsoft 365 Copilot → **More agents** |
 | 5 | [Sign in](#step-5--sign-in) | Each user | Copilot (one time) |
 | 6 | [Grant an access level](#step-6--grant-an-access-level) | PlaidCloud administrator | PlaidCloud |
 
@@ -198,7 +198,7 @@ show or change data they couldn't already reach themselves.
 | Level | The agent can… | Typical use |
 |---|---|---|
 | **Read-only** | List and describe projects and tables, read table data, list dimension members, explain allocations. No changes. | Most people. The safe default. |
-| **Read / Write** | Everything in read-only, plus structured writes the person is permitted to make (e.g. updating table data). | Analysts who maintain data. |
+| **Read/Write** | Everything in read-only, plus structured writes the person is permitted to make (e.g. updating table data). | Analysts who maintain data. |
 | **Full** | The person's complete PlaidCloud tool set, including running raw SQL that writes. | Power users and builders. |
 
 A few rules apply at every level:

--- a/src/content/docs/integrations/microsoft-365-copilot.mdx
+++ b/src/content/docs/integrations/microsoft-365-copilot.mdx
@@ -1,17 +1,16 @@
 ---
 title: Microsoft 365 Copilot
-description: Let your team ask questions of their PlaidCloud data from Microsoft 365 Copilot — install the PlaidCloud agent once and sign in.
+description: Let your team ask questions of their PlaidCloud data from Microsoft 365 Copilot — install the PlaidCloud agent once, sign in, and grant access levels.
 sidebar:
   label: Microsoft 365 Copilot
   order: 12
 ---
 
-import { Aside, Steps, CardGrid, Card } from '@astrojs/starlight/components';
+import { Aside, Steps } from '@astrojs/starlight/components';
 
-Bring your PlaidCloud data into **Microsoft 365 Copilot**. Once your administrator installs
-the PlaidCloud agent, anyone in your organization can ask Copilot about their projects,
-tables, dimensions, and allocation models in plain language — no separate login, no PlaidCloud
-window, no SQL.
+Bring your PlaidCloud data into **Microsoft 365 Copilot**. Once the PlaidCloud agent is installed
+and a person is granted access, they can ask Copilot about their projects, tables, dimensions, and
+allocation models in plain language — no separate login, no PlaidCloud window, no SQL.
 
 > *"List my PlaidCloud projects."*
 > *"What tables are in Enterprise Profitability, and show me the first rows of one."*
@@ -29,125 +28,191 @@ PlaidCloud publishes a small **agent** that plugs into Microsoft 365 Copilot. Wh
 Copilot a question about their data, the agent securely connects to your PlaidCloud workspace, runs
 the request under that person's own permissions, and Copilot explains the answer.
 
-- **Read-only by default.** The agent ships with a read-only set of tools — list and describe
-  projects and tables, read table data, list dimension members, and explain allocation results.
-  It never invents numbers; every answer comes from a real query against your data.
-- **Each person sees only their own data.** Requests run as the signed-in user, bounded by the
-  same PlaidCloud roles and access controls they already have. The AI can never reach credential,
+- **Read-only by default.** A person's access starts at read-only — list and describe projects and
+  tables, read table data, list dimension members, and explain allocation results. It never invents
+  numbers; every answer comes from a real query against your data.
+- **Each person sees only their own data.** Requests run as the signed-in user, bounded by the same
+  PlaidCloud roles and access controls they already have. The agent can never reach credential,
   identity, or access-control settings.
-- **Access is granted by PlaidCloud.** No one can use the agent until your PlaidCloud
-  administrator grants them access (see [Who Can Use It](#who-can-use-it)).
+- **No access until granted.** Installing the agent is not the same as granting access. A signed-in
+  person gets a clear *"no access has been granted"* message until a PlaidCloud administrator gives
+  them an access level. This is deliberate — see [Access Levels](#access-levels).
 
-## What Each Role Does
+## Setup at a Glance
 
-<CardGrid>
-	<Card title="PlaidCloud (us)">
-		We provision your workspace and grant access. Your agent package is ready to download from
-		the control plane — a single `.zip` — whenever you want it.
-	</Card>
-	<Card title="Your Microsoft 365 admin">
-		Enables custom-app upload, installs the `.zip` once, and assigns who can use it.
-		About 10 minutes, one time.
-	</Card>
-	<Card title="Your team">
-		Opens the agent in Copilot and signs in once with their Microsoft account. After that it
-		just works.
-	</Card>
-</CardGrid>
+The full path, in order. Up to three roles are involved — often the same person wears more than one
+hat. **Steps 1–5 install the agent; step 6 is what actually lets data flow.**
 
-## Prerequisites
+| # | Step | Who | Where |
+|---|---|---|---|
+| 1 | [Download the agent package](#step-1--download-the-agent-package) (`.zip`) | PlaidCloud workspace admin | PlaidCloud control plane → **Workspaces** |
+| 2 | [Allow custom apps](#step-2--allow-custom-apps) | Microsoft 365 / Teams admin | Teams admin center → **Setup policies** |
+| 3 | [Upload the package](#step-3--upload-the-package) | Microsoft 365 / Teams admin | Teams admin center → **Manage apps → Actions** |
+| 4 | [Add the agent in Copilot](#step-4--add-the-agent-in-copilot) | Each user (or pre-installed) | Microsoft 365 Copilot → **More agents** |
+| 5 | [Sign in](#step-5--sign-in) | Each user | Copilot (one time) |
+| 6 | [Grant an access level](#step-6--grant-an-access-level) | PlaidCloud administrator | PlaidCloud |
 
-- A **Microsoft 365 Copilot** license for each person who will use the agent.
-- A **Microsoft 365 / Teams administrator** who can change app setup policies.
-- Your organization's **PlaidCloud agent package** — a `.zip` you download yourself from the
-  [PlaidCloud control plane](/administration/control-plane/) (see [Download Your Agent
-  Package](#download-your-agent-package)).
+<Aside type="caution">
+**Until step 6, the agent connects but returns no data.** A successful sign-in followed by a
+*"no access has been granted"* answer means everything is working — the person just needs an access
+level. It is not an error.
+</Aside>
 
-## Download Your Agent Package
+## Step 1 — Download the Agent Package
 
-Download your organization's agent package — a single `.zip` — yourself from the
-[PlaidCloud control plane](/administration/control-plane/), the site where you manage your
-workspaces. There's nothing to request and no file to wait for.
+Your organization's agent package is a single `.zip`, ready to download yourself from the
+[PlaidCloud control plane](/administration/control-plane/) — nothing to request and no file to wait
+for.
 
 <Steps>
 
 1. Sign in to the **PlaidCloud control plane** and open **Workspaces** from the left navigation.
 
-2. Find the workspace that holds your data and open it with the **Edit** (or **View**) action.
+2. Open the workspace that holds your data (the **Edit** or **View** action).
 
-3. Click **Download Copilot Package** and save the `.zip` to your computer.
+3. At the bottom of the workspace dialog, click **Download Copilot Package** and save the `.zip`.
 
 </Steps>
 
 <Aside type="note">
-You need workspace access in the PlaidCloud control plane to download the package — this can be the
-same person who installs it in Microsoft 365, or a colleague who passes the file along.
+The **Download Copilot Package** button appears only after PlaidCloud has set up the workspace's
+Copilot connection. If you don't see it, the connection isn't ready yet — contact your PlaidCloud
+representative. (The button is on the **Workspaces** screen, not the admin-only Tenants screen.)
 </Aside>
 
-## Administrator Setup
+## Step 2 — Allow Custom Apps
 
-Three steps, about 10 minutes, done once. You don't need to be technical — if you can change a
-setting in the Teams admin center, you can do this.
+*Microsoft 365 / Teams administrator.* By default, Microsoft 365 blocks apps that aren't from the
+public store, so the PlaidCloud agent can't be installed until you turn this on.
 
 <Steps>
 
-1. **Allow custom apps to be uploaded.**
+1. In the [Teams admin center](https://admin.teams.microsoft.com/), go to **Teams apps → Setup
+   policies → Global (Org-wide default)**.
 
-   By default, Microsoft 365 blocks uploading apps that aren't from the public store, so the
-   PlaidCloud agent can't be installed until you turn this on.
-
-   In the [Teams admin center](https://admin.teams.microsoft.com/), go to **Teams apps → Setup
-   policies → Global (Org-wide default)** and set **Upload custom apps** to **On**, then **Save**.
-
-   <Aside type="caution">
-   Being a global administrator is **not** the same as having this setting on — it's a separate
-   policy. If you skip this step, the upload fails with *"Uploading custom apps is not allowed."*
-   Policy changes can take up to about 24 hours to propagate (often much less). To scope it to a
-   pilot group instead of org-wide, create a separate setup policy and assign it to those users.
-   </Aside>
-
-2. **Install the PlaidCloud agent package.**
-
-   Either path works:
-
-   - **Org-wide (recommended):** Teams admin center → **Teams apps → Manage apps →
-     Upload new app** → choose the `.zip` you downloaded. This adds it to your organization's app
-     catalog so you can target it to users.
-   - **Quick test:** open [Microsoft 365 Copilot](https://m365.cloud.microsoft/chat), and under
-     **Agents** choose to upload a custom app, then select the `.zip`.
-
-3. **Choose who can use it.**
-
-   In **Manage apps**, open the **PlaidCloud** app and use the permission and assignment controls
-   to make it available to everyone or to a specific group. For a pilot, start with a small group.
+2. Set **Upload custom apps** to **On**, then **Save**.
 
 </Steps>
 
-That's the whole administrator job. There's nothing technical to set up — no passwords, sign-in
-settings, or connection details to enter. Everything needed to connect is already built into the
-package we provide.
+<Aside type="caution">
+Being a global administrator is **not** the same as having this setting on — it's a separate policy.
+Skip it and the upload fails with *"Uploading custom apps is not allowed."* Policy changes can take
+up to about 24 hours to propagate (often much less). To limit it to a pilot group instead of
+org-wide, create a separate setup policy and assign it to those users.
+</Aside>
 
-## First Sign-In
+## Step 3 — Upload the Package
 
-The first time each person opens the agent and asks a question, Copilot prompts them to **sign in**
-with their Microsoft account. This is a normal, one-time step:
+*Microsoft 365 / Teams administrator.* Add the `.zip` to your organization's app catalog.
 
-1. Open Microsoft 365 Copilot and pick the **PlaidCloud** agent from the agent list.
-2. Ask a question, for example *"List my PlaidCloud projects."*
-3. When prompted, choose **Sign in** and complete the Microsoft sign-in.
+<Steps>
+
+1. In the Teams admin center, go to **Teams apps → Manage apps**.
+
+2. Click the **Actions** menu at the **top-right** of the page, then **Upload new app**.
+
+   <Aside type="note">
+   "Upload new app" is in the **Actions** menu in the top-right corner — not in the grey toolbar
+   (Edit installs / Edit availability / …), which acts on an already-selected app.
+   </Aside>
+
+3. Choose the `.zip` you downloaded. The app uploads and publishes (you'll see **Published
+   version 1.0.0**), supported across Teams, Outlook, and Copilot.
+
+4. On the app's page, set **Availability** — **Everyone (org-wide default)** for general rollout, or
+   a specific group for a pilot.
+
+</Steps>
+
+<Aside type="tip">
+**Want to test it on yourself immediately, without org-wide rollout?** Skip the admin center: open
+[Microsoft 365 Copilot](https://m365.cloud.microsoft/chat), and under **Agents** choose to upload a
+custom app, then select the `.zip`. It sideloads just for you and appears right away.
+</Aside>
+
+## Step 4 — Add the Agent in Copilot
+
+The agent now needs to be added to each person's Copilot.
+
+<Steps>
+
+1. Open **Microsoft 365 Copilot** ([m365.cloud.microsoft/chat](https://m365.cloud.microsoft/chat)
+   or in Teams) and click **More agents** in the Agents list.
+
+2. Find your organization's agent (it's named after your workspace) and click **Add**. It then
+   appears in the Agents list, ready to open.
+
+</Steps>
+
+<Aside type="note">
+A newly **org-wide-published** agent can take a while to appear under **More agents** — minutes,
+occasionally a few hours, as Microsoft propagates it. A **sideloaded** app (the tip in step 3)
+appears immediately. To pre-install the agent for everyone so they don't have to add it themselves,
+pin it through a Teams **setup policy**.
+</Aside>
+
+## Step 5 — Sign In
+
+The first time a person opens the agent and asks a question, Copilot prompts them to **sign in**.
+This is a normal, one-time step.
+
+<Steps>
+
+1. Open the agent and ask a question, for example *"List my PlaidCloud projects."*
+
+2. When prompted, choose **Sign in** and complete the PlaidCloud sign-in.
+
+</Steps>
 
 After that the connection is remembered — people don't sign in every time, or every day. A fresh
 sign-in is only needed occasionally (roughly monthly) or if access changes.
 
 <Aside type="note">
-The first sign-in is interactive even though you're already in Microsoft 365 — Copilot opens its own
-sign-in window that doesn't carry your existing session. This is expected and only happens
-occasionally thereafter.
+The sign-in is interactive even though you're already in Microsoft 365 — Copilot opens its own
+sign-in window that doesn't carry your existing session. This is expected.
 </Aside>
+
+## Step 6 — Grant an Access Level
+
+This is the step that turns *"no access has been granted"* into real answers. After a person has
+signed in, a **PlaidCloud administrator** grants them an access level (see
+[Access Levels](#access-levels) below). Access is **deny-by-default**: with no level assigned, the
+agent connects but returns no data.
+
+Once a level is granted, the person simply **asks again** — there's no need to sign out or
+reinstall. Access is checked live on every request, so the next message returns data.
+
+<Aside type="note">
+Access levels are managed on the PlaidCloud side. Contact your PlaidCloud representative or
+[support@plaidcloud.com](mailto:support@plaidcloud.com) to have people granted (or changed), or — if
+your PlaidCloud administrator manages identity directly — assign the level in PlaidCloud's identity
+management.
+</Aside>
+
+## Access Levels
+
+Every PlaidCloud Copilot user holds one of three levels. The level is a **ceiling** on what the
+agent may do; within it, the person's own PlaidCloud permissions still apply, so the agent can never
+show or change data they couldn't already reach themselves.
+
+| Level | The agent can… | Typical use |
+|---|---|---|
+| **Read-only** | List and describe projects and tables, read table data, list dimension members, explain allocations. No changes. | Most people. The safe default. |
+| **Read / Write** | Everything in read-only, plus structured writes the person is permitted to make (e.g. updating table data). | Analysts who maintain data. |
+| **Full** | The person's complete PlaidCloud tool set, including running raw SQL that writes. | Power users and builders. |
+
+A few rules apply at every level:
+
+- **Deny-by-default.** No level assigned ⇒ no access. Nothing is exposed until someone is granted a
+  level.
+- **Most permissive wins.** If a person somehow holds more than one level, the highest applies.
+- **Sensitive actions are always off-limits to the agent.** Credential, identity, and
+  access-control tools — and raw write SQL below the Full level — are never callable through Copilot,
+  regardless of the person's own PlaidCloud permissions.
 
 ## Using the Agent
 
-Open Copilot, select the **PlaidCloud** agent, and ask in plain language. Good starting points:
+Open Copilot, select your PlaidCloud agent, and ask in plain language. Good starting points:
 
 - **Find your work:** *"List my PlaidCloud projects."* / *"What tables are in project X?"*
 - **Read data:** *"Show me the first 20 rows of the customers table."* / *"What values are in the
@@ -156,34 +221,24 @@ Open Copilot, select the **PlaidCloud** agent, and ask in plain language. Good s
   and Q2?"*
 
 The agent picks the right tool, runs the query against your data, and Copilot answers — leading with
-the result, then a short table or summary. If a request needs data you don't have access to, it says
-so rather than guessing.
-
-## Who Can Use It
-
-Access is controlled in **two** places, and both must allow it:
-
-1. **Microsoft 365** — your admin assigns the agent to people (the [setup](#administrator-setup) above).
-2. **PlaidCloud** — your PlaidCloud administrator grants each person a Copilot access level.
-   Until they do, a signed-in user gets a clear *"no access has been granted"* message rather than
-   data. The default level is **read-only**; higher levels are opt-in and managed by PlaidCloud.
-
-Either way, every request still runs under the user's own PlaidCloud permissions — the agent can't
-show someone data they couldn't already see, and read-only access can't change anything.
+the result, then a short table or summary. If a request needs data you don't have access to, or a
+change above your level, it says so rather than guessing.
 
 ## Troubleshooting
 
 | Symptom | Cause and fix |
 |---|---|
-| **"Uploading custom apps is not allowed"** on install | The *Upload custom apps* policy is off. Turn it on in Teams admin center (step 1), wait for it to propagate, and retry. |
-| The agent doesn't appear in Copilot's agent list | It hasn't been assigned to that user yet, or the assignment is still propagating. Check the app's assignment in **Manage apps**. |
-| **"No Microsoft 365 Copilot access has been granted to this user"** | The person is signed in but hasn't been granted a PlaidCloud access level — ask your PlaidCloud administrator to grant one. |
+| Can't find **Upload new app** in Manage apps | It's in the **Actions** menu at the top-right of the page, not the grey toolbar. If it's missing entirely, [Allow custom apps](#step-2--allow-custom-apps) isn't on yet. |
+| **"Uploading custom apps is not allowed"** on install | The *Upload custom apps* policy is off. Turn it on ([step 2](#step-2--allow-custom-apps)), wait for it to propagate, and retry. |
+| The agent isn't in Copilot's Agents list | Look under **More agents** and click **Add**. An org-wide-published agent can take time to appear; to test now, [sideload the `.zip`](#step-3--upload-the-package) to yourself. |
+| **"No Microsoft 365 Copilot access has been granted to this user"** | Expected until [an access level is granted](#step-6--grant-an-access-level). The person is signed in and connected — they just need a level. Ask again right after it's granted. |
+| A request to change data is refused | The person's access level (or their own PlaidCloud permissions) doesn't allow that write. Raise their [access level](#access-levels) if appropriate. |
 | Asked to sign in again after it was working | Normal — the saved connection is refreshed periodically (roughly monthly). Sign in once more and continue. |
-| Answers seem to need data the user can't reach | Expected — the agent only ever returns data the signed-in user is already permitted to see. |
+| Answers seem to need data the person can't reach | Expected — the agent only ever returns data the signed-in user is already permitted to see. |
 
-## Need a Package or Access?
+## Need Help?
 
-You download the agent package yourself from the control plane — see [Download Your Agent
-Package](#download-your-agent-package). Access levels are managed by PlaidCloud: contact your
-PlaidCloud representative or [support@plaidcloud.com](mailto:support@plaidcloud.com) to have people
-granted access.
+You download the agent package yourself from the control plane — see
+[Step 1](#step-1--download-the-agent-package). For access levels, or anything that isn't behaving as
+described here, contact your PlaidCloud representative or
+[support@plaidcloud.com](mailto:support@plaidcloud.com).


### PR DESCRIPTION
Rewrites the Microsoft 365 Copilot integration guide into a single, obvious, step-by-step journey after a real production setup surfaced several non-obvious steps.

## What changed
- **Linear numbered flow** + a **Setup at a Glance** table (who does what, where) so the whole path is visible up front.
- **Download** (Step 1): clarifies the button is on the **Workspaces** screen, at the **bottom of the dialog**, and only appears once the Copilot connection is set up.
- **Upload** (Step 3): `Upload new app` is in the **Actions** menu (top-right of Manage apps) — the gap that tripped up setup.
- **Add the agent** (Step 4): org-wide publishes land under **More agents** and can lag; **sideload** for an instant test; click **Add**.
- **Grant an access level** (Step 6): the first query returning *'no access'* is **by design** (deny-by-default) — now a prominent step + caution Aside, not a footnote.
- **Access Levels** section: enumerates Read-only / Read/Write / Full and the always-on safety rules (deny-by-default, most-permissive-wins, sensitive tools never callable).
- Troubleshooting expanded for each of the above.

No new pages/links beyond in-page anchors (verified against headings); single `.mdx` edit.