### PR TITLE
docs(rest_v2): document the fan-out resolved-request Preview

### DIFF
--- a/src/content/docs/guides/workflows/rest-request-step.mdx
+++ b/src/content/docs/guides/workflows/rest-request-step.mdx
@@ -107,7 +107,7 @@ By default the step sends **one** request. To call an API once per row of a tabl
 
 Use `{{row.column}}` tokens anywhere in the endpoint, query, headers, or body to substitute that row's values — for example `GET /customers/{{row.customer_id}}`. Each row's response records are parsed into the target table (with any key columns prepended); with **Dump raw JSON** on, you get one row per request instead.
 
-**Test Row 1** reads the first driver row (honoring the driver filter), substitutes its values into the endpoint, query, headers, and body, and fires that one request — so you can confirm the fan-out is wired correctly before running it over every row. The response is shown inline like **Send Test Request**, along with the driver-row values that were used.
+**Test Row 1** reads the first driver row (honoring the driver filter), substitutes its values into the endpoint, query, headers, and body, and fires that one request — so you can confirm the fan-out is wired correctly before running it over every row. The response is shown inline like **Send Test Request**, along with the driver-row values that were used. The **Preview** tab likewise resolves the first driver row's `{{row.column}}` values in table mode, so you can read the exact first request without firing it.
 
 <Aside type="note">One request per table row writes to a table — it can't capture to workflow variables. The response destination stays **Table**.</Aside>
 

--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -37,6 +37,8 @@ Versions are listed here as each July 2026 release ships.
 
 - **REST Request: test the first fan-out row** — when a REST Request step fans out over a table, a new **Test Row 1** button reads the first driver row, substitutes its values into the request, and fires that one call so you can confirm the fan-out is right before running it over every row. See [Send One Request Per Table Row](/guides/workflows/rest-request-step/#send-one-request-per-table-row).
 
+- **REST Request: preview the resolved fan-out request** — in table (fan-out) mode the **Preview** tab now resolves the first driver row's `{{row.column}}` values, so you see the exact first request the run will send without firing it. See [Send One Request Per Table Row](/guides/workflows/rest-request-step/#send-one-request-per-table-row).
+
 - **REST Request: preview pagination** — a **Test Paging** button follows the configured pagination and reports how many records come back across pages (up to a preview cap), so you can confirm the paging mode and its params/paths chain correctly before a full run. See [Test the Request](/guides/workflows/rest-request-step/#test-the-request).
 
 - **REST Request: rate-limit the fan-out** — a **Max req/sec** control caps how fast requests start across all workers, so a burst of concurrent driver rows doesn't trip an API's rate limit. It's independent of concurrency (how many run at once); 0 means no limit. See [Send One Request Per Table Row](/guides/workflows/rest-request-step/#send-one-request-per-table-row).


### PR DESCRIPTION
Documents that the Preview tab resolves driver row 1 in table mode. Pairs with the plaid backend PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)