### PR TITLE
docs(faq): Free plan is card-free (email verification only)

### DIFF
--- a/src/content/docs/get-started/faq.mdx
+++ b/src/content/docs/get-started/faq.mdx
@@ -185,9 +185,13 @@ PlaidCloud offers self-service trial workspaces, team plans, and enterprise plan
 
 For current pricing and plan details, see [plaidcloud.com](https://plaidcloud.com/) or contact your account team.
 
+### Do I Need a Credit Card to Sign Up?
+
+No — the **Free** plan requires only email verification. There's no credit card and no payment step; just verify your email and your workspace is created. (The paid **Starter** and **Team** plans offer an optional 7-day trial that does collect a card so it can convert automatically; **Free** is permanent and never asks for one.)
+
 ### What's the Free Trial Limit?
 
-Trial workspaces have time-limited access and usage limits appropriate for evaluating the platform. Specifics are shown during signup.
+The **Free** plan is permanent (no time limit) with usage limits appropriate for evaluating the platform. The separate 7-day **Starter/Team trials** give full access to those tiers for a week. Specifics are shown during signup.
 
 ### Can I Switch Plans Later?
 

--- a/src/content/docs/get-started/faq.mdx
+++ b/src/content/docs/get-started/faq.mdx
@@ -189,7 +189,7 @@ For current pricing and plan details, see [plaidcloud.com](https://plaidcloud.co
 
 No — the **Free** plan requires only email verification. There's no credit card and no payment step; just verify your email and your workspace is created. (The paid **Starter** and **Team** plans offer an optional 7-day trial that does collect a card so it can convert automatically; **Free** is permanent and never asks for one.)
 
-### What's the Free Trial Limit?
+### Are There Limits on the Free Plan?
 
 The **Free** plan is permanent (no time limit) with usage limits appropriate for evaluating the platform. The separate 7-day **Starter/Team trials** give full access to those tiers for a week. Specifics are shown during signup.
 


### PR DESCRIPTION
Companion to plaidcloud-cp-rest#333. Adds a 'Do I need a credit card?' FAQ and clarifies the permanent **Free** plan (no card, email verification only) vs the 7-day **Starter/Team trials** (which do collect a card). Draft until the card-free Free signup is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)