### PR TITLE
docs(alteryx): document the post-import conversion report screen

### DIFF
--- a/src/content/docs/guides/workflows/migrate-alteryx-workflows.mdx
+++ b/src/content/docs/guides/workflows/migrate-alteryx-workflows.mdx
@@ -41,14 +41,16 @@ Collect the workflow files and dependencies together before importing:
 ## Import A Workflow
 
 1. Open the target project in PlaidCloud.
-2. Open **Workflows**.
-3. Choose the import action for Alteryx workflows.
-4. Select the `.yxmd`, `.yxwz`, or `.yxmc` file to import.
+2. Open **Tools → Import Alteryx Workflow**.
+3. Choose the target project and select the `.yxmd`, `.yxwz`, or `.yxmc` file to import.
+4. Optionally set workflow, step, and table name prefixes.
 5. Choose the Document account and folder where imported files should be stored.
 6. Add any referenced files or folders that the workflow needs at runtime.
 7. Start the import.
-8. Review the conversion summary for uploaded files, generated workflows, generated macros, readiness notes, and validation recommendations.
+8. Review the conversion report shown when the import finishes.
 9. Open the generated Advanced workflow.
+
+When the import finishes, the import window replaces its form with a conversion report: a summary of how many steps mapped with high confidence and how many need review, and — when any step needs a look — a table of the lower-confidence or caveated steps listing each step's name, operation, confidence, and notes. Use it to go straight to the steps worth checking before you run the workflow; each of those steps also carries the same confidence note in its step memo on the canvas.
 
 PlaidCloud stores imported dependencies in the Document location selected during import. Converted steps then reference those Document paths, so the workflow can run repeatedly without relying on a desktop file system.
 

--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -37,6 +37,7 @@ Versions are listed here as each July 2026 release ships.
 - **Data-freshness checks now include the driver and basis tables**, not just the input cost pools, so a stale driver that would silently skew a split is surfaced instead of going unflagged.
 - **A year-over-year comparison with no prior-year data now says so** — reported as no baseline available rather than labelling the change "normal".
 - **Packaged report macros are now first-class Report steps** — a report bundle imported from an Alteryx packaged report macro now appears as a hand-editable Report step, carrying its macro definition automatically and rendering through the same path as the other Report steps. See [Report: Packaged Macro](/reference/workflow-steps/reports/report-packaged-macro/).
+- **Importing an Alteryx workflow now ends on a conversion report** instead of a plain "imported" message. It summarizes how many steps mapped with high confidence and how many need review, and lists the lower-confidence or caveated steps with their operation and notes so you can check them before running the workflow. Each imported step also carries its mapping confidence as a memo on the canvas. See [Migrate Alteryx Workflows](/guides/workflows/migrate-alteryx-workflows/).
 
 ## Fixed
 


### PR DESCRIPTION
Documents the new post-import conversion report in the Import Alteryx Workflow window ([PlaidClient #1780](https://github.com/PlaidCloud/PlaidClient/pull/1780), backend [plaid #6477](https://github.com/PlaidCloud/plaid/pull/6477)):

- **Migrate Alteryx Workflows guide** — corrected the import steps to the shipped UI (launched from **Tools → Import Alteryx Workflow**, prefix fields) and described the report screen (confidence summary + review table) and the per-step confidence memos on the canvas.
- **July 2026 release notes** — added the conversion-report entry under Changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)