### PR TITLE
docs(git): document the Git Administration permission

### DIFF
--- a/src/content/docs/guides/git/index.md
+++ b/src/content/docs/guides/git/index.md
@@ -10,6 +10,10 @@ PlaidCloud Git is a private Git service built into your workspace. Each workspac
 
 You sign in with your PlaidCloud account, so there's no separate username or password to set up. Open **Git** from your workspace and you're already signed in. New repositories are private by default, visible only to members you grant access.
 
+## Administering Git
+
+Any member can create repositories, but **creating organizations** — shared spaces that group repositories and teams — requires the **Git Administration** permission. Grant it in **Identity** by adding the permission to a security group, or by adding members to the built-in **Git Administration** group. Anyone in a group that has the permission becomes a Git administrator the next time they sign in to Git. PlaidCloud support staff have it automatically.
+
 ## What's in This Section
 
 - [Repositories](/guides/git/repositories/) — create a repository, then clone, commit, and push your work

--- a/src/content/docs/guides/git/index.md
+++ b/src/content/docs/guides/git/index.md
@@ -12,7 +12,9 @@ You sign in with your PlaidCloud account, so there's no separate username or pas
 
 ## Administering Git
 
-Any member can create repositories, but **creating organizations** — shared spaces that group repositories and teams — requires the **Git Administration** permission. Grant it in **Identity** by adding the permission to a security group, or by adding members to the built-in **Git Administration** group. Anyone in a group that has the permission becomes a Git administrator the next time they sign in to Git. PlaidCloud support staff have it automatically.
+Any member can create repositories, but **creating organizations** — shared spaces that group repositories and teams — requires the **Git Administration** permission. Grant it in **Identity** by adding the permission to a security group, or by adding members to the built-in **Git Administration** group. Anyone in a group that has the permission becomes a Git administrator when they next sign in to Git. PlaidCloud support staff have it automatically.
+
+If a newly-granted administrator has never opened Git before, they may need to sign in to Git **twice** for administrator access to take effect — the first sign-in creates their Git account, and the permission is applied on the next.
 
 ## What's in This Section
 

--- a/src/content/docs/releases/2026-06.mdx
+++ b/src/content/docs/releases/2026-06.mdx
@@ -44,6 +44,7 @@ description: Multi-agent AI assistant, 140+ data connectors, table snapshots, a 
 - **Easier-to-read Panel app logs** — the log viewer now lets you select a row to read its full message in a side pane, so long errors and complete stack traces are no longer cut off. You can also select several lines at once and copy them — handy for pasting into an AI assistant or a message to your team while you debug.
 - **Panel app logs show who triggered them** — when your app signs viewers in, each log line is tagged with the user whose session produced it, so you can tell which viewer hit an error or warning. (Best-effort — some startup lines run before any viewer is involved.)
 - **Usage metrics for server Panel apps** — a new Usage Metrics view, opened from the app list next to View Logs, shows how an app is being used: unique users, session count, average and median session length, and when it was last used, plus a per-user and per-day breakdown. (Durations are approximate, since apps idle and scale down between visits.)
+- **Delegated Git administration** — a new **Git Administration** permission controls who can administer your workspace's Git service, including creating organizations. Attach it to any security group (or use the built-in **Git Administration** group) to let your own users manage Git, without involving PlaidCloud.
 
 ## Changed
 


### PR DESCRIPTION
## What

- `guides/git/index.md`: new **Administering Git** section — creating organizations requires the **Git Administration** permission, grantable via a security group or the built-in Git Administration group.
- `releases/2026-06.mdx`: What's New entry under Added.

## Related
- plaid#6402, plaidcloud-cp-rest#293

🤖 Generated with [Claude Code](https://claude.com/claude-code)