### PR TITLE
docs(ai): Analysis Paths + "Answers You Can Trust" honesty page

### DIFF
--- a/src/content/docs/integrations/ai-coding-agents/analysis-paths.mdx
+++ b/src/content/docs/integrations/ai-coding-agents/analysis-paths.mdx
@@ -26,7 +26,7 @@ Without an analysis path, every question has to spell out exactly where the data
 
 ## Register an Analysis Path
 
-You don't need a form or a settings screen — just ask your connected AI assistant, in plain language, to register the path for you:
+If you're a workspace administrator, you don't need a form or a settings screen — just ask your connected AI assistant, in plain language, to register the path for you:
 
 > *"Register an analysis path named **Operations Results** that points at the `ops_summary` table in the **Enterprise Profitability** project."*
 
@@ -38,7 +38,7 @@ Choose names the way your team talks: *"Operations Results," "the Forecast," "He
 
 ## Set a Default Path
 
-Mark one path as the **default** so questions that don't name a table land on it automatically:
+As an administrator, mark one path as the **default** so questions that don't name a table land on it automatically:
 
 > *"Make **Operations Results** my default analysis path."*
 

--- a/src/content/docs/integrations/ai-coding-agents/analysis-paths.mdx
+++ b/src/content/docs/integrations/ai-coding-agents/analysis-paths.mdx
@@ -1,0 +1,72 @@
+---
+title: Analysis Paths
+description: Give your key tables friendly names so you — and your AI assistant — can just ask about "the operations results" without naming the project and table every time. Set one as the default.
+sidebar:
+  label: Analysis Paths
+  order: 10
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+An **analysis path** is a friendly name for a table you analyze often — like *"Operations Results"* or *"the P&L"*. Register it once, and from then on you (and your connected AI assistant) can ask questions about it by that name, without repeating which project and which table you mean every single time.
+
+Pick one as your **default**, and plain questions like *"why did this go up last quarter?"* just work — the assistant already knows what "this" refers to.
+
+<Aside>
+Analysis paths are a shared workspace convenience: an administrator sets them up, and then **anyone** on the workspace can use them in their questions — through [Microsoft 365 Copilot](/integrations/microsoft-365-copilot/) or a coding agent connected over [MCP](../getting-started/). Every question still runs under each person's own permissions.
+</Aside>
+
+## Why Use Them
+
+Without an analysis path, every question has to spell out exactly where the data lives — the project *and* the table — which gets tedious fast and is easy to get wrong. With one, you talk about your data the way you actually think about it:
+
+- **Ask by name.** *"Summarize the Operations Results."* instead of *"summarize table `ops_summary_v3` in project `Enterprise Profitability`."*
+- **Set a default.** Mark your most-used table as the default and drop the name entirely — *"what changed since last month?"* lands on the right data automatically.
+- **Keep everyone consistent.** When the whole team refers to *"the P&L,"* they all reach the same table — no guessing, no stale copies.
+
+## Register an Analysis Path
+
+You don't need a form or a settings screen — just ask your connected AI assistant, in plain language, to register the path for you:
+
+> *"Register an analysis path named **Operations Results** that points at the `ops_summary` table in the **Enterprise Profitability** project."*
+
+The assistant confirms the path and it's ready to use immediately. You can register as many as you like — one per table you analyze regularly.
+
+<Aside type="tip">
+Choose names the way your team talks: *"Operations Results," "the Forecast," "Headcount."* The friendlier the name, the more natural your questions become.
+</Aside>
+
+## Set a Default Path
+
+Mark one path as the **default** so questions that don't name a table land on it automatically:
+
+> *"Make **Operations Results** my default analysis path."*
+
+From then on, *"what were the top movers this quarter?"* or *"why did the total drop?"* run against that table with nothing else to specify. Setting a new default simply moves the crown — there's only ever one, and the assistant tells you which it is.
+
+## Using Them
+
+Once your paths are registered, just ask:
+
+<Steps>
+
+1. **By name** — *"Show me the first rows of the Operations Results."*
+
+2. **By your default** — *"What changed versus last quarter?"* (no table named — it uses your default path).
+
+3. **Switch freely** — *"Now do the same for the Forecast."* The assistant follows along, path to path.
+
+</Steps>
+
+This pairs naturally with allocation questions — see [Tracing Allocations](../tracing-allocations/) — so you can go from *"why did the Operations Results move?"* straight into the accounts and drivers behind it.
+
+## Who Can Set Them Up
+
+Setting up analysis paths — registering them and choosing the default — is an **administrator** action, so the shared names stay clean and trustworthy for everyone. Once they exist, every member of the workspace can use them in their questions, each still seeing only the data their own permissions allow.
+
+## Related
+
+- [Answers You Can Trust](../honest-answers/) — how PlaidCloud grades and caveats every AI answer
+- [Tracing Allocations](../tracing-allocations/) — explain *why* a named result changed
+- [Getting Started with AI Coding Agents](../getting-started/) — connect an assistant over MCP
+- [Microsoft 365 Copilot](/integrations/microsoft-365-copilot/) — use analysis paths from Teams and Outlook

--- a/src/content/docs/integrations/ai-coding-agents/analysis-paths.mdx
+++ b/src/content/docs/integrations/ai-coding-agents/analysis-paths.mdx
@@ -10,7 +10,7 @@ import { Aside, Steps } from '@astrojs/starlight/components';
 
 An **analysis path** is a friendly name for a table you analyze often — like *"Operations Results"* or *"the P&L"*. Register it once, and from then on you (and your connected AI assistant) can ask questions about it by that name, without repeating which project and which table you mean every single time.
 
-Pick one as your **default**, and plain questions like *"why did this go up last quarter?"* just work — the assistant already knows what "this" refers to.
+Pick one as the workspace **default**, and plain questions like *"why did this go up last quarter?"* just work — the assistant already knows what "this" refers to.
 
 <Aside>
 Analysis paths are a shared workspace convenience: an administrator sets them up, and then **anyone** on the workspace can use them in their questions — through [Microsoft 365 Copilot](/integrations/microsoft-365-copilot/) or a coding agent connected over [MCP](../getting-started/). Every question still runs under each person's own permissions.
@@ -40,9 +40,9 @@ Choose names the way your team talks: *"Operations Results," "the Forecast," "He
 
 As an administrator, mark one path as the **default** so questions that don't name a table land on it automatically:
 
-> *"Make **Operations Results** my default analysis path."*
+> *"Make **Operations Results** the default analysis path."*
 
-From then on, *"what were the top movers this quarter?"* or *"why did the total drop?"* run against that table with nothing else to specify. Setting a new default simply moves the crown — there's only ever one, and the assistant tells you which it is.
+From then on, *"what were the top movers this quarter?"* or *"why did the total drop?"* run against that table with nothing else to specify. There's a single default for the whole workspace, so everyone's untargeted questions resolve to the same table. Setting a new default simply moves the crown — there's only ever one, and the assistant tells you which it is.
 
 ## Using Them
 
@@ -52,7 +52,7 @@ Once your paths are registered, just ask:
 
 1. **By name** — *"Show me the first rows of the Operations Results."*
 
-2. **By your default** — *"What changed versus last quarter?"* (no table named — it uses your default path).
+2. **By the default** — *"What changed versus last quarter?"* (no table named — it uses the workspace default path).
 
 3. **Switch freely** — *"Now do the same for the Forecast."* The assistant follows along, path to path.
 

--- a/src/content/docs/integrations/ai-coding-agents/honest-answers.mdx
+++ b/src/content/docs/integrations/ai-coding-agents/honest-answers.mdx
@@ -10,7 +10,7 @@ import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 Any AI can write a confident paragraph about your numbers. The hard part — the part that decides whether you can act on the answer — is knowing **when to trust it**. That is what PlaidCloud is built for.
 
-When you ask a connected AI assistant to explain your data, PlaidCloud doesn't just hand back a figure. It grades how much to trust that figure, tells you in plain language where the ground is soft, cross-checks its own arithmetic, and refuses to make anything up. This is the difference between an assistant that *sounds* right and one you can put in front of a CFO.
+When you ask a connected AI assistant to explain your data, PlaidCloud doesn't just hand back a figure. It grades how much to trust that figure, tells you in plain language where the ground is soft, reconciles its own arithmetic, and refuses to make anything up. This is the difference between an assistant that *sounds* right and one you can put in front of a CFO.
 
 <Aside>
 This applies to **every** way you connect an AI to PlaidCloud — [Microsoft 365 Copilot](/integrations/microsoft-365-copilot/) for your whole team, or a coding agent like Claude Code or Cursor over [MCP](../getting-started/). The honesty travels with the answer, not the tool.
@@ -26,13 +26,13 @@ You never have to wonder whether the assistant is sure. It tells you, up front, 
 
 Instead of burying assumptions, PlaidCloud surfaces them as plain-language heads-up notes attached to the answer:
 
-| When PlaidCloud says… | It means… |
+| When an answer flags… | It means… |
 | --- | --- |
 | "This describes the whole pool" | The figure is a total; to see how it shifts *between* members (regions, products, cost centers), ask about a specific one. |
 | "These periods aren't equally complete" | One period may be a partial month or a short window, so part of the movement could be missing data rather than a real change. |
 | "The pieces don't fully reconcile" | The detailed breakdown doesn't perfectly sum to the headline number — treat the split as indicative, not exact. |
 | "The precise cause is partial" | The totals are correct, but the exact driver of the change can't be fully attributed from the data on hand. |
-| "This is an upper bound" | A what-if estimate is a worst-case envelope for sizing the blast radius — not an additive forecast. |
+| "This is an upper bound" | A what-if estimate is a worst-case envelope for sizing the potential impact — not an additive forecast. |
 
 These aren't fine print. They're the safeguards that keep a confident-sounding answer from quietly overstating what the data actually supports.
 
@@ -42,7 +42,7 @@ When PlaidCloud explains why a number moved, it doesn't stop at the first plausi
 
 ## It Never Invents a Number
 
-Every figure comes from a real query against your data. If a question needs data you don't have access to, or the data simply isn't there, PlaidCloud tells you plainly instead of guessing. There are no hallucinated totals, no invented account names, no made-up trends.
+Every figure comes from a real query against your data. If a question needs data you don't have access to, or the data simply isn't there, PlaidCloud tells you plainly instead of guessing. PlaidCloud invents nothing: no hallucinated totals, no invented account names, no made-up trends.
 
 <Aside type="tip">
 Ask follow-ups freely. Because each answer carries its own confidence and caveats, you can keep drilling — "show me just the US," "compare full months only" — and watch the confidence rise as the question gets sharper.

--- a/src/content/docs/integrations/ai-coding-agents/honest-answers.mdx
+++ b/src/content/docs/integrations/ai-coding-agents/honest-answers.mdx
@@ -1,0 +1,78 @@
+---
+title: Answers You Can Trust
+description: PlaidCloud's AI analysis is built to be honest — every answer carries a confidence signal, plain-language caveats when the data is thin, and a promise never to invent a number.
+sidebar:
+  label: Answers You Can Trust
+  order: 9
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+Any AI can write a confident paragraph about your numbers. The hard part — the part that decides whether you can act on the answer — is knowing **when to trust it**. That is what PlaidCloud is built for.
+
+When you ask a connected AI assistant to explain your data, PlaidCloud doesn't just hand back a figure. It grades how much to trust that figure, tells you in plain language where the ground is soft, cross-checks its own arithmetic, and refuses to make anything up. This is the difference between an assistant that *sounds* right and one you can put in front of a CFO.
+
+<Aside>
+This applies to **every** way you connect an AI to PlaidCloud — [Microsoft 365 Copilot](/integrations/microsoft-365-copilot/) for your whole team, or a coding agent like Claude Code or Cursor over [MCP](../getting-started/). The honesty travels with the answer, not the tool.
+</Aside>
+
+## Every Answer Carries a Confidence Signal
+
+PlaidCloud rates its own answers — **High**, **Medium**, or **Low** confidence — and says *why*. A clean, fully-attributed result comes back as High. If the two periods you're comparing aren't equally complete, or part of a change can't be pinned to a single cause, PlaidCloud says so and lowers its own confidence rather than presenting a shaky number as a certain one.
+
+You never have to wonder whether the assistant is sure. It tells you, up front, in the answer.
+
+## It Tells You When to Be Careful
+
+Instead of burying assumptions, PlaidCloud surfaces them as plain-language heads-up notes attached to the answer:
+
+| When PlaidCloud says… | It means… |
+| --- | --- |
+| "This describes the whole pool" | The figure is a total; to see how it shifts *between* members (regions, products, cost centers), ask about a specific one. |
+| "These periods aren't equally complete" | One period may be a partial month or a short window, so part of the movement could be missing data rather than a real change. |
+| "The pieces don't fully reconcile" | The detailed breakdown doesn't perfectly sum to the headline number — treat the split as indicative, not exact. |
+| "The precise cause is partial" | The totals are correct, but the exact driver of the change can't be fully attributed from the data on hand. |
+| "This is an upper bound" | A what-if estimate is a worst-case envelope for sizing the blast radius — not an additive forecast. |
+
+These aren't fine print. They're the safeguards that keep a confident-sounding answer from quietly overstating what the data actually supports.
+
+## It Checks Its Own Math
+
+When PlaidCloud explains why a number moved, it doesn't stop at the first plausible story. It reconciles the parts back against the whole and, if they don't line up, it says so and dials back its confidence — so a subtle gap in the data shows up as a caveat, never as false precision.
+
+## It Never Invents a Number
+
+Every figure comes from a real query against your data. If a question needs data you don't have access to, or the data simply isn't there, PlaidCloud tells you plainly instead of guessing. There are no hallucinated totals, no invented account names, no made-up trends.
+
+<Aside type="tip">
+Ask follow-ups freely. Because each answer carries its own confidence and caveats, you can keep drilling — "show me just the US," "compare full months only" — and watch the confidence rise as the question gets sharper.
+</Aside>
+
+## Why This Is Different
+
+Most AI analytics tools are confident whether or not they're right. A generic chatbot bolted onto a dashboard will produce a fluent, authoritative-sounding answer — and give you no way to tell a solid one from a wrong one. To that kind of tool, every number is just a number.
+
+PlaidCloud is built the other way around. Confidence grading, self-reconciliation, and honest caveats are part of every answer, because an answer you can't trust isn't worth having. That honesty is the whole point: it's what lets you take an AI-generated explanation and actually *use* it — in a board deck, a forecast, a decision — without re-checking it by hand.
+
+## Works With the AI You Already Use
+
+You don't adopt a new tool to get this. PlaidCloud's honest analysis comes through whichever assistant your team already lives in:
+
+<CardGrid>
+	<LinkCard
+		title="Microsoft 365 Copilot"
+		href="/integrations/microsoft-365-copilot/"
+		description="Your whole team asks in Teams, Outlook, and the Microsoft 365 app — sign in once, read-only by default."
+	/>
+	<LinkCard
+		title="AI Coding Agents (MCP)"
+		href="../getting-started/"
+		description="Connect Claude Code, Cursor, Claude Desktop, ChatGPT, or Gemini over the Model Context Protocol."
+	/>
+</CardGrid>
+
+## Related
+
+- [Tracing Allocations](../tracing-allocations/) — see honest confidence and caveats at work on a real allocation question
+- [Analysis Paths](../analysis-paths/) — name your key tables so you can just ask "why did this change?"
+- [Microsoft 365 Copilot](/integrations/microsoft-365-copilot/) — bring honest AI analysis to your whole team

--- a/src/content/docs/integrations/ai-coding-agents/index.md
+++ b/src/content/docs/integrations/ai-coding-agents/index.md
@@ -9,3 +9,15 @@ sidebar:
 PlaidCloud exposes a curated [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server at `/mcp` on every workspace. AI agents connect to it the same way they connect to any other MCP server, then call the tools to read projects, run workflows, query tables, manage dimensions, and more.
 
 The pages in this section cover what the server exposes, how to authenticate, and step-by-step setup for the most common AI clients.
+
+## What Makes PlaidCloud's AI Analysis Different
+
+- **[Answers You Can Trust](./honest-answers/)** — every answer carries a confidence signal and plain-language caveats, and PlaidCloud never invents a number. This honesty is what lets you act on an AI answer without re-checking it by hand.
+- **[Tracing Allocations](./tracing-allocations/)** — ask *why* an allocated result changed, what feeds it, and what a hypothetical change would do — in plain language.
+- **[Analysis Paths](./analysis-paths/)** — give your key tables friendly names and a default, so you can just ask "why did this go up last quarter?"
+
+## Connect Your Assistant
+
+- [Getting Started](./getting-started/) — what the MCP server exposes and how to authenticate.
+- [Microsoft 365 Copilot](/integrations/microsoft-365-copilot/) — bring PlaidCloud to your whole team in Teams and Outlook.
+- Per-client setup: [Claude Code](./claude-code/), [Claude Desktop](./claude-desktop/), [Cursor](./cursor/), [GitHub Copilot](./copilot/), [Gemini](./gemini/), [ChatGPT](./chatgpt/).

--- a/src/content/docs/integrations/ai-coding-agents/troubleshooting.md
+++ b/src/content/docs/integrations/ai-coding-agents/troubleshooting.md
@@ -2,7 +2,7 @@
 title: Troubleshooting
 description: Common issues connecting AI agents to the PlaidCloud MCP server and how to fix them.
 sidebar:
-  order: 9
+  order: 12
 ---
 
 ## Cursor (or Another Strict Client) Won't Connect at All

--- a/src/content/docs/integrations/microsoft-365-copilot.mdx
+++ b/src/content/docs/integrations/microsoft-365-copilot.mdx
@@ -30,7 +30,9 @@ the request under that person's own permissions, and Copilot explains the answer
 
 - **Read-only for most people.** The common access level is read-only — list and describe projects
   and tables, read table data, list dimension members, and explain allocation results. It never
-  invents numbers; every answer comes from a real query against your data.
+  invents numbers; every answer comes from a real query against your data, and each answer carries a
+  confidence signal and plain-language caveats — see [Answers You Can
+  Trust](/integrations/ai-coding-agents/honest-answers/).
 - **Each person sees only their own data.** Requests run as the signed-in user, bounded by the same
   PlaidCloud roles and access controls they already have. The agent can never reach credential,
   identity, or access-control settings.
@@ -235,6 +237,12 @@ change above your level, it says so rather than guessing.
 | A request to change data is refused | The person's access level (or their own PlaidCloud permissions) doesn't allow that write. Raise their [access level](#access-levels) if appropriate. |
 | Asked to sign in again after it was working | Normal — the saved connection is refreshed periodically (roughly monthly). Sign in once more and continue. |
 | Answers seem to need data the person can't reach | Expected — the agent only ever returns data the signed-in user is already permitted to see. |
+
+## Related
+
+- [Answers You Can Trust](/integrations/ai-coding-agents/honest-answers/) — how PlaidCloud grades and caveats every AI answer
+- [Tracing Allocations](/integrations/ai-coding-agents/tracing-allocations/) — ask *why* an allocated result changed
+- [Analysis Paths](/integrations/ai-coding-agents/analysis-paths/) — name your key tables so the whole team asks about them the same way
 
 ## Need Help?
 

--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -16,3 +16,5 @@ Versions are listed here as each July 2026 release ships.
 - **Support console for agents and partners** — support agents work a sorted, filterable ticket queue: reply, attach files, add internal notes, claim tickets, set priority, and escalate to PlaidCloud. See [The Support Console](/guides/support/support-console/).
 
 - **Team notifications and escalation for partners** — organization admins can route new-ticket alerts to a Slack, Teams, or email channel, email the ticket owner on replies, and escalate tickets left unanswered too long. See [Managing Support](/guides/support/managing-support/).
+
+- **Analysis paths for AI questions** — give the tables you analyze most a friendly name, and set one as your default, so you and your AI assistant can ask about "the Operations Results" — or just "what changed last quarter?" — without naming the project and table every time. Works across Microsoft 365 Copilot and any MCP-connected agent. See [Analysis Paths](/integrations/ai-coding-agents/analysis-paths/).


### PR DESCRIPTION
## What

Two new user-facing pages under **integrations/ai-coding-agents**, plus cross-links and a July release note.

- **Answers You Can Trust** (`honest-answers.mdx`) — positions PlaidCloud's honest AI analysis as a differentiator: per-answer **confidence signals**, plain-language **caveats**, self-reconciliation, and never inventing a number. Framed as the trust moat and written to span **Microsoft 365 Copilot** and MCP-connected agents. Marketing-forward — no implementation detail.
- **Analysis Paths** (`analysis-paths.mdx`) — the previously **undocumented** feature: how to register a friendly name for a table and set a workspace **default**, so you (and your AI) can ask about "the Operations Results" — or just "what changed last quarter?" — without naming the project and table each time.

Supporting edits:
- AI-agents section index — a "What Makes PlaidCloud's AI Analysis Different" block + a "Connect Your Assistant" list.
- Microsoft 365 Copilot page — inline honesty callout + a Related section linking the three pages.
- July 2026 release notes — one additive **Analysis Paths** entry.
- Troubleshooting `sidebar.order` bumped 9 → 12 to seat the two new pages.

## Relationship to the in-flight honesty PRs

This **complements** #225 (`sc-22811` confidence + caveats) and #226 (allocation cost-tracing guide) rather than colliding with them:
- Does **not** edit `tracing-allocations.mdx` (both those PRs do) — links to it instead.
- Leaves the honesty **release note** to #225; adds only the Analysis Paths bullet to `2026-07.mdx` (a trivial additive merge).
- Adds a distinct **positioning/moat** page + the **Analysis Paths** gap that none of #219/#224/#225/#226 cover.

## Verification

- `npm run build` passes locally (1,516 pages); all internal links resolve.
- Vale runs in CI (not installed locally).

## Notes for review

- Kept the honesty framing **honest**: the engine does *self-reconciliation* (do the parts sum to the whole), not a fully independent second-method estimator — so the page says "checks its own math," not "recomputes a second way."
- No competitors named — moat is framed against "generic AI bolted onto a dashboard," appropriate for public docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)