### PR TITLE
docs(rest_v2): document the Test Paging pagination preview

### DIFF
--- a/src/content/docs/guides/workflows/rest-request-step.mdx
+++ b/src/content/docs/guides/workflows/rest-request-step.mdx
@@ -60,7 +60,8 @@ When the workflow is started by a sensor or webhook, four trigger variables are 
 
 ### Test the Request
 
-- **Send Test Request** fires the request with your current settings and shows the live response inline, so you can confirm the call works before saving.
+- **Send Test Request** fires the request with your current settings and shows the live response inline, so you can confirm the call works before saving. (This sends a single request; pagination runs only when the step executes.)
+- **Test Paging** follows the configured pagination and reports how many records come back across pages (up to a preview cap), so you can confirm the paging mode and its params/paths chain correctly before a full run. Only enough pages fire to reach the cap.
 - **Copy as curl** copies an equivalent curl command to the clipboard for sharing or debugging (with secrets masked).
 - **Import from curl** does the reverse: paste a curl command — for example, a browser's "Copy as cURL" — and its method, URL, headers, and body replace the current request. Basic-auth (`-u`) becomes an Authorization header; unsupported options are reported rather than silently dropped. Use **Undo replace** to restore the previous values.
 

--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -37,6 +37,8 @@ Versions are listed here as each July 2026 release ships.
 
 - **REST Request: test the first fan-out row** — when a REST Request step fans out over a table, a new **Test Row 1** button reads the first driver row, substitutes its values into the request, and fires that one call so you can confirm the fan-out is right before running it over every row. See [Send One Request Per Table Row](/guides/workflows/rest-request-step/#send-one-request-per-table-row).
 
+- **REST Request: preview pagination** — a **Test Paging** button follows the configured pagination and reports how many records come back across pages (up to a preview cap), so you can confirm the paging mode and its params/paths chain correctly before a full run. See [Test the Request](/guides/workflows/rest-request-step/#test-the-request).
+
 - **REST Request: rate-limit the fan-out** — a **Max req/sec** control caps how fast requests start across all workers, so a burst of concurrent driver rows doesn't trip an API's rate limit. It's independent of concurrency (how many run at once); 0 means no limit. See [Send One Request Per Table Row](/guides/workflows/rest-request-step/#send-one-request-per-table-row).
 
 - **REST Request: idempotent POST fan-outs** — turn on **Add Idempotency-Key header** so a fan-out that POSTs (or PUTs/PATCHes) one request per row sends a stable per-row `Idempotency-Key`. Re-running the step then won't double-create records on an idempotency-aware API — each row always sends the same key, so the API dedupes the repeat. See [Send One Request Per Table Row](/guides/workflows/rest-request-step/#send-one-request-per-table-row).


### PR DESCRIPTION
Documents the new Test Paging button (follows pagination, reports records across pages up to a preview cap). Pairs with the plaid backend PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)