### PR TITLE
docs(ai): what-if estimates are a proportional split, not an upper bound

### DIFF
--- a/src/content/docs/integrations/ai-coding-agents/honest-answers.mdx
+++ b/src/content/docs/integrations/ai-coding-agents/honest-answers.mdx
@@ -32,7 +32,7 @@ Instead of burying assumptions, PlaidCloud surfaces them as plain-language heads
 | "These periods aren't equally complete" | One period may be a partial month or a short window, so part of the movement could be missing data rather than a real change. |
 | "The pieces don't fully reconcile" | The detailed breakdown doesn't perfectly sum to the headline number — treat the split as indicative, not exact. |
 | "The precise cause is partial" | The totals are correct, but the exact driver of the change can't be fully attributed from the data on hand. |
-| "This is an upper bound" | A what-if estimate is a worst-case envelope for sizing the potential impact — not an additive forecast. |
+| "Estimated on today's shares" | A what-if estimate splits the change across the affected results by each one's current share of the pool — so the figures add up — and reflects how your model is configured today, not a precise forecast of a future in which the shares may have moved. |
 
 These aren't fine print. They're the safeguards that keep a confident-sounding answer from quietly overstating what the data actually supports.
 


### PR DESCRIPTION
## What

Follow-up to #228 (merged). One-line correction on the new **Answers You Can Trust** page.

The what-if caveat still read *"This is an upper bound … not an additive forecast."* That's the **old** forward-impact behaviour. Per **sc-22807** (plaid#6444) and the tracing-allocations updates in #224/#226, `allocation_forward_impact` now returns a **proportional** per-target split — each target's current share of the pool, so the per-result figures **add up**. This corrects the honesty page to match, so it doesn't contradict the tracing guide.

Only touches `honest-answers.mdx` (not `tracing-allocations.mdx`), so no conflict with #224/#225/#226.

## Verification

- `npm run build` passes locally; all links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)