### PR TITLE
Docs: Preview Step Data guide for the VWD Data Preview drawer

### DIFF
--- a/src/content/docs/guides/workflows/advanced-workflows.mdx
+++ b/src/content/docs/guides/workflows/advanced-workflows.mdx
@@ -102,6 +102,7 @@ Right-click any step for:
 - **Duplicate Step…** — open the new-step form pre-populated from this step.
 - **Enable Step** / **Disable Step** — a disabled step is skipped at run time.
 - **View Step Inputs** / **View Step Outputs** — open the step's data in the Inspector.
+- **Preview Output Data** — open the step's output in the docked [Data Preview drawer](/guides/workflows/preview-step-data/). Hovering a step also fades in a browse glyph that does the same thing.
 - **Color** — apply or clear a step color.
 - **Delete Step…** — removes it from the workflow structure. Downstream steps that depended on its output will need to be reconfigured.
 
@@ -172,7 +173,7 @@ A **container** groups related steps into a labeled box you can collapse or disa
 
 The docked **Step Inspector** shows everything about the step you select:
 
-- **Inputs** and **Outputs** — the data flowing into and out of the step.
+- **Inputs** and **Outputs** — the data flowing into and out of the step. The eye icon on an output card opens the [Data Preview drawer](/guides/workflows/preview-step-data/) for a quick look at the table's first rows.
 - **Run Stats** — the step's **Last Run** result, **Last Duration**, run count, and timing summaries including the **Average** and **p95** durations, plus the **Last Run Error** or **Last Run Warning** when there is one.
 - **Edit Step Configuration…** and **Edit Step Details…** — jump straight to the step's forms, and rename the step inline by clicking its name.
 - **Rollback Step Config (Flashback)** — restore the step's configuration to an earlier saved version.
@@ -186,6 +187,7 @@ Choose **View this workflow's run history** to see past runs with summary statis
 
 ## Next Steps
 
+- [Preview Step Data](/guides/workflows/preview-step-data/) — browse any step's output in the docked Data Preview drawer
 - [Run a workflow](/guides/workflows/run-a-workflow/) — running a workflow end to end
 - [Managing step errors](/guides/workflows/managing-step-errors/) — debugging failures
 - [Upcoming runs calendar](/administration/scheduled-events/upcoming-runs-calendar/) — see when scheduled workflows will run

--- a/src/content/docs/guides/workflows/preview-step-data.mdx
+++ b/src/content/docs/guides/workflows/preview-step-data.mdx
@@ -1,0 +1,66 @@
+---
+title: Preview Step Data
+description: Open the Data Preview drawer in the Visual Workflow Designer to see a step's output data in place — first 100 rows with typed columns, no new window.
+sidebar:
+  label: Preview Step Data
+  order: 19.5
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## Description
+
+The **Data Preview drawer** shows a step's output data right inside the [Visual Workflow Designer](/guides/workflows/advanced-workflows/) — a read-only grid of the **first 100 rows** with typed, sortable columns, docked at the bottom of the canvas. It's built for the quick glance between edits: check that a join produced the columns you expect, confirm a filter actually filtered, then keep building — without opening a full Table Explorer window for every look.
+
+<Aside type="note">The drawer previews data that already exists. If the step hasn't produced its output table yet, the drawer shows *"No data yet — run the step to generate this table"* — run the step, and the preview fills in.</Aside>
+
+## Open the Preview
+
+There are three ways in, all landing in the same drawer:
+
+- **Hover the step tile** — a small browse (table) glyph fades in at the tile's bottom-right corner. Click it.
+- **Right-click the step** and choose **Preview Output Data**.
+- **In the Inspector**, click the **eye icon** on any output card under the step's **Outputs** section.
+
+The drawer docks below the canvas and loads the step's first table output.
+
+## Browse from Step to Step
+
+While the drawer is open, **clicking any other step retargets the preview** to that step's output — one click per step. Walk down a chain of steps clicking each in turn and watch the data change shape at each stage.
+
+To close the drawer, click **✕** in its header or press **Esc**. (If a step is selected, the first Esc closes the drawer and the next clears the selection.)
+
+## The Drawer Header
+
+The header keeps the preview honest about what you're seeing:
+
+- **Table name** and **Showing first N of ~M rows** — the tilde appears when the engine reports the total as an approximation.
+- **Column count**.
+- **Output selector** — when a step writes more than one table, pick which output to preview. The first output is preselected.
+- **Refresh** — refetch the preview on demand.
+- **Open in Table Explorer** — one-click escalation to the full explorer (see below).
+- **✕** — close the drawer.
+
+## Fresh After Every Run
+
+If the step you're previewing runs while the drawer is open, the preview **refreshes automatically once when the run completes** — so after a Run This Step, the drawer already shows the new data. If the output table didn't actually change, the drawer redraws instantly from its cache.
+
+## When You Need More: Table Explorer
+
+The preview is deliberately a glance, not a workbench — no editing, filtering, or downloading. When you need those, click **Open in Table Explorer** in the drawer header to open the same table in the full [Table Explorer](/guides/data/table-explorer/), with everything it offers.
+
+Two cases where you'll want that button:
+
+- **Wide tables** — the drawer renders the **first 150 columns** and notes that the rest are available in Table Explorer.
+- **Deep dives** — anything beyond the first 100 rows, or any slicing and filtering.
+
+## What the Drawer Shows When There's Nothing to Show
+
+- **This step has no table outputs** — the step writes files or dimensions instead of tables (the preview covers table outputs only).
+- **No data yet — run the step to generate this table** — the output table hasn't been created yet. Run the step.
+- **Table is empty** — the table exists but has zero rows.
+
+## Next Steps
+
+- [Advanced Workflows (Visual Workflow Designer)](/guides/workflows/advanced-workflows/) — the full canvas guide
+- [Running one step in a workflow](/guides/workflows/running-one-step-in-a-workflow/) — run just the step you're previewing

--- a/src/content/docs/guides/workflows/preview-step-data.mdx
+++ b/src/content/docs/guides/workflows/preview-step-data.mdx
@@ -24,7 +24,7 @@ There are three ways in, all landing in the same drawer:
 
 The drawer docks below the canvas and loads the step's first table output.
 
-## Browse from Step to Step
+## Browse From Step to Step
 
 While the drawer is open, **clicking any other step retargets the preview** to that step's output — one click per step. Walk down a chain of steps clicking each in turn and watch the data change shape at each stage.
 
@@ -43,7 +43,7 @@ The header keeps the preview honest about what you're seeing:
 
 ## Fresh After Every Run
 
-If the step you're previewing runs while the drawer is open, the preview **refreshes automatically once when the run completes** — so after a Run This Step, the drawer already shows the new data. If the output table didn't actually change, the drawer redraws instantly from its cache.
+If the step you're previewing runs while the drawer is open, the preview **refreshes automatically once when the run completes** — so after a Run This Step, the drawer already shows the new data. Returning to a step whose output hasn't changed reopens its preview without refetching.
 
 ## When You Need More: Table Explorer
 

--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -23,6 +23,8 @@ Versions are listed here as each July 2026 release ships.
 
 - **AI allocation cost-tracing over the REST API** — the full root-cause analysis (the plain-language headline plus the year-over-year baseline, anomaly, and data-freshness summary) can now be driven directly from the analyze REST API, not only through an MCP-connected AI agent.
 
+- **Data Preview drawer in the Visual Workflow Designer** — see a step's output data in place, without opening a new window. Hover a step and click the browse glyph (or right-click → **Preview Output Data**, or the eye icon on an Inspector output card) to dock a preview of the table's first 100 rows — typed columns, row and column counts, a selector for multi-output steps — at the bottom of the canvas. With the drawer open, clicking another step retargets the preview, the drawer refreshes itself when the previewed step finishes a run, and **Open in Table Explorer** escalates to the full explorer in one click. See [Preview Step Data](/guides/workflows/preview-step-data/).
+
 - **Directory Listing workflow step** — write a table listing the files in a document directory, with an optional file pattern (like `*.csv`) and an option to include subdirectories. Use it to drive downstream steps from whatever files are present. See [Directory Listing](/reference/workflow-steps/document/directory-listing/).
 
 - **Row Count Assert workflow step** — a data-quality gate that fails the workflow when two tables have different row counts, with a customizable failure message. Use it to confirm a transform kept every row or that a reconciliation didn't drop or duplicate records. See [Row Count Assert](/reference/workflow-steps/workflow-control/row-count-assert/).


### PR DESCRIPTION
## Summary

Customer docs for the new browse-anywhere **Data Preview drawer** in the Visual Workflow Designer (PlaidClient #1784 + plaid #6484): a new guide, cross-links from the Advanced Workflows guide, and a July 2026 release-notes entry.

## User-facing change?

- [x] Yes — customers will notice this
- [ ] No — internal/infrastructure only

**Customer summary:** Data Preview drawer: glance at any step's output data (first 100 rows, typed columns) right on the Visual Workflow Designer canvas — hover a step and click the browse glyph, click other steps to retarget, and escalate to Table Explorer in one click.

## Category

- [x] Added — new feature or capability
- [ ] Changed — modified existing behavior
- [ ] Fixed — bug fix users would notice
- [ ] Security — auth, data handling, vuln fix
- [ ] Deprecated — feature on its way out

## Testing

- `npm run build` passes locally (1,519 pages, Pagefind index built).
- New page renders at `/guides/workflows/preview-step-data/`; internal links target existing pages (`/guides/workflows/advanced-workflows/`, `/guides/data/table-explorer/`, `/guides/workflows/running-one-step-in-a-workflow/`).
- Behavior described matches the shipped feature as documented in PlaidClient #1784 (100-row preview, 150-column cap, multi-output selector, Esc precedence, auto-refresh on run completion, empty states).

## Files

- `src/content/docs/guides/workflows/preview-step-data.mdx` — new guide (open paths, retargeting, header readout, auto-refresh, Table Explorer escalation, empty/wide-table states).
- `src/content/docs/guides/workflows/advanced-workflows.mdx` — cross-links (right-click menu entry, Inspector output-card eye icon, Next Steps).
- `src/content/docs/releases/2026-07.mdx` — Added entry linking the guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)