### PR TITLE
docs: in-app Help & Support guide

### DIFF
--- a/src/content/docs/guides/index.mdx
+++ b/src/content/docs/guides/index.mdx
@@ -80,4 +80,9 @@ How to accomplish specific things in PlaidCloud. Each guide is task-focused — 
 		href="/guides/sandbox/"
 		description="A safe scratch space for trying things out."
 	/>
+	<LinkCard
+		title="Help & Support"
+		href="/guides/support/"
+		description="Open and track support tickets from inside the app."
+	/>
 </CardGrid>

--- a/src/content/docs/guides/support/getting-help.mdx
+++ b/src/content/docs/guides/support/getting-help.mdx
@@ -1,0 +1,62 @@
+---
+title: Getting Help
+description: Open a PlaidCloud support ticket from inside the app, follow the conversation, and reply — all from the in-app Help & Support window.
+sidebar:
+  order: 1
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## Description
+
+**Help & Support** is the in-app way to reach PlaidCloud support. You can open a
+ticket, watch for a reply, and continue the conversation — all from a single
+window, without switching to email. Your messages and the support team's replies
+appear together as a thread.
+
+## Opening Help & Support
+
+The window opens from the user menu:
+
+1. Click your **avatar** in the top-right corner of any screen.
+2. Choose **Help & Support** (the lifebuoy icon).
+
+The window opens with your tickets listed on the left and the selected
+conversation on the right.
+
+## Opening a New Ticket
+
+1. In the Help & Support window, click **New Ticket**.
+2. Describe your question or issue in the box.
+3. Click **Send**.
+
+The new ticket opens in the conversation pane. PlaidCloud automatically attaches
+a little context about where you were in the app (such as the page and app
+version) to help the support team — it never includes your data.
+
+<Aside type="note">
+You don't need to set a subject or priority — just describe what you need. The
+support team triages from there.
+</Aside>
+
+## Reading and Replying to a Ticket
+
+1. Select a ticket in the list on the left.
+2. The full conversation opens on the right, with your messages and the support
+   team's replies in order.
+3. To continue the conversation, type in the reply box and click **Reply**.
+
+New replies from the support team appear in the thread the next time you open
+the ticket.
+
+## Who Can See Which Tickets
+
+- **Regular members** see and reply to their own tickets.
+- **Tenant administrators** see every ticket raised across the workspace, so they
+  can keep track of all open requests.
+
+<Aside type="note">
+Resellers who manage your workspace handle first-line support; PlaidCloud steps in
+automatically if a request goes unanswered. You don't need to do anything — just
+open the ticket and reply as the conversation continues.
+</Aside>

--- a/src/content/docs/guides/support/index.md
+++ b/src/content/docs/guides/support/index.md
@@ -1,0 +1,13 @@
+---
+title: Help & Support
+description: Open and track PlaidCloud support tickets from inside the app — ask a question, follow the conversation, and reply without leaving your workspace.
+sidebar:
+  label: Help & Support
+  order: 16
+---
+
+The **Help & Support** window lets you raise a support request and follow the
+conversation without leaving PlaidCloud. Open it from the user menu in the
+top-right corner of any screen.
+
+See [Getting Help](/guides/support/getting-help/) for the full walkthrough.

--- a/src/content/docs/releases/2026-06.mdx
+++ b/src/content/docs/releases/2026-06.mdx
@@ -44,6 +44,7 @@ description: Multi-agent AI assistant, 140+ data connectors, table snapshots, a 
 - **Easier-to-read Panel app logs** — the log viewer now lets you select a row to read its full message in a side pane, so long errors and complete stack traces are no longer cut off. You can also select several lines at once and copy them — handy for pasting into an AI assistant or a message to your team while you debug.
 - **Panel app logs show who triggered them** — when your app signs viewers in, each log line is tagged with the user whose session produced it, so you can tell which viewer hit an error or warning. (Best-effort — some startup lines run before any viewer is involved.)
 - **Usage metrics for server Panel apps** — a new Usage Metrics view, opened from the app list next to View Logs, shows how an app is being used: unique users, session count, average and median session length, and when it was last used, plus a per-user and per-day breakdown. (Durations are approximate, since apps idle and scale down between visits.)
+- **In-app Help & Support** — open and track support tickets without leaving PlaidCloud. The user menu's new **Help & Support** window lets you raise a request, follow the conversation, and reply in a single thread; tenant administrators can see every ticket across the workspace, while members see their own. See [Getting Help](/guides/support/getting-help/).
 
 ## Changed
 


### PR DESCRIPTION
## In-app Help & Support guide

Documents the new in-app **Help & Support** window (the user-menu lifebuoy): opening a ticket, reading/replying to the thread, and who sees which tickets (members see their own; tenant admins see all). Matches the shipped `SupportWindow`.

- `guides/support/` — `index.md` + `getting-help.mdx`
- a card on the Guides index
- a June **What's New** entry linking the guide

Build verified locally (`npm run build` — 1510 pages, clean).

Companion to the in-app feature (plaid #6394 / PlaidClient #1748, deployed to CI).
