### PR TITLE
docs(releases): note allocation-tracing spaced/symbol column fix in June What's New

### DIFF
--- a/src/content/docs/releases/2026-06.mdx
+++ b/src/content/docs/releases/2026-06.mdx
@@ -62,6 +62,7 @@ description: Multi-agent AI assistant, 140+ data connectors, table snapshots, a 
 
 ## Fixed
 
+- **Allocation tracing handles column names with spaces or symbols** — asking the AI assistant to explain or break down an allocation result no longer fails on models whose columns are named with spaces or parentheses (for example, "Driver Value"); these now trace correctly.
 - **No more "stuck refreshing"** — fixed a case where the app could repeatedly reload itself when the server briefly couldn't confirm the current version.
 - **Join type now sticks** — selecting a Right or Full Outer join now persists instead of silently reverting to a Left join.
 - **Reliable table exports** — fixed table exports to Parquet, Avro, and XML that could fail, including uncompressed Parquet on some projects.


### PR DESCRIPTION
Adds a **Fixed** entry to the June 2026 What's New page for the AI allocation cost-tracing fix — tracing now handles column names with spaces or parentheses (e.g. "Driver Value") instead of failing.

Customer-facing companion to the plaid change ([sc-22787](https://app.shortcut.com/plaidcloud/story/22787), PR PlaidCloud/plaid#6420), per the repo guidance to land the What's New entry in the same change rather than a later pass. The June page and its index LinkCard already exist, so this is a single bullet under `## Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)