### PR TITLE
Document Panel app local builds

### DIFF
--- a/src/content/docs/guides/panel-apps/creating.md
+++ b/src/content/docs/guides/panel-apps/creating.md
@@ -83,7 +83,12 @@ PlaidCloud installs these with `pip` when it builds the image.
 
 ### Set the Theme: Light, Dark, or a Toggle
 
-Server apps render in PlaidCloud's modern **Fast** design by default — a clean, Fluent-style look applied platform-wide, so you get it with no code. What you control, in your app, is the **theme**: light, dark, or a switch the viewer can flip.
+Server apps render in PlaidCloud's modern **Fast** design by default — a clean, Fluent-style look applied platform-wide. In the publish dialog, **Design** controls that platform layer:
+
+- **FAST** — the PlaidCloud default. Use it for new apps and apps built with Fast templates.
+- **Default** — Panel's default styling. Use it when an existing app's CSS or visuals break under FAST.
+
+What you control in your app code is the **theme**: light, dark, or a switch the viewer can flip.
 
 The theme is a property of the **template** you serve. The Fast templates — `FastListTemplate` (a single column) and `FastGridTemplate` (a responsive grid) — take two settings for it:
 
@@ -150,14 +155,95 @@ Your repository must be reachable through a **git connection** in PlaidCloud. If
 
      > Fewer resources (lower CPU / memory) let the app schedule and cold-start faster.
 
+   - **Design** — choose **FAST** for PlaidCloud's modern design, or **Default** if the app's CSS expects Panel's default styling.
    - **Idle (minutes)** — how long the app stays warm with no traffic before it scales back to zero. The default is 5 minutes.
    - **Allow Public Access** — tick to allow unauthenticated access; otherwise viewers must sign in to your tenant.
 5. Under **Advanced (Embedded Serving)** — optional. By default the app serves only from your PlaidCloud tenant. To embed it in another site, click **Add Domain** and enter each domain allowed to load it, one per row — a host only, no scheme or path (for example, `example.com` or `app.example.com:8443`). Leave the list empty unless you're embedding the app elsewhere.
 6. Click **Publish**.
 
-After you publish, the app **builds** — its **Status** shows in the list and updates automatically. See [Using a Panel App](/guides/panel-apps/using/) for what the statuses mean and how to open the app once it is ready.
+After you publish, the app **builds** — its **Status** shows in the list and updates automatically. See [Using a Panel App](/guides/panel-apps/using/) for what the statuses mean, how to open the app once it is ready, and how to trigger a rebuild without unpublishing.
 
 > The app's URL works only once its build status is **Ready**, and the first request after it has been idle spins it up (~15 seconds).
+
+### Advanced: Match PlaidCloud Locally
+
+Technical users can build and test the app with the same inputs PlaidCloud uses. This is the closest local check before publishing or clicking **Rebuild**.
+
+PlaidCloud builds from the selected git branch with this generated Dockerfile. Use the same content locally as `Dockerfile.plaidcloud-panel`:
+
+```dockerfile
+FROM us-docker.pkg.dev/plaidcloud-build/panel-base/platform-panel-base:0.5.1
+USER root
+COPY . /app
+RUN if [ -f /app/requirements.txt ]; then pip install --no-cache-dir -r /app/requirements.txt; fi
+USER 10001
+```
+
+To match the server build:
+
+1. Check out the same branch you select in **Branch**.
+2. Run the build from the repository root, so `COPY . /app` matches PlaidCloud.
+3. Put optional dependencies in `requirements.txt` at the repository root.
+4. Use the same entry-point path you select in **Entry Point**.
+
+```sh
+docker build \
+  -f Dockerfile.plaidcloud-panel \
+  -t local-panel-app:plaidcloud \
+  .
+```
+
+The deployed image does not override the base image entry point. It runs `panel serve` from environment variables injected by PlaidCloud. Test the built image with the same runtime contract:
+
+```sh
+docker run --rm \
+  --cpus 0.5 \
+  --memory 512m \
+  -p 5006:5006 \
+  -e APP_PATH=/app/app.py \
+  -e PANEL_PREFIX=/serve/local \
+  -e PANEL_PORT=5006 \
+  -e PANEL_ORIGIN=localhost:5006 \
+  -e PANEL_KEEP_ALIVE_MS=25000 \
+  -e PLAID_PANEL_DESIGN=fast \
+  local-panel-app:plaidcloud
+```
+
+Open `http://localhost:5006/serve/local/`.
+
+Match the publish dialog settings when you test:
+
+- **Entry Point** maps to `APP_PATH=/app/<entry-point>`.
+- **CPU** and **Memory** map to Docker's `--cpus` and `--memory` limits.
+- **Design: FAST** maps to `PLAID_PANEL_DESIGN=fast`.
+- **Design: Default** means omit `PLAID_PANEL_DESIGN`.
+- **Idle (minutes)** maps to the deployed scale-down window. It is not enforced by local Docker, but the app still uses the same Panel websocket keepalive and session cleanup settings.
+- **Embedded Serving** domains map to `PANEL_ORIGIN`; use a space-separated list if you need to test more than one host.
+
+If you do not need a container, you can still test the serve layer from a local Python environment. Install the same `requirements.txt`, set the platform environment variables, then run `panel serve` with the same flags the deployed image uses.
+
+```sh
+export APP_PATH=app.py
+export PANEL_PREFIX=/serve/local
+export PANEL_PORT=5006
+export PANEL_ORIGIN=localhost:5006
+export PANEL_KEEP_ALIVE_MS=25000
+export PLAID_PANEL_DESIGN=fast
+
+panel serve "$APP_PATH" \
+  --address 0.0.0.0 \
+  --port "$PANEL_PORT" \
+  --prefix "$PANEL_PREFIX" \
+  --allow-websocket-origin "$PANEL_ORIGIN" \
+  --num-procs 1 \
+  --keep-alive "$PANEL_KEEP_ALIVE_MS" \
+  --unused-session-lifetime 15000 \
+  --index "$(basename "$APP_PATH" .py)"
+```
+
+Open `http://localhost:5006/serve/local/`.
+
+Use `PLAID_PANEL_DESIGN=fast` to match the default deployed look. To test the publish dialog's **Default** design option, leave `PLAID_PANEL_DESIGN` unset and run the same command. Keep `PANEL_PREFIX`, `PANEL_ORIGIN`, `--keep-alive`, and `--unused-session-lifetime` in place; those are part of the deployed runtime contract.
 
 ## Creating a WASM App
 

--- a/src/content/docs/guides/panel-apps/using.md
+++ b/src/content/docs/guides/panel-apps/using.md
@@ -1,11 +1,11 @@
 ---
 title: Using a Panel App
-description: Track build status, open, view logs and usage metrics for, edit, and remove published HoloViz Panel apps from the My Panel Apps screen in PlaidCloud.
+description: Track build status, open, rebuild, view logs and usage metrics for, edit, and remove published HoloViz Panel apps from the My Panel Apps screen in PlaidCloud.
 sidebar:
   order: 3
 ---
 
-Every published app appears on the **My Panel Apps** screen with its **Runtime**, **Status**, **Slug**, and timestamps. The leftmost column opens the app; the remaining row icons let you edit it, remove it, and — for server apps — view its logs. The open icon reflects the app's runtime, so WASM and server apps are easy to tell apart at a glance.
+Every published app appears on the **My Panel Apps** screen with its **Runtime**, **Status**, **Slug**, and timestamps. The leftmost column opens the app; the remaining row icons let you edit it, remove it, and — for server apps — rebuild it, view its logs, and view usage metrics. The open icon reflects the app's runtime, so WASM and server apps are easy to tell apart at a glance.
 
 ## Build Status (Server Apps)
 
@@ -16,6 +16,12 @@ A server app's **Status** column tracks its build, and the list refreshes on its
 - **Failed** — the build did not complete. Check the entry point and branch, then edit the app to republish.
 
 WASM apps have no build step and are available as soon as they are published.
+
+## Rebuilding a Server App
+
+Click the **Rebuild** icon on a server app's row to rebuild and redeploy it without changing its settings. The app's status returns to **Building…** while PlaidCloud builds the same branch and entry point again, then switches back to **Ready** when the new build is live.
+
+Use **Rebuild** after dependency changes, base-image updates, or a transient failed build. Editing and saving a server app also rebuilds it, but a rebuild does not require opening the edit form.
 
 ## Opening an App
 
@@ -30,7 +36,7 @@ A server app scales to zero when idle to save resources, so the first open after
 
 ### Appearance
 
-Server Panel apps use PlaidCloud's modern **Fast** design and open in the **light theme** by default. The theme — light, dark, or a light/dark switch viewers can flip — is something you set in your app's template, not on this screen. See [Set the Theme](/guides/panel-apps/creating/#set-the-theme-light-dark-or-a-toggle) in the Creating guide for the patterns. If your app's tables or custom styling are built for a light background, keep it pinned to light.
+Server Panel apps use PlaidCloud's modern **Fast** design by default, but the app's **Design** setting can switch it back to Panel's **Default** styling when existing CSS depends on it. The theme — light, dark, or a light/dark switch viewers can flip — is something you set in your app's template. See [Set the Theme](/guides/panel-apps/creating/#set-the-theme-light-dark-or-a-toggle) in the Creating guide for the patterns. If your app's tables or custom styling are built for a light background, keep it pinned to light.
 
 ## Viewing Logs (Server Apps)
 
@@ -74,7 +80,7 @@ Below the summary you get a breakdown **per user** and **per day**, so you can s
 
 Click the **pencil** icon on an app's row to edit it. The edit form matches the app's runtime.
 
-For a **server** app you can change the name, slug, branch, entry point, CPU, memory, idle window, public flag, embedded-serving domains, and memo. The **Git Connection** is fixed once the app is created and is shown read-only. Saving rebuilds the app — its status returns to **Building…** until the new build is ready.
+For a **server** app you can change the name, slug, branch, entry point, CPU, memory, design, idle window, public flag, embedded-serving domains, and memo. The **Git Connection** is fixed once the app is created and is shown read-only. Saving rebuilds the app — its status returns to **Building…** until the new build is ready.
 
 ## Removing an App
 

--- a/src/content/docs/releases/2026-06.mdx
+++ b/src/content/docs/releases/2026-06.mdx
@@ -58,7 +58,9 @@ description: Multi-agent AI assistant, 140+ data connectors, table snapshots, a 
 - **Smoother dashboards and user sync** — dashboard rendering fixes and tighter synchronization of users and roles with the analytics layer.
 - **More resilient connections** — self-healing for the caching layer and background-processing fixes reduce stalls and improve overall responsiveness.
 - **A loading screen for server Panel apps** — opening a server-side Panel app that has gone idle now shows a branded PlaidCloud loading screen while it spins up, instead of a blank tab, and turns into a clear "This app didn’t start" message with a retry if it can't launch.
-- **A modern look and theme control for server Panel apps** — server Panel apps now use a modern Fast design by default, and you set the theme in your app — light, dark, or a light/dark toggle viewers can flip — through the template you serve. Tables and custom styling built for a light background should stay on light.
+- **Rebuild server Panel apps from the app list** — use the new **Rebuild** row action to rebuild and redeploy a server app without unpublishing and republishing it.
+- **A modern look and appearance control for server Panel apps** — server Panel apps now use a modern Fast design by default, can switch back to Panel's Default design when existing CSS needs it, and let you set the theme in your app — light, dark, or a light/dark toggle viewers can flip — through the template you serve. Tables and custom styling built for a light background should stay on light.
+- **Local build controls for server Panel apps** — the Panel app guide now lists the same `PANEL_*` environment variables and `panel serve` flags PlaidCloud uses when it deploys an app, so advanced users can reproduce the deployed runtime locally.
 
 ## Fixed
 

--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -5,7 +5,9 @@ description: Self-service PlaidCloud Managed Buckets, plus a big honesty-and-acc
 
 ## Releases Shipped
 
-Versions are listed here as each July 2026 release ships.
+| Version | Released |
+|---|---|
+| v5.11.0 | 2026-07-09 |
 
 ## Added
 

--- a/src/content/docs/releases/index.mdx
+++ b/src/content/docs/releases/index.mdx
@@ -13,7 +13,7 @@ Monthly summaries of changes shipped to PlaidCloud tenants. Months with substant
 	<LinkCard
 		title="July 2026"
 		href="/releases/2026-07/"
-		description="PlaidCloud Managed Buckets — self-service fully managed file storage for Document; AI allocation cost-tracing honesty pass — confidence signals, real per-target what-if estimates, dimension allocations explained."
+		description="v5.11.0 · PlaidCloud Managed Buckets, ML workflow steps, REST Request fan-out, support attachments, and AI allocation cost-tracing confidence signals."
 	/>
 	<LinkCard
 		title="June 2026"


### PR DESCRIPTION
## Summary
- document the server Panel app Design setting and Rebuild action
- add an advanced local build section matching the generated PlaidCloud Dockerfile and runtime env
- update June Panel app notes and July v5.11.0 release listing/index summary

## Why
Advanced users need a local build/test path that matches PlaidCloud deployment parameters, and the user-facing docs should describe rebuild, design choice, and the July release version accurately.

## Validation
- git diff --check origin/main...HEAD