### PR TITLE
Match REST Request fan-out guide to the native form UI

### DIFF
--- a/src/content/docs/guides/workflows/rest-request-step.mdx
+++ b/src/content/docs/guides/workflows/rest-request-step.mdx
@@ -113,9 +113,9 @@ By default the step sends **one** request. To call an API once per row of a tabl
 
 Use `{{row.column}}` tokens anywhere in the endpoint, query, headers, or body to substitute that row's values — for example `GET /customers/{{row.customer_id}}`. Each row's response records are parsed into the target table (with any key columns prepended); with **Dump raw JSON** on, you get one row per request instead.
 
-The variable insert buttons in the endpoint and body fields include the selected driver table's columns, so you can insert `{{row.customer_id}}`-style tokens from the menu instead of typing column names by hand.
+The **Insert `{{row.column}}`** menu lists the selected driver table's columns, so you can drop a `{{row.customer_id}}`-style token into the endpoint or body — whichever field you edited last — instead of typing column names by hand. As you edit, the form also lists the `{{row.column}}` tokens you've used and highlights in red any that aren't a column of the driver table, so typos are caught before you run the step.
 
-**Test Row 1** reads the first driver row (honoring the driver filter), substitutes its values into the endpoint, query, headers, and body, and fires that one request — so you can confirm the fan-out is wired correctly before running it over every row. The response is shown inline like **Send Test Request**, along with the driver-row values that were used. The **Preview** tab likewise resolves the first driver row's `{{row.column}}` values in table mode, so you can read the exact first request without firing it.
+**Test Row 1** reads the first driver row (honoring the driver filter), substitutes its values into the endpoint, query, headers, and body, and fires that one request — so you can confirm the fan-out is wired correctly before running it over every row. The response is shown inline like **Send Test Request**, along with the driver-row values that were used. **Preview Row 1** likewise resolves the first driver row's `{{row.column}}` values and shows the resolved request without firing it.
 
 <Aside type="note">One request per table row writes to a table — it can't capture to workflow variables. The response destination stays **Table**.</Aside>
 


### PR DESCRIPTION
Corrects drift in the REST Request fan-out guide so it matches the shipped native step form:

- The row-1 resolved preview is now a **Preview Row 1** button (PlaidClient #1821), not a "Preview tab".
- Token insertion is a single **Insert {{row.column}}** menu that drops a token into whichever of the endpoint/body you edited last (PlaidClient #1818).
- Notes the token-usage hint that highlights `{{row.column}}` tokens which aren't columns of the driver table (PlaidClient #1819).

Guide-only wording fix; no new pages. Test Paging and the row preview were already described from the earlier phase — this aligns the exact UI names/behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)