### PR TITLE
docs(panel-apps): fix stale force-light Appearance note

### DIFF
--- a/src/content/docs/guides/panel-apps/using.md
+++ b/src/content/docs/guides/panel-apps/using.md
@@ -30,7 +30,7 @@ A server app scales to zero when idle to save resources, so the first open after
 
 ### Appearance
 
-Server Panel apps always display in the **light theme**. PlaidCloud forces light mode so that your app and its loading screen look consistent for every viewer. Dark mode is not supported yet, so you don't need to design for it — build and test your app against a light background.
+Server Panel apps use PlaidCloud's modern **Fast** design and open in the **light theme** by default. The theme — light, dark, or a light/dark switch viewers can flip — is something you set in your app's template, not on this screen. See [Set the Theme](/guides/panel-apps/creating/#set-the-theme-light-dark-or-a-toggle) in the Creating guide for the patterns. If your app's tables or custom styling are built for a light background, keep it pinned to light.
 
 ## Viewing Logs (Server Apps)
 


### PR DESCRIPTION
Follow-up to #212. The Using guide's **Appearance** section still said server Panel apps are forced to light and "dark mode is not supported" — now factually wrong after the theme-control feature shipped. Rewrites it to describe the default (Fast design, light) and that the theme is set in the app's template, linking to the new **Set the Theme** section in the Creating guide.

Swept the whole corpus: this was the only remaining stale force-light claim. Astro build passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)