### PR TITLE
docs(releases): July 2026 What's New — PlaidCloud Managed Buckets

### DIFF
--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -1,0 +1,12 @@
+---
+title: July 2026
+description: Self-service PlaidCloud Managed Buckets — add fully managed file storage to Document with just a name, no cloud setup required.
+---
+
+## Releases Shipped
+
+Versions are listed here as each July 2026 release ships.
+
+## Added
+
+- **PlaidCloud Managed Bucket document accounts** — add fully managed file storage to Document in a single step. Choose **PlaidCloud Managed Bucket** as the account type, give it a name, and PlaidCloud provisions and runs the storage for you — there's no cloud project, credentials, region, or storage tier to set up or tune. Available on the **Business** and **Enterprise** plans. See [Add a PlaidCloud Managed Bucket Account](/guides/documents/adding-accounts/add-managed-bucket-account/).

--- a/src/content/docs/releases/index.mdx
+++ b/src/content/docs/releases/index.mdx
@@ -11,6 +11,11 @@ Monthly summaries of changes shipped to PlaidCloud tenants. Months with substant
 
 <CardGrid>
 	<LinkCard
+		title="July 2026"
+		href="/releases/2026-07/"
+		description="PlaidCloud Managed Buckets — self-service, fully managed file storage for Document, added with just a name (Business & Enterprise plans)."
+	/>
+	<LinkCard
 		title="June 2026"
 		href="/releases/2026-06/"
 		description="v5.7.1 → v5.10.2 · Multi-agent AI assistant, 140+ connectors, table snapshots, rebuilt project report, Forecast & Solver steps, collaborative Workflow Designer."


### PR DESCRIPTION
Adds the **July 2026** What's New page with the new **PlaidCloud Managed Bucket** account type under `## Added`, and its `<LinkCard>` in the releases index.

- Customer-facing framing (no cloud project / credentials / region / storage tier to configure; Business & Enterprise plans); links to the usage guide.
- The `## Releases Shipped` version table is left with a note to fill as July releases actually ship (latest shipped is v5.10.4 from June — no July tenant version has cut yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)