### PR TITLE
Document REST Request draft restore

### DIFF
--- a/src/content/docs/guides/workflows/rest-request-step.mdx
+++ b/src/content/docs/guides/workflows/rest-request-step.mdx
@@ -13,6 +13,8 @@ The **REST Request** step calls a REST API as one step in a workflow. It's a sin
 
 You choose where the response goes. By default it's parsed into a **table**. Alternatively, the step can capture the response into **workflow variables** so a later step can branch on the status code or read a value out of the body.
 
+If you close or reload the browser before saving, the editor keeps a local draft in that browser. Reopen the same step and choose **Restore** when prompted to recover the unsaved request settings.
+
 <Aside type="note">The REST Request step replaces the older REST-flavored steps with one unified step. Use it for new work; existing REST steps keep running.</Aside>
 
 ## Before You Start

--- a/src/content/docs/reference/workflow-steps/general/rest-request.md
+++ b/src/content/docs/reference/workflow-steps/general/rest-request.md
@@ -11,6 +11,8 @@ The **REST Request** step calls a REST API and routes the response to a target t
 
 For a full walkthrough, see the [REST Request step guide](/guides/workflows/rest-request-step/).
 
+While you edit, the browser keeps a local draft for the step. If you close or reload before saving, reopening the step offers to restore that unsaved draft.
+
 ## Configuration
 
 ### Request

--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -41,6 +41,8 @@ Versions are listed here as each July 2026 release ships.
 
 - **REST Request: insert driver-row columns** — after you pick a driver table for a fan-out request, the endpoint and body variable insert menus include that table's columns as `{{row.column}}` tokens. See [Send One Request Per Table Row](/guides/workflows/rest-request-step/#send-one-request-per-table-row).
 
+- **REST Request: restore unsaved edits** — the step editor now keeps a local browser draft while you edit. If you close or reload before saving, reopening the same step offers to restore the unsaved request settings. See [REST Request Step](/guides/workflows/rest-request-step/).
+
 - **REST Request: preview pagination** — a **Test Paging** button follows the configured pagination and reports how many records come back across pages (up to a preview cap), so you can confirm the paging mode and its params/paths chain correctly before a full run. See [Test the Request](/guides/workflows/rest-request-step/#test-the-request).
 
 - **REST Request: rate-limit the fan-out** — a **Max req/sec** control caps how fast requests start across all workers, so a burst of concurrent driver rows doesn't trip an API's rate limit. It's independent of concurrency (how many run at once); 0 means no limit. See [Send One Request Per Table Row](/guides/workflows/rest-request-step/#send-one-request-per-table-row).


### PR DESCRIPTION
## Summary
- document local REST Request draft restore in the workflow guide
- add the behavior to the REST Request step reference
- add a July 2026 release note

## Validation
- git diff --check
- npm run build