### PR TITLE
docs(rest_v2): document fan-out per-row failure detail in the run log

### DIFF
--- a/src/content/docs/guides/workflows/rest-request-step.mdx
+++ b/src/content/docs/guides/workflows/rest-request-step.mdx
@@ -102,7 +102,7 @@ By default the step sends **one** request. To call an API once per row of a tabl
 - **Row Limit** and **Concurrency** — the maximum number of rows to process and how many requests run at once.
 - **Max req/sec** *(optional)* — cap how fast requests start across all workers so a burst doesn't trip the API's rate limit (0 = no limit). This is independent of **Concurrency**: concurrency bounds how many run at once, while Max req/sec paces how often a new one starts.
 - **Add Idempotency-Key header** *(optional)* — for a single (No Paging) POST, PUT, or PATCH request per row, sends a stable `Idempotency-Key` header derived from each row so that re-running the step doesn't double-create records on an idempotency-aware API (the same row always sends the same key, so the API dedupes the repeat). It's skipped, with a warning, for GET/HEAD/DELETE or a paging mode. A request that already sets its own `Idempotency-Key` keeps it.
-- **Continue on error** — when on, a row that fails is recorded and the step ends with a warning instead of aborting on the first failure.
+- **Continue on error** — when on, a row that fails is recorded and the step ends with a warning instead of aborting on the first failure. The run log names the first few failed rows (by their key columns) and the error each hit, so you can tell which rows failed and why.
 
 Use `{{row.column}}` tokens anywhere in the endpoint, query, headers, or body to substitute that row's values — for example `GET /customers/{{row.customer_id}}`. Each row's response records are parsed into the target table (with any key columns prepended); with **Dump raw JSON** on, you get one row per request instead.
 

--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -47,6 +47,8 @@ Versions are listed here as each July 2026 release ships.
 
 ## Changed
 
+- **REST Request: see which fan-out rows failed.** When a table fan-out has failures, the run log now names the first few failed driver rows (by their key columns) and the error each hit, instead of only counting them — so you can debug which rows failed and why, including in parse mode where failed rows are dropped from the output. See [Send One Request Per Table Row](/guides/workflows/rest-request-step/#send-one-request-per-table-row).
+
 - **REST Request: honor rate limits.** REST Request steps now back off and retry on HTTP 429 (rate limited) and wait the interval a `Retry-After` header asks for (capped at 2 minutes), instead of failing immediately — for idempotent methods only (a POST/PUT/PATCH is still sent once). Applies to single requests and the table fan-out. See [Route the Response](/guides/workflows/rest-request-step/#route-the-response).
 
 - **What-if ("forward impact") estimates are now real per-target numbers instead of upper bounds.** A hypothetical change is split across the results that share a driver by each one's current share of the pool, so a fan-out's figures **add up** rather than each showing the whole change, and you can scope the estimate to a single target. Pointed at a driver or basis table rather than the input pool, the agent now declines the estimate and explains why.


### PR DESCRIPTION
Documents that fan-out failures now name the failed driver rows + errors in the run log. Pairs with the plaid backend PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)