### PR TITLE
Document REST Request connection editor shortcut

### DIFF
--- a/src/content/docs/guides/workflows/rest-request-step.mdx
+++ b/src/content/docs/guides/workflows/rest-request-step.mdx
@@ -43,7 +43,7 @@ For an imported source, choose **Load Catalog** to list the available endpoints,
 
 ### Connection, Method, and Endpoint
 
-- **Connection** — the REST connection to authenticate with. Leave it unset to call a fully-qualified URL directly.
+- **Connection** — the REST connection to authenticate with. Leave it unset to call a fully-qualified URL directly. Use the edit shortcut beside the picker to view or edit the selected connection without leaving the request editor.
 - **Method** — `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, or `HEAD`.
 - **Endpoint** — the path (when a connection is set) or a full URL.
 

--- a/src/content/docs/reference/workflow-steps/general/rest-request.md
+++ b/src/content/docs/reference/workflow-steps/general/rest-request.md
@@ -18,7 +18,7 @@ While you edit, the browser keeps a local draft for the step. If you close or re
 ### Request
 
 * **Endpoint Source** — `Manual`, `Postman collection (file/URL)`, `OpenAPI / Swagger (URL/file)`, or `HAR archive (file)`. Use **Load Catalog** to list and pick an endpoint from an imported source.
-* **Connection** *(optional)* — a REST connection for auth and base URL; omit to call a full URL directly.
+* **Connection** *(optional)* — a REST connection for auth and base URL; omit to call a full URL directly. The edit shortcut beside the picker opens the selected connection editor for viewing or editing.
 * **Method** — `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`.
 * **Endpoint** — path (with a connection) or full URL.
 * **Headers** / **Query Parameters** — name/value rows with an on/off toggle.

--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -43,6 +43,8 @@ Versions are listed here as each July 2026 release ships.
 
 - **REST Request: highlight variable tokens** — the editor now highlights detected `{{...}}` tokens in endpoints, header and query rows, and request bodies so substitutions are easier to review before testing or saving. See [Variable Substitution](/guides/workflows/rest-request-step/#variable-substitution).
 
+- **REST Request: edit the selected connection in place** — the request editor now has a shortcut beside the connection picker that opens the selected connection's native editor, then returns you to the request editor with the same connection selected. See [Build the Request](/guides/workflows/rest-request-step/#build-the-request).
+
 - **REST Request: restore unsaved edits** — the step editor now keeps a local browser draft while you edit. If you close or reload before saving, reopening the same step offers to restore the unsaved request settings. See [REST Request Step](/guides/workflows/rest-request-step/).
 
 - **REST Request: confirm untested saves** — if you change the outbound request fields and save before a successful test request, PlaidCloud asks you to confirm. In fan-out mode, **Test Row 1** is the test that clears the warning. See [Test the Request](/guides/workflows/rest-request-step/#test-the-request).


### PR DESCRIPTION
## Summary
- document the REST Request connection picker shortcut in the workflow guide
- update the REST Request step reference and July release notes

## Validation
- git diff --check
- /Users/inviscid/Projects/plaidcloud-docs/node_modules/.bin/astro build --root /Users/inviscid/Projects/plaidcloud-docs/.worktrees/rest-v2-edit-connection-docs

## Notes
- The paired client PR is PlaidCloud/PlaidClient#1808.