### PR TITLE
Document REST request token highlighting

### DIFF
--- a/src/content/docs/guides/workflows/rest-request-step.mdx
+++ b/src/content/docs/guides/workflows/rest-request-step.mdx
@@ -56,6 +56,8 @@ For an imported source, choose **Load Catalog** to list the available endpoints,
 
 Anywhere in the endpoint, headers, query values, or body you can inject a variable at run time by wrapping its name in double braces: `{{name}}`. You can also write `{{var.name}}` for a workflow-run variable or `{{project_var.name}}` for a project variable — the prefix is optional and both resolve the same name.
 
+The editor highlights detected `{{...}}` tokens in the endpoint, header and query tables, and body editor so substitutions are easy to spot before you test or save.
+
 Only double braces are substituted, so a single `{` or `}` in a JSON body is left exactly as written — you can freely mix variables into JSON, for example `{"id": "{{var.order_id}}", "qty": 1}`. An unknown variable name fails the step so a typo surfaces immediately.
 
 When the workflow is started by a sensor or webhook, four trigger variables are also available: `{{trigger_sensor_id}}`, `{{trigger_sensor_type}}`, `{{trigger_fired_at}}`, and `{{trigger_payload_json}}` (the inbound payload as a JSON string — parse it in a later step to reach nested fields). On a manual or scheduled run these resolve to an empty string.

--- a/src/content/docs/reference/workflow-steps/general/rest-request.md
+++ b/src/content/docs/reference/workflow-steps/general/rest-request.md
@@ -32,6 +32,8 @@ When **Send** is `One request per table row`, pick a **Driver Table** (choose it
 
 `{{name}}` references to workflow variables (also `{{var.name}}` / `{{project_var.name}}`) are substituted in the endpoint, headers, query values, and body at run time. Only double braces are substituted, so single braces in a JSON body are left literal. Sensor/webhook runs also expose `{{trigger_sensor_id}}`, `{{trigger_sensor_type}}`, `{{trigger_fired_at}}`, and `{{trigger_payload_json}}` (empty on non-triggered runs).
 
+The editor highlights detected `{{...}}` tokens in the endpoint, header and query tables, and body editor.
+
 **Retries** apply only to idempotent methods (GET/HEAD/OPTIONS/DELETE); a POST/PUT/PATCH is always sent once so a non-idempotent body is never re-sent. **Timeout (s)** is the per-request limit, capped at 600.
 
 ### Response Destination

--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -41,6 +41,8 @@ Versions are listed here as each July 2026 release ships.
 
 - **REST Request: insert driver-row columns** — after you pick a driver table for a fan-out request, the endpoint and body variable insert menus include that table's columns as `{{row.column}}` tokens. See [Send One Request Per Table Row](/guides/workflows/rest-request-step/#send-one-request-per-table-row).
 
+- **REST Request: highlight variable tokens** — the editor now highlights detected `{{...}}` tokens in endpoints, header and query rows, and request bodies so substitutions are easier to review before testing or saving. See [Variable Substitution](/guides/workflows/rest-request-step/#variable-substitution).
+
 - **REST Request: restore unsaved edits** — the step editor now keeps a local browser draft while you edit. If you close or reload before saving, reopening the same step offers to restore the unsaved request settings. See [REST Request Step](/guides/workflows/rest-request-step/).
 
 - **REST Request: confirm untested saves** — if you change the outbound request fields and save before a successful test request, PlaidCloud asks you to confirm. In fan-out mode, **Test Row 1** is the test that clears the warning. See [Test the Request](/guides/workflows/rest-request-step/#test-the-request).


### PR DESCRIPTION
## Summary
- document REST Request token highlighting in the workflow guide
- update the REST Request reference
- add the July 2026 release note

## Validation
- git diff --check
- /Users/inviscid/Projects/plaidcloud-docs/node_modules/.bin/astro build --root /Users/inviscid/Projects/plaidcloud-docs/.worktrees/rest-v2-token-highlight-docs (passed; existing category-entry warnings)