### PR TITLE
docs(ai-agents): forward-impact estimates are a proportional split (sc-22807)

### DIFF
--- a/src/content/docs/integrations/ai-coding-agents/tracing-allocations.mdx
+++ b/src/content/docs/integrations/ai-coding-agents/tracing-allocations.mdx
@@ -58,7 +58,7 @@ A finance analyst notices a revenue-driven cost line has fallen year on year and
 >
 > **Heads-up — that driver is shared.** `revenue_by_line` also drives `cost_line_cs` and `cost_line_admin`, so a revenue restatement ripples into all three.
 >
-> **Your +$1M US scenario.** A $1M US revenue increase could shift allocated cost by **up to $1M in each of** `cost_line_rev`, `cost_line_cs`, and `cost_line_admin` — three affected results, each an independent upper bound rather than a shared total.
+> **Your +$1M US scenario.** A $1M US revenue increase is estimated to shift allocated cost by about **$620K in `cost_line_rev`, $250K in `cost_line_cs`, and $130K in `cost_line_admin`** — each result's share of the change based on how the pool is split today. Because the shares come from the current split, the per-result figures add up to the $1M.
 
 The analyst gets a complete answer — the size of the change, the accounts behind it, the lineage, and the blast radius of a what-if — without opening a single table.
 
@@ -76,8 +76,8 @@ For an allocation driven by a **dimension hierarchy** — for example, splitting
 When one allocation feeds another — a cascade — a project-wide "why" would mix the wrong rows, so the agent asks you to scope the question to a slice (a specific region, product, or cost centre) and then explains it.
 </Aside>
 
-<Aside type="caution" title="What-if estimates are upper bounds">
-"What happens if …" answers are **upper bounds** — they assume the full change flows to each target, so the per-table figures are worst-case envelopes, not additive totals. Use them to size the blast radius, not as a precise forecast.
+<Aside type="note" title="What-if estimates are a proportional split">
+"What happens if …" answers split the change across affected results by each one's current share of the pool, so a fan-out's per-result figures add up rather than each being a worst-case envelope. You can also scope the question to a target (for example a single customer), and the estimate is restricted to that slice. The split uses today's allocation configuration, so treat it as an estimate under current settings rather than a past-period forecast.
 </Aside>
 
 ## Tips

--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -10,3 +10,7 @@ Versions are listed here as each July 2026 release ships.
 ## Added
 
 - **PlaidCloud Managed Bucket document accounts** — add fully managed file storage to Document in a single step. Choose **PlaidCloud Managed Bucket** as the account type, give it a name, and PlaidCloud provisions and runs the storage for you — there's no cloud project, credentials, region, or storage tier to set up or tune. Available on the **Business** and **Enterprise** plans. See [Add a PlaidCloud Managed Bucket Account](/guides/documents/adding-accounts/add-managed-bucket-account/).
+
+## Changed
+
+- **AI allocation what-if estimates are now a proportional split.** When you ask an AI agent "what happens if this input changes?", the estimated impact on each downstream result is now that result's actual current share of the pool — so a fan-out's figures add up instead of each showing the full change. You can also scope the question to a specific target (e.g. one customer) and the estimate is restricted to that slice. See [Tracing Allocations](/integrations/ai-coding-agents/tracing-allocations/).


### PR DESCRIPTION
Companion to PlaidCloud/plaid#6444 ([sc-22807](https://app.shortcut.com/plaidcloud/story/22807)).

`allocation_forward_impact` now returns a **proportional** per-target estimate (each target's realized current share of the pool, so a fan-out's figures add up) and applies a **target filter** to the estimate, instead of an upper bound. Updates the customer-facing docs to match:

- **Tracing Allocations guide** — replaced the "what-if estimates are upper bounds" caution with a note explaining the proportional split and target-filter scoping, and updated the worked "+$1M" example to show additive per-result shares.
- **July 2026 "What's New"** — added a `## Changed` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
