### PR TITLE
docs: rename to 'PlaidCloud Managed Bucket' to match the UI

### DIFF
--- a/src/content/docs/guides/documents/adding-accounts/add-managed-bucket-account.md
+++ b/src/content/docs/guides/documents/adding-accounts/add-managed-bucket-account.md
@@ -1,13 +1,13 @@
 ---
-title: Add a Managed Bucket Account
+title: Add a PlaidCloud Managed Bucket Account
 description: Add fully managed file storage to PlaidCloud Document in one step — pick a name and PlaidCloud sets everything up for you, with nothing to configure.
 sidebar:
   order: 2
 ---
 
-A **Managed Bucket** is the fastest way to add file storage to Document. PlaidCloud creates and runs the storage for you — there's nothing to set up beforehand and no credentials to manage. You just give it a name.
+A **PlaidCloud Managed Bucket** is the fastest way to add file storage to Document. PlaidCloud creates and runs the storage for you — there's nothing to set up beforehand and no credentials to manage. You just give it a name.
 
-Use a Managed Bucket when you want a new, self-contained place to keep Document files. To connect storage you already own and manage yourself, pick one of the other providers on the [Adding New Document Accounts](/guides/documents/adding-accounts/) page instead.
+Use a PlaidCloud Managed Bucket when you want a new, self-contained place to keep Document files. To connect storage you already own and manage yourself, pick one of the other providers on the [Adding New Document Accounts](/guides/documents/adding-accounts/) page instead.
 
 ## Setup
 
@@ -15,7 +15,7 @@ Use a Managed Bucket when you want a new, self-contained place to keep Document 
 2. Select the workspace where the new Document account will reside
 3. Go to `Document > Manage Accounts`
 4. Select the `+ New Account` button
-5. Select `Managed Bucket` as the Service Type
+5. Select `PlaidCloud Managed Bucket` as the Service Type
 6. Fill in a name and an optional description
 7. Enter a **Bucket Name**. Names must be 3–63 characters, use only lowercase letters, digits, dots, or hyphens, and start and end with a letter or digit. The name must be **globally unique** — if it's already in use, you'll be asked to choose another
 8. Select an appropriate **Security Model** for your use case. Leave it `Private` if unsure
@@ -24,11 +24,11 @@ Use a Managed Bucket when you want a new, self-contained place to keep Document 
 PlaidCloud sets up the storage and makes you its owner. The account is ready to browse and upload to immediately — there's nothing else to configure.
 
 :::note
-Managed Buckets are available on the **Business** and **Enterprise** plans. If your plan doesn't include them, or you've reached your plan's limit, the form will tell you when you try to create one.
+PlaidCloud Managed Buckets are available on the **Business** and **Enterprise** plans. If your plan doesn't include them, or you've reached your plan's limit, the form will tell you when you try to create one.
 :::
 
 ## After Creation
 
 - The bucket name is fixed once created — it can't be changed on an existing account.
 - Deleting the account **leaves the stored files in place**, so a deletion never destroys your data. Contact support if you need the storage itself removed.
-- A Managed Bucket behaves like any other Document account for [access control](/guides/documents/account-management/control-document-account-access/), [ownership](/guides/documents/account-management/managing-document-account-owners/), and browsing.
+- A PlaidCloud Managed Bucket behaves like any other Document account for [access control](/guides/documents/account-management/control-document-account-access/), [ownership](/guides/documents/account-management/managing-document-account-owners/), and browsing.

--- a/src/content/docs/guides/documents/adding-accounts/index.md
+++ b/src/content/docs/guides/documents/adding-accounts/index.md
@@ -8,4 +8,4 @@ sidebar:
 
 Connect cloud and on-prem document storage to PlaidCloud — S3, Google Cloud Storage, Azure Blob, Google Drive, OneDrive, SFTP, WebDAV, and more. Each provider has its own credentials and connection flow.
 
-The quickest option is a **Managed Bucket**, where PlaidCloud sets up and runs the storage for you — you only pick a name, with nothing else to configure. To connect storage you already own, choose the matching provider below.
+The quickest option is a **PlaidCloud Managed Bucket**, where PlaidCloud sets up and runs the storage for you — you only pick a name, with nothing else to configure. To connect storage you already own, choose the matching provider below.


### PR DESCRIPTION
Renames the account type in the guide + adding-accounts index from **Managed Bucket** → **PlaidCloud Managed Bucket** to match the renamed client dropdown option (provider-neutral, since it will use native cluster storage — not always GCS). File slug/URL is unchanged, so no links break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)