### PR TITLE
docs(rest_v2): document Import from curl

### DIFF
--- a/src/content/docs/guides/workflows/rest-request-step.mdx
+++ b/src/content/docs/guides/workflows/rest-request-step.mdx
@@ -62,6 +62,7 @@ When the workflow is started by a sensor or webhook, four trigger variables are 
 
 - **Send Test Request** fires the request with your current settings and shows the live response inline, so you can confirm the call works before saving.
 - **Copy as curl** copies an equivalent curl command to the clipboard for sharing or debugging (with secrets masked).
+- **Import from curl** does the reverse: paste a curl command — for example, a browser's "Copy as cURL" — and its method, URL, headers, and body replace the current request. Basic-auth (`-u`) becomes an Authorization header; unsupported options are reported rather than silently dropped. Use **Undo replace** to restore the previous values.
 
 ## Route the Response
 

--- a/src/content/docs/reference/workflow-steps/general/rest-request.md
+++ b/src/content/docs/reference/workflow-steps/general/rest-request.md
@@ -21,7 +21,7 @@ For a full walkthrough, see the [REST Request step guide](/guides/workflows/rest
 * **Endpoint** — path (with a connection) or full URL.
 * **Headers** / **Query Parameters** — name/value rows with an on/off toggle.
 * **Body** — request payload (JSON, form, or raw).
-* **Send Test Request** / **Copy as curl** — fire the request and inspect the response inline, or copy an equivalent curl command (secrets masked).
+* **Send Test Request** / **Copy as curl** / **Import from curl** — fire the request and inspect the response inline; copy an equivalent curl command (secrets masked); or paste a curl command to fill the method, URL, headers, and body.
 * **Send** — `One request` (default), or `One request per table row` to fan the request out over a driver table.
 
 When **Send** is `One request per table row`, pick a **Driver Table** (choose it with the table picker or type a name) and use `{{row.column}}` tokens in the endpoint, query, headers, or body to substitute each row's values. Optional: **Driver Filter** (a SQL `WHERE` clause), **Key Columns** (carried onto each output row), **Row Limit**, **Concurrency**, and **Continue on error** (record a failed row and warn instead of aborting). Fan-out writes to the target table; it can't capture to variables.

--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -33,6 +33,8 @@ Versions are listed here as each July 2026 release ships.
 
 - **REST Request: send one request per table row** — a REST Request step can now fan a call out over the rows of a driver table, one request per row. Set **Send** to "One request per table row", pick the driver table with a table picker, and use `{{row.column}}` tokens in the endpoint, query, headers, or body to substitute each row's values — with a row filter, key columns carried onto the results, a concurrency control, and a continue-on-error option. See [Send One Request Per Table Row](/guides/workflows/rest-request-step/#send-one-request-per-table-row).
 
+- **REST Request: import from curl** — paste a curl command (for example, a browser's "Copy as cURL") into a REST Request step and its method, URL, headers, and body fill the request for you — the inverse of the existing "Copy as curl" button. See [Test the Request](/guides/workflows/rest-request-step/#test-the-request).
+
 - **Directory Listing workflow step** — write a table listing the files in a document directory, with an optional file pattern (like `*.csv`) and an option to include subdirectories. Use it to drive downstream steps from whatever files are present. See [Directory Listing](/reference/workflow-steps/document/directory-listing/).
 
 - **Row Count Assert workflow step** — a data-quality gate that fails the workflow when two tables have different row counts, with a customizable failure message. Use it to confirm a transform kept every row or that a reconciliation didn't drop or duplicate records. See [Row Count Assert](/reference/workflow-steps/workflow-control/row-count-assert/).


### PR DESCRIPTION
## What

Documents the new **Import from curl** button (plaid#6524) in the REST Request guide and step reference, and adds a What's New entry.

## Files
- `guides/workflows/rest-request-step.mdx` — Import from curl bullet under **Test the Request**.
- `reference/workflow-steps/general/rest-request.md` — Import from curl in the Send/Copy line.
- `releases/2026-07.mdx` — What's New entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)