### PR TITLE
docs(mcp): drop trailing slash from MCP server URLs (SC-22813)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -211,7 +211,7 @@ Concepts:
 - **Allocation**: distributes a value across a *dimension* using a driver and a method.
 - **Lakehouse v1 vs v2**: v1 uses Databend SQL; v2 uses Apache Iceberg tables with StarRocks 4.1 SQL — function names differ.
 - **PlaidLink Agent**: outbound proxy that lets workflows reach on-prem databases and file systems.
-- **MCP server**: every workspace exposes \`/mcp/\` for AI coding agents (Claude Code, Cursor, ChatGPT, etc.).
+- **MCP server**: every workspace exposes \`/mcp\` for AI coding agents (Claude Code, Cursor, ChatGPT, etc.).
 
 Documentation structure:
 

--- a/src/content/docs/get-started/tutorials/mcp-with-ai-agent.mdx
+++ b/src/content/docs/get-started/tutorials/mcp-with-ai-agent.mdx
@@ -32,7 +32,7 @@ A working connection between your AI coding agent and your PlaidCloud workspace,
 Every PlaidCloud workspace exposes an MCP endpoint at:
 
 ```text
-https://<your-workspace>.plaid.cloud/mcp/
+https://<your-workspace>.plaid.cloud/mcp
 ```
 
 Replace `<your-workspace>` with your workspace subdomain — the same one you use to sign in to the PlaidCloud UI.
@@ -62,7 +62,7 @@ Treat the token like a password. It bypasses interactive authentication and acts
 Run in your terminal:
 
 ```bash
-claude mcp add --transport http plaidcloud https://<your-workspace>.plaid.cloud/mcp/
+claude mcp add --transport http plaidcloud https://<your-workspace>.plaid.cloud/mcp
 ```
 
 For static-token authentication (no OAuth flow, simpler for long sessions), open the URL from Step 2 in a browser, copy the displayed config snippet, and paste it into your `.mcp.json` file.
@@ -79,7 +79,7 @@ Get a Bearer token from `https://<your-workspace>.plaid.cloud/mcp/setup/token` a
 {
   "mcpServers": {
     "plaidcloud": {
-      "url": "https://<your-workspace>.plaid.cloud/mcp/",
+      "url": "https://<your-workspace>.plaid.cloud/mcp",
       "headers": {
         "Authorization": "Bearer <token>"
       }
@@ -96,7 +96,7 @@ See [Cursor setup](/integrations/ai-coding-agents/cursor/) for full options.
 
 Open Settings → Developer → MCP Servers and add:
 
-- **Server URL**: `https://<your-workspace>.plaid.cloud/mcp/`
+- **Server URL**: `https://<your-workspace>.plaid.cloud/mcp`
 - Use OAuth login when prompted
 
 See [Claude Desktop setup](/integrations/ai-coding-agents/claude-desktop/) for full options.
@@ -108,7 +108,7 @@ See [Claude Desktop setup](/integrations/ai-coding-agents/claude-desktop/) for f
 1. Settings → Connectors → Add custom connector
 2. Enter:
    - **Name**: `PlaidCloud`
-   - **MCP server URL**: `https://<your-workspace>.plaid.cloud/mcp/`
+   - **MCP server URL**: `https://<your-workspace>.plaid.cloud/mcp`
 3. ChatGPT redirects you to PlaidCloud for OAuth login. Approve the connection.
 4. Toggle the connector on inside any conversation that should use it.
 
@@ -124,7 +124,7 @@ Get a Bearer token and add to `.vscode/mcp.json`:
 {
   "servers": {
     "plaidcloud": {
-      "url": "https://<your-workspace>.plaid.cloud/mcp/",
+      "url": "https://<your-workspace>.plaid.cloud/mcp",
       "headers": {
         "Authorization": "Bearer <token>"
       }

--- a/src/content/docs/integrations/ai-coding-agents/chatgpt.mdx
+++ b/src/content/docs/integrations/ai-coding-agents/chatgpt.mdx
@@ -16,7 +16,7 @@ If your ChatGPT plan exposes the **Connectors** UI (Settings → Connectors), yo
 1. Go to **Settings → Connectors → Add custom connector**.
 2. Enter:
    - **Name**: `PlaidCloud`
-   - **MCP server URL**: `https://<your-workspace>.plaid.cloud/mcp/`
+   - **MCP server URL**: `https://<your-workspace>.plaid.cloud/mcp`
 3. ChatGPT will redirect you to PlaidCloud for OAuth login. Approve the connection.
 4. Toggle the connector on inside any conversation that should be able to use it.
 

--- a/src/content/docs/integrations/ai-coding-agents/claude-code.mdx
+++ b/src/content/docs/integrations/ai-coding-agents/claude-code.mdx
@@ -16,7 +16,7 @@ OAuth is the lowest-maintenance path. Claude Code's MCP bridge handles the brows
 1. From your project root, add the server. The CLI form:
 
     ```bash
-    claude mcp add --transport http plaidcloud https://<your-workspace>.plaid.cloud/mcp/
+    claude mcp add --transport http plaidcloud https://<your-workspace>.plaid.cloud/mcp
     ```
 
     Or in `.mcp.json` at the project root:
@@ -26,7 +26,7 @@ OAuth is the lowest-maintenance path. Claude Code's MCP bridge handles the brows
       "mcpServers": {
         "plaidcloud": {
           "type": "http",
-          "url": "https://<your-workspace>.plaid.cloud/mcp/"
+          "url": "https://<your-workspace>.plaid.cloud/mcp"
         }
       }
     }
@@ -57,7 +57,7 @@ When OAuth isn't practical (remote sessions, devcontainers, agent runtimes that 
       "mcpServers": {
         "plaidcloud": {
           "type": "http",
-          "url": "https://<your-workspace>.plaid.cloud/mcp/",
+          "url": "https://<your-workspace>.plaid.cloud/mcp",
           "headers": {
             "Authorization": "Bearer eyJhbGc…"
           }
@@ -70,7 +70,7 @@ When OAuth isn't practical (remote sessions, devcontainers, agent runtimes that 
 
     ```bash
     claude mcp add --transport http plaidcloud \
-      https://<your-workspace>.plaid.cloud/mcp/ \
+      https://<your-workspace>.plaid.cloud/mcp \
       -H "Authorization: Bearer eyJhbGc…"
     ```
 
@@ -85,8 +85,8 @@ You can configure multiple PlaidCloud tenants side-by-side — give each a disti
 ```json
 {
   "mcpServers": {
-    "plaidcloud-prod":  { "type": "http", "url": "https://prod.plaid.cloud/mcp/" },
-    "plaidcloud-dev":   { "type": "http", "url": "https://dev.plaid.cloud/mcp/"  }
+    "plaidcloud-prod":  { "type": "http", "url": "https://prod.plaid.cloud/mcp" },
+    "plaidcloud-dev":   { "type": "http", "url": "https://dev.plaid.cloud/mcp"  }
   }
 }
 ```

--- a/src/content/docs/integrations/ai-coding-agents/claude-desktop.mdx
+++ b/src/content/docs/integrations/ai-coding-agents/claude-desktop.mdx
@@ -17,7 +17,7 @@ The consumer Claude app — both the web UI at [claude.ai](https://claude.ai) an
 2. Click **Add custom connector**.
 3. Fill in:
    - **Name**: `PlaidCloud` (or `PlaidCloud (prod)`, `PlaidCloud (dev)` if you have multiple tenants).
-   - **Server URL**: `https://<your-workspace>.plaid.cloud/mcp/`
+   - **Server URL**: `https://<your-workspace>.plaid.cloud/mcp`
 4. Click **Add**. Claude opens a browser tab to PlaidCloud's Keycloak login.
 5. Sign in and approve the connection. You'll be redirected back to Claude with the connection saved.
 

--- a/src/content/docs/integrations/ai-coding-agents/copilot.mdx
+++ b/src/content/docs/integrations/ai-coding-agents/copilot.mdx
@@ -24,7 +24,7 @@ GitHub Copilot's [agent mode](https://docs.github.com/copilot/using-github-copil
       "servers": {
         "plaidcloud": {
           "type": "http",
-          "url": "https://<your-workspace>.plaid.cloud/mcp/",
+          "url": "https://<your-workspace>.plaid.cloud/mcp",
           "headers": {
             "Authorization": "Bearer eyJhbGc…"
           }

--- a/src/content/docs/integrations/ai-coding-agents/cursor.md
+++ b/src/content/docs/integrations/ai-coding-agents/cursor.md
@@ -21,7 +21,7 @@ sidebar:
     {
       "mcpServers": {
         "plaidcloud": {
-          "url": "https://<your-workspace>.plaid.cloud/mcp/",
+          "url": "https://<your-workspace>.plaid.cloud/mcp",
           "headers": {
             "Authorization": "Bearer eyJhbGc…"
           }
@@ -47,8 +47,8 @@ Repeat the entry under a different name:
 ```json
 {
   "mcpServers": {
-    "plaidcloud-prod": { "url": "https://prod.plaid.cloud/mcp/", "headers": { "Authorization": "Bearer …" } },
-    "plaidcloud-dev":  { "url": "https://dev.plaid.cloud/mcp/",  "headers": { "Authorization": "Bearer …" } }
+    "plaidcloud-prod": { "url": "https://prod.plaid.cloud/mcp", "headers": { "Authorization": "Bearer …" } },
+    "plaidcloud-dev":  { "url": "https://dev.plaid.cloud/mcp",  "headers": { "Authorization": "Bearer …" } }
   }
 }
 ```

--- a/src/content/docs/integrations/ai-coding-agents/gemini.md
+++ b/src/content/docs/integrations/ai-coding-agents/gemini.md
@@ -17,7 +17,7 @@ Google's [`gemini-cli`](https://github.com/google-gemini/gemini-cli) supports MC
     {
       "mcpServers": {
         "plaidcloud": {
-          "httpUrl": "https://<your-workspace>.plaid.cloud/mcp/",
+          "httpUrl": "https://<your-workspace>.plaid.cloud/mcp",
           "headers": {
             "Authorization": "Bearer eyJhbGc…"
           }

--- a/src/content/docs/integrations/ai-coding-agents/getting-started.mdx
+++ b/src/content/docs/integrations/ai-coding-agents/getting-started.mdx
@@ -14,7 +14,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io) is an open standar
 The server lives at:
 
 ```text
-https://<your-workspace>.plaid.cloud/mcp/
+https://<your-workspace>.plaid.cloud/mcp
 ```
 
 Replace `<your-workspace>` with your workspace subdomain (whatever you use to log into the PlaidCloud UI).

--- a/src/content/docs/integrations/ai-coding-agents/index.md
+++ b/src/content/docs/integrations/ai-coding-agents/index.md
@@ -6,6 +6,6 @@ sidebar:
   order: 13
 ---
 
-PlaidCloud exposes a curated [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server at `/mcp/` on every workspace. AI agents connect to it the same way they connect to any other MCP server, then call the tools to read projects, run workflows, query tables, manage dimensions, and more.
+PlaidCloud exposes a curated [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server at `/mcp` on every workspace. AI agents connect to it the same way they connect to any other MCP server, then call the tools to read projects, run workflows, query tables, manage dimensions, and more.
 
 The pages in this section cover what the server exposes, how to authenticate, and step-by-step setup for the most common AI clients.

--- a/src/content/docs/integrations/ai-coding-agents/troubleshooting.md
+++ b/src/content/docs/integrations/ai-coding-agents/troubleshooting.md
@@ -5,6 +5,14 @@ sidebar:
   order: 9
 ---
 
+## Cursor (or Another Strict Client) Won't Connect at All
+
+Symptom: the server never establishes a session in Cursor and similar strict clients, while the same workspace works in Claude Code.
+
+Cause: a **trailing slash** on the server URL. Use `https://<your-workspace>.plaid.cloud/mcp` — not `.../mcp/`. Strict clients reject a trailing-slash URL (or won't follow the redirect the older path issued), whereas lenient clients like Claude Code tolerate it.
+
+Fix: remove the trailing slash from the `url` in your config and reconnect. Every example in these guides uses the slash-free form.
+
 ## "failed to Connect" / "session Not Found"
 
 Symptom: the client config looks correct but the server shows as failed in the client's MCP status panel. Server logs show 404 `Session not found` errors.


### PR DESCRIPTION
## Problem — SC-22813 (Sev 1)

The AI-coding-agent guides advertised the MCP server URL **with** a trailing slash (`https://<workspace>.plaid.cloud/mcp/`). Strict clients like Cursor reject the slashed form at config time (Claude Code is lenient and works).

## Fix

Replace the bare endpoint `/mcp/` → `/mcp` across all guides (JSON `url`/`httpUrl` fields, `claude mcp add` CLI examples, prose references, and `astro.config.mjs`) — 22 occurrences in 10 files. `/mcp/setup/token` references (a real subpath) are **preserved** (15 intact). Adds a troubleshooting entry for the strict-client trailing-slash failure.

## Companion PRs
- Traefik transport fix: https://github.com/PlaidCloud/plaid-tenant-infrastructure/pull/769
- plaid setup snippet: https://github.com/PlaidCloud/plaid/pull/6441

## Verification
- `grep -rP "/mcp/(?![a-zA-Z])"` → only the intentional "don't use `.../mcp/`" example in the new troubleshooting prose.
- `/mcp/setup` references intact (15).
- No MDX/JSX hazards introduced (edits are inside code fences / backticks; troubleshooting is `.md`).
- Adversarial Sonnet review: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)