### PR TITLE
docs(support): Help & Support guides (getting help, support console, managing support)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -141,6 +141,7 @@ export default defineConfig({
 							],
 						},
 						{ label: 'Email',             collapsed: true, items: [{ autogenerate: { directory: 'guides/email' } }] },
+						{ label: 'Help & Support',    collapsed: true, items: [{ autogenerate: { directory: 'guides/support' } }] },
 						{ label: 'Panel apps',        collapsed: true, items: [{ autogenerate: { directory: 'guides/panel-apps' } }] },
 						{ label: 'PlaidCloud Git',    collapsed: true, items: [{ autogenerate: { directory: 'guides/git' } }] },
 						{ label: 'Projects',          collapsed: true, items: [{ autogenerate: { directory: 'guides/projects' } }] },

--- a/src/content/docs/guides/support/getting-help.mdx
+++ b/src/content/docs/guides/support/getting-help.mdx
@@ -1,0 +1,76 @@
+---
+title: Getting Help
+description: Open and track PlaidCloud support tickets from inside the app — ask the assistant, describe your issue, attach a screenshot, and reply by email or in-app.
+sidebar:
+  order: 1
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## Description
+
+Help & Support is built into PlaidCloud. From it you can ask the AI assistant a question, open a support ticket with our team, attach screenshots, and follow the whole conversation in one place — replying either in the app or straight from your email.
+
+## Open Help & Support
+
+1. Click your name (or avatar) in the top-right corner
+2. Select `Help & Support`
+
+The window opens with two tabs: **Ask the Assistant** and **My Tickets**.
+
+## Ask the Assistant First
+
+The **Ask the Assistant** tab is the fastest way to an answer — it can see your workspace context and search the documentation.
+
+1. Type your question and press Enter
+2. Read the answer; ask follow-ups in the same thread
+
+If the assistant can't resolve it, you can hand the conversation to a human — the transcript is attached to the ticket so our team has the full context.
+
+## Open a Support Ticket
+
+1. Open Help & Support and go to the **My Tickets** tab
+2. Click to start a new ticket
+3. Describe your question or issue in the message box
+4. (Optional) Click `Attach` to add a screenshot or file — see [Attach a Screenshot](#attach-a-screenshot) below
+5. Click `Send`
+
+Your ticket is created and our team is notified. You'll also get an email confirming the ticket was opened.
+
+<Aside type="note">
+You can submit a ticket with only a screenshot attached — a message is not required when you've attached a file.
+</Aside>
+
+## Attach a Screenshot
+
+Screenshots make an issue far easier to diagnose. You can attach files both when opening a ticket and when replying.
+
+1. Click `Attach`
+2. Choose one or more files (images such as PNG/JPG, or documents like PDF, plain text, or logs)
+3. Each file appears as a chip; click a chip to remove it before sending
+4. Send the message
+
+Limits: up to **10 files** per message, **10 MB** each. Images you attach appear inline in the conversation; other files show as a download link.
+
+## Follow the Conversation
+
+Open a ticket from the **My Tickets** list to see the full thread. When a support agent replies:
+
+- You'll receive an email notification
+- The reply appears in the thread, with any images shown inline
+
+## Reply
+
+You can reply two ways:
+
+- **In the app** — open the ticket, type in the reply box, optionally `Attach` a file, and click `Reply`.
+- **By email** — just reply to any support email you receive. Your reply is added to the same ticket, and any files you attach to the email come along with it.
+
+## Ticket Status Emails
+
+You're kept informed by email at every step:
+
+- When your ticket is **opened**
+- When an agent **replies**
+- When your ticket is **resolved**
+- When a resolved ticket is **reopened**

--- a/src/content/docs/guides/support/index.md
+++ b/src/content/docs/guides/support/index.md
@@ -1,0 +1,15 @@
+---
+title: Help & Support
+description: Get help inside PlaidCloud — open and track support tickets, attach screenshots, and (for partners) run the support console, assign agents, and escalate to PlaidCloud.
+sidebar:
+  label: Help & Support
+  order: 16
+---
+
+PlaidCloud has a built-in help system so you never have to leave the app to get support. There are two sides to it:
+
+- **[Getting Help](/guides/support/getting-help/)** — for everyone. Ask the built-in assistant, open a support ticket, attach a screenshot, and follow the conversation, all from inside PlaidCloud.
+- **[The Support Console](/guides/support/support-console/)** — for support agents (PlaidCloud staff and partner agents). Work the ticket queue, reply to customers, attach files, claim tickets, set priority, and escalate to PlaidCloud.
+- **[Managing Support](/guides/support/managing-support/)** — for organization administrators. Add people to your organization, assign them as support agents, and choose how your team is notified about new tickets.
+
+Which pages apply to you depends on your role. Every user can get help; agents additionally see the **Support** console; organization admins additionally see **Support Agents**.

--- a/src/content/docs/guides/support/managing-support.mdx
+++ b/src/content/docs/guides/support/managing-support.mdx
@@ -1,0 +1,80 @@
+---
+title: Managing Support
+description: Organization admins — add people to your organization, assign them as PlaidCloud support agents with workspace scopes, and route new-ticket and escalation notifications to Slack, Teams, or email.
+sidebar:
+  order: 3
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## Description
+
+If you administer a PlaidCloud **Organization** (a "partner"), you can decide who on your team handles support and how they're alerted. A **Support Agents** item appears in the left navigation for organization admins (and PlaidCloud staff). From it you assign agents and configure notification routing per organization.
+
+An organization's **workspaces** are its tenants. A support agent you assign can be scoped to *all* of the organization's workspaces or to a specific subset.
+
+## Add People to Your Organization First
+
+Only members of your organization can be made support agents — specifically, members with an **Admin** or **Workspace** role. So the first step is making sure the person is in the organization.
+
+1. Open the **Organizations** area
+2. Select your organization
+3. Open its **Members**
+4. Invite or add the person, granting them an **Admin** or **Workspace** role
+
+<Aside type="note">
+The person must have signed in to PlaidCloud at least once before they can be added, and they need the Admin or Workspace role — a read-only directory role is not enough to be assigned as a support agent.
+</Aside>
+
+Once they're an Admin or Workspace member, they'll show up as an assignable candidate in the next step.
+
+## Assign a Support Agent
+
+1. Open **Support Agents**
+2. Choose your organization from the **Organization** picker
+3. Click `Add Agent`
+4. Pick the **Member** to assign
+5. Choose **Workspace access**:
+   - **All workspaces** — the agent sees tickets for every workspace in the organization
+   - **Specific workspaces** — pick the exact workspaces the agent should cover
+6. Click `Save`
+
+The agent now sees the **Support** console, scoped to the workspaces you granted (see [The Support Console](/guides/support/support-console/)). Edit an agent to change their scope, or remove them to revoke access. A workspace that's later trashed or moved out of the organization drops out of an agent's scope automatically.
+
+## Configure Notifications and Escalation
+
+So your team responds fast, route new-ticket alerts to a shared channel and set up escalation for tickets that sit too long.
+
+1. Open **Support Agents** and choose your organization
+2. Click `Notification Settings`
+3. Configure the options below
+4. Click `Save` — or `Send Test` to post a test message to your channel first
+
+### Team Channel
+
+Where a **new ticket / new unclaimed message** alert goes:
+
+- **Off** — no team-channel alerts
+- **Slack** — paste a Slack **incoming webhook** URL
+- **Microsoft Teams** — paste a Teams **workflow (incoming webhook)** URL
+- **Email** — enter an email address
+
+The alert fires when a customer opens a thread that needs an owner, and includes the tenant and ticket number.
+
+### Ticket Owner Notifications
+
+Leave **Email the ticket owner when a customer replies** on so the agent who claimed a ticket is emailed whenever the customer adds a reply.
+
+### Escalation
+
+Turn on **Escalate tickets left unclaimed and unanswered** to nudge your team about tickets no one has picked up:
+
+- **Escalate after (minutes)** — how long a ticket may sit unclaimed and unanswered before escalating
+- **Escalation contact email** (optional) — a point of contact emailed when a ticket escalates; if left blank, the team channel is pinged again instead
+- **Max reminders** — how many escalation pings to send before stopping
+
+The escalation clock resets once a ticket is claimed, answered, or resolved.
+
+<Aside type="note">
+Incoming-webhook channels post to a shared channel — they can't direct-message a person. That's why the ticket owner is notified by **email**, while new-ticket and escalation alerts go to the **team channel**.
+</Aside>

--- a/src/content/docs/guides/support/support-console.mdx
+++ b/src/content/docs/guides/support/support-console.mdx
@@ -1,0 +1,73 @@
+---
+title: The Support Console
+description: Work the PlaidCloud support queue — filter tickets by saved views, reply to customers, attach files, add internal notes, claim tickets, set priority, and escalate to PlaidCloud.
+sidebar:
+  order: 2
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## Description
+
+The **Support** console is where support agents work customer tickets. PlaidCloud staff see every tenant's tickets; a partner agent sees only the workspaces they've been assigned (see [Managing Support](/guides/support/managing-support/)). If you have support access, a **Support** item appears in the left navigation.
+
+## Work the Queue
+
+The console opens on a sorted, filterable list of tickets. Saved-view tabs across the top narrow it:
+
+- **Active** — everything that still needs attention
+- **Unassigned** — tickets no one has claimed
+- **My tickets** — tickets you've claimed
+- **Needs response** — a customer is waiting on a reply
+- **Awaiting customer** — you've replied; waiting on them
+- **Urgent** — high-priority tickets
+- **Snoozed**
+- **Resolved**
+
+The list is sorted by priority, then by how long the customer has been waiting, so the most pressing work is at the top. Use the search box to filter by text; PlaidCloud staff can also narrow to a single workspace.
+
+## Open and Read a Ticket
+
+Click any row to open the ticket thread. The header shows the workspace, status, and who (if anyone) has claimed it. The thread shows every message with its sender; **internal notes** are shown to agents (highlighted) but never to the customer. Attachments render inline for images, with a download link for other files.
+
+## Claim a Ticket
+
+Claiming signals that you're handling a ticket and puts it in your **My tickets** view.
+
+1. Open the ticket
+2. Click `Claim` (click `Unclaim` to release it)
+
+Claiming is separate from Chatwoot's own assignment — it's a lightweight "I've got this" for your team. A ticket is unclaimed automatically when it's resolved.
+
+## Reply to a Customer
+
+1. Open the ticket
+2. Type your reply in the box at the bottom
+3. (Optional) Click `Attach` to add a screenshot or file (up to 10 files, 10 MB each), or `Insert saved reply…` to drop in a canned response
+4. Click `Send`
+
+The customer is emailed your reply, and the ticket moves to **Awaiting customer**.
+
+## Add an Internal Note
+
+To leave a note for other agents that the customer never sees:
+
+1. Type your note in the reply box
+2. Check `Internal note`
+3. Click `Send`
+
+Internal notes appear highlighted in the thread and are agent-only. The toggle resets to a public reply after each send.
+
+## Set Priority, Resolve, Reopen
+
+- **Priority** — pick a level (Urgent / High / Medium / Low / None) from the priority selector; the queue re-sorts accordingly.
+- **Resolve** — click `Resolve` when the issue is handled; the customer is emailed. Click `Reopen` if it comes back.
+
+## Escalate to PlaidCloud
+
+A partner agent who needs PlaidCloud to take over a ticket can hand it off:
+
+1. Open the ticket
+2. Click `Escalate`
+
+The ticket is routed to PlaidCloud's support team. Escalation also happens automatically for tickets left unclaimed and unanswered past your organization's configured window — see [Managing Support](/guides/support/managing-support/#configure-notifications-and-escalation).

--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -10,3 +10,9 @@ Versions are listed here as each July 2026 release ships.
 ## Added
 
 - **PlaidCloud Managed Bucket document accounts** — add fully managed file storage to Document in a single step. Choose **PlaidCloud Managed Bucket** as the account type, give it a name, and PlaidCloud provisions and runs the storage for you — there's no cloud project, credentials, region, or storage tier to set up or tune. Available on the **Business** and **Enterprise** plans. See [Add a PlaidCloud Managed Bucket Account](/guides/documents/adding-accounts/add-managed-bucket-account/).
+
+- **Attach screenshots to support tickets** — when you open a ticket or reply in Help & Support (or reply by email), you can attach screenshots and files. Images show inline in the conversation. See [Getting Help](/guides/support/getting-help/).
+
+- **Support console for agents and partners** — support agents work a sorted, filterable ticket queue: reply, attach files, add internal notes, claim tickets, set priority, and escalate to PlaidCloud. See [The Support Console](/guides/support/support-console/).
+
+- **Team notifications and escalation for partners** — organization admins can route new-ticket alerts to a Slack, Teams, or email channel, email the ticket owner on replies, and escalate tickets left unanswered too long. See [Managing Support](/guides/support/managing-support/).


### PR DESCRIPTION
New **guides/support/** area documenting the support features shipped this cycle, for all three audiences:

- **Getting Help** — customers: open and track tickets, ask the assistant, **attach screenshots**, reply in-app or by email, and the status emails they get.
- **The Support Console** — agents (staff + partner): work the saved-view queue, reply, attach files, add internal notes, claim, set priority, resolve, and **escalate to PlaidCloud**.
- **Managing Support** — organization admins: **add people to the org** (Admin/Workspace role) so they can be **assigned as support agents** with All/Specific workspace scope, and configure **Slack/Teams/email notification routing + escalation**.

Plus the sidebar entry (Guides → Help & Support) and a July What's New section. Local `npm run build` passes (1514 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)