### PR TITLE
Add end-to-end "Deploy a Panel App from PlaidCloud Git" guide + close the docs seam

### DIFF
--- a/src/content/docs/guides/connections/plaidcloud-git.mdx
+++ b/src/content/docs/guides/connections/plaidcloud-git.mdx
@@ -63,6 +63,7 @@ From then on, every push to that branch on your managed Git server rebuilds the 
 
 ## Related
 
+- [Deploy a Panel App From PlaidCloud Git](/guides/panel-apps/deploy-from-git/) — the end-to-end path from repository to a served app.
 - [Create and Manage a Connection](/guides/connections/create-connection/) — the shared form, environments, testing, and access controls.
 - [Creating a Panel App](/guides/panel-apps/creating/) — publish and rebuild a Server Panel app from a Git branch.
 - [PlaidCloud Git](/guides/git/) — your workspace's built-in Git service.

--- a/src/content/docs/guides/git/index.md
+++ b/src/content/docs/guides/git/index.md
@@ -29,4 +29,5 @@ If a newly-granted administrator has never opened Git before, they may need to s
 
 ## Related
 
+- [Deploy a Panel App From PlaidCloud Git](/guides/panel-apps/deploy-from-git/) — serve a HoloViz Panel app straight from a repository, with a managed no-credentials connection
 - [Access Management](/administration/access/) — how workspace membership and security groups govern who can see and edit repositories

--- a/src/content/docs/guides/git/repositories.mdx
+++ b/src/content/docs/guides/git/repositories.mdx
@@ -63,5 +63,6 @@ Open a repository's **Settings** tab to rename it, change its visibility, or tra
 
 ## Next Steps
 
+- [Deploy a Panel App From This Repository](/guides/panel-apps/deploy-from-git/) — turn app code you've pushed here into a served app
 - [Track work with Issues](/guides/git/issues/)
 - [Propose changes with Pull Requests](/guides/git/pull-requests/)

--- a/src/content/docs/guides/panel-apps/creating.md
+++ b/src/content/docs/guides/panel-apps/creating.md
@@ -137,7 +137,7 @@ pn.template.FastListTemplate(
 
 A plain app with no template — `pn.Column(...).servable()` — follows Panel's default and isn't affected by these settings; reach for a template when you want explicit control.
 
-Your repository must be reachable through a **git connection** in PlaidCloud. If you don't have one yet, create it under **Tools > Connections** before publishing.
+Your repository must be reachable through a **git connection** in PlaidCloud. If your code lives in [PlaidCloud Git](/guides/git/), create a managed **PlaidCloud Git** connection under **Tools > Connections** — it needs no server URL or credentials. For the whole path from an empty repository to a served app, see [Deploy a Panel App From PlaidCloud Git](/guides/panel-apps/deploy-from-git/).
 
 ### Publish the App
 

--- a/src/content/docs/guides/panel-apps/deploy-from-git.md
+++ b/src/content/docs/guides/panel-apps/deploy-from-git.md
@@ -1,0 +1,108 @@
+---
+title: Deploy a Panel App From PlaidCloud Git
+description: The end-to-end path to serve a HoloViz Panel app in PlaidCloud — put your code in a PlaidCloud Git repository, connect it with a managed no-credentials connection, and publish it live.
+sidebar:
+  order: 1
+---
+
+This is the complete path from Panel app code on your machine to a live URL, using **[PlaidCloud Git](/guides/git/)** — the managed Git service built into your workspace — as the source. Because PlaidCloud Git is managed, the connection your app deploys from needs **no server URL, username, or token**: PlaidCloud authenticates on your behalf.
+
+There are five steps:
+
+1. Write a minimal Panel app.
+2. Put it in a PlaidCloud Git repository.
+3. Create a managed PlaidCloud Git connection.
+4. Publish a server app that points at the repository.
+5. Open the served app — and read the build logs if it doesn't start.
+
+Each step links to the deeper guide for that piece; this page stitches them into one path.
+
+## Before You Start
+
+- Open **Git** from your workspace to confirm you can reach PlaidCloud Git. By default, your workspace's organization includes an **`apps`** repository (and a **`udfs`** one) — the natural home for Panel apps.
+- Have `git` installed locally if you want to push code from your machine (you can also add files in the Git web UI).
+
+## 1. Write a Minimal Panel App
+
+Your app needs an **entry point** — a Python file that builds a Panel app and marks it `.servable()` — and, optionally, a **`requirements.txt`** at the repository root for extra packages.
+
+```
+apps/
+├── app.py            # entry point — calls .servable()
+└── requirements.txt  # optional; extra dependencies, at the repo root
+```
+
+Create `app.py`:
+
+```python
+import panel as pn
+
+pn.extension()
+
+pn.pane.Markdown("# Hello from PlaidCloud Git 👋\n\nServed straight from your workspace repository.").servable()
+```
+
+That's a complete app — the `.servable()` call is what PlaidCloud serves. `panel`, `bokeh`, and the PlaidCloud client libraries (`plaidcloud-rpc`, `plaidcloud-utilities`) are pre-installed, so list only *extra* packages in `requirements.txt`. For richer examples, dependencies, and light/dark theming, see [Creating a Panel App](/guides/panel-apps/creating/).
+
+## 2. Put Your App in a PlaidCloud Git Repository
+
+Use your workspace's existing **`apps`** repository, or [create a new one](/guides/git/repositories/#create-a-repository). Then get your code into it.
+
+Because you sign in through PlaidCloud, your Git account has no separate password — [generate a personal access token](/guides/git/repositories/#generate-a-personal-access-token) (**your avatar → Settings → Applications**) with repository **read** and **write** scopes, and use it as the password when Git prompts. Copy the repository's **HTTPS** clone URL from its **Code** button, then:
+
+```bash
+git clone https://<your-git-host>/<org>/apps.git
+cd apps
+# add app.py (and requirements.txt), then:
+git add app.py requirements.txt
+git commit -m "Add hello panel app"
+git push
+```
+
+Note the repository path — `<org>/apps` — where `<org>` is your workspace's organization name. You'll enter that path in the next step. Full clone, commit, and push details are in [Repositories](/guides/git/repositories/).
+
+> **The token here is only for *you* to push code.** The connection you create next is managed and needs no token — don't confuse the two.
+
+## 3. Create a Managed PlaidCloud Git Connection
+
+A **connection** tells a Panel deployment where its code lives. For PlaidCloud Git the connection is *managed* — PlaidCloud supplies the host and credentials, so you enter only the repository target.
+
+1. Open **Tools > Connections**, click **New Connection**, and choose **PlaidCloud Git**.
+2. Give the connection an **Account Name** (for example, `Apps Repo`).
+3. Set **Repository Path** to `<org>/apps` — the path you noted in step 2 — and **Default Branch** to `main`. Leave **Start Path** blank unless your apps live in a subdirectory.
+4. Click **Create**.
+
+There is no Server URL, User, Password, or SSL/SSH field — PlaidCloud Git is managed, so the platform handles the host and authentication. For the complete form, including the connection's **Usage** and **Security Model** (who in the workspace may use it), see [PlaidCloud Git Connection](/guides/connections/plaidcloud-git/).
+
+> **On an older workspace build?** If the form still shows a Server URL or credential fields, just leave them blank — the platform authenticates on your behalf either way.
+
+## 4. Publish the Server App
+
+Now point a server deployment at that connection.
+
+1. Open **My Panel Apps** and click **New Server App**.
+2. Under **Directory Settings**, set an **App Name** and a **URL Slug** — the slug is the app's URL and internal name, so use lowercase letters, digits, and hyphens, starting with a letter, 40 characters or fewer (for example, `hello-panel`).
+3. Under **Git Connection and Publish Watcher**:
+   - **Git Connection** — the PlaidCloud Git connection you created in step 3.
+   - **Branch** — `main`. Pushes to this branch rebuild and redeploy the app automatically.
+   - **Entry Point** — `app.py`.
+4. Under **Runtime**, choose the **CPU**, **Memory**, **Design** (**FAST** for PlaidCloud's modern look), and **Idle** window. Tick **Allow Public Access** only if the app should be reachable without signing in.
+5. Click **Publish**.
+
+Every field in this dialog is described in [Creating a Panel App](/guides/panel-apps/creating/#publish-the-app).
+
+## 5. Open the App — and Read Logs if It Doesn't Start
+
+After you publish, the app **builds**: PlaidCloud clones the branch, installs your `requirements.txt`, and builds a container image. Its **Status** shows in the **My Panel Apps** list and updates automatically.
+
+- When Status is **Ready**, open the app at `https://<your-tenant-host>/serve/<slug>/`. The first request after it has been idle spins it up (~15 seconds).
+- If the build fails, open the app and check its **Build** logs — a missing dependency or an import error shows up there. See [Using a Panel App](/guides/panel-apps/using/) for what each status means, how to read logs, and how to trigger a rebuild.
+
+From here on, **every push to the connection's branch rebuilds and redeploys the app automatically** — edit `app.py`, `git push`, and your change goes live.
+
+## Next Steps
+
+- [Creating a Panel App](/guides/panel-apps/creating/) — richer examples, dependencies, and light/dark theming
+- [PlaidCloud Git Connection](/guides/connections/plaidcloud-git/) — the full connection form, usage, and security model
+- [Reading Data and the Signed-In User](/guides/panel-apps/accessing-data/) — query PlaidCloud data as the person viewing the app
+- [Repositories](/guides/git/repositories/) — branches, tokens, and collaborating in PlaidCloud Git

--- a/src/content/docs/guides/panel-apps/index.md
+++ b/src/content/docs/guides/panel-apps/index.md
@@ -23,5 +23,6 @@ There are two runtimes, shown in the **Runtime** column:
 
 ## Next Steps
 
+- [Deploy a Panel App From PlaidCloud Git](/guides/panel-apps/deploy-from-git/) — the complete path from repository to a served app, using a managed no-credentials connection.
 - [Creating a Panel App](/guides/panel-apps/creating/) — publish a server app from git, or a WASM app from a file.
 - [Using a Panel App](/guides/panel-apps/using/) — build status, opening the app, editing, and removing it.

--- a/src/content/docs/reference/connectors/git/index.md
+++ b/src/content/docs/reference/connectors/git/index.md
@@ -3,10 +3,11 @@ title: Git Repository Connections
 description: Connect PlaidCloud to Git repositories including GitHub, GitLab, Bitbucket, Azure Repos, and AWS CodeCommit for version control.
 ---
 
-PlaidCloud connects to Git hosts so workflows can read from (or push to) version-controlled repositories. Useful for sourcing configuration, scripts, or templated files that live in source control rather than a database or document account.
+PlaidCloud connects to Git hosts so workflows and Panel apps can read from (or push to) version-controlled repositories. Useful for sourcing configuration, scripts, or templated files that live in source control rather than a database or document account.
 
 ## Providers
 
+- [PlaidCloud Git](/reference/connectors/git/plaidcloud-git/) — the managed Git service built into your workspace; no server URL or credentials to configure
 - [GitHub](/reference/connectors/git/github/)
 - [GitLab](/reference/connectors/git/gitlab/)
 - [Bitbucket](/reference/connectors/git/bitbucket/)

--- a/src/content/docs/reference/connectors/git/plaidcloud-git.md
+++ b/src/content/docs/reference/connectors/git/plaidcloud-git.md
@@ -1,0 +1,43 @@
+---
+title: PlaidCloud Git Connector
+description: Connect a Panel app or workflow to a repository in PlaidCloud Git — the managed built-in Git service — with no server URL or credentials to configure.
+sidebar:
+  order: 0
+---
+
+**PlaidCloud Git** is the managed Git service built into your workspace. A PlaidCloud Git connection points a Panel deployment — or a workflow — at one of your repositories. Because the service is managed, it needs **no server URL, username, or token**: PlaidCloud supplies the host and authenticates on your behalf.
+
+For the end-to-end walkthrough of serving a Panel app from one of these connections, see [Deploy a Panel App From PlaidCloud Git](/guides/panel-apps/deploy-from-git/). To create repositories and push code, see the [PlaidCloud Git guides](/guides/git/).
+
+## Configuration
+
+From **Tools > Connections**, click **New Connection** and choose **PlaidCloud Git**. The form drops the authentication, SSL, and SSH sections that external Git providers show — credentials are platform-derived — leaving the connection's identity, usage, and repository target.
+
+### Identification
+
+| Field | Type | Description |
+|---|---|---|
+| Account Name | Text | Display name for this connection. |
+| Memo | Text | Optional note about what the connection is for. |
+
+### Repository
+
+| Field | Type | Description |
+|---|---|---|
+| Repository Path | Text | The repository to use, in the form `<organization>/<repository>` — for example, your workspace's `apps` or `udfs` repository. |
+| Default Branch | Text | The branch to read from. Defaults to `main`. |
+| Start Path | Text | Optional path prefix applied to all file lookups, if your files live in a subdirectory of the repository. |
+
+**Usage** (`Active` / `Read Only`) and the **Security Model** (who in the workspace may use the connection) are the standard connection settings — see the [connection guide](/guides/connections/plaidcloud-git/) and [Create and Manage a Connection](/guides/connections/create-connection/).
+
+## Common Uses
+
+- Serving a [HoloViz Panel app](/guides/panel-apps/deploy-from-git/) from your workspace's `apps` repository.
+- Sourcing user-defined functions, configuration, or templated files that live in PlaidCloud Git.
+
+## Related
+
+- [PlaidCloud Git Connection](/guides/connections/plaidcloud-git/) — task guide for creating the connection, with usage and security model
+- [Deploy a Panel App From PlaidCloud Git](/guides/panel-apps/deploy-from-git/) — the full path from repository to served app
+- [PlaidCloud Git guides](/guides/git/) — repositories, issues, pull requests, and more
+- [Git Repository Connections](/reference/connectors/git/) — external Git providers (GitHub, GitLab, and others)

--- a/src/content/docs/reference/connectors/index.md
+++ b/src/content/docs/reference/connectors/index.md
@@ -27,7 +27,7 @@ Relational databases, cloud warehouses, query engines, and lakehouse formats.
 
 ### Development and Source Control
 
-- [Git providers](/reference/connectors/git/) — GitHub, GitLab, Bitbucket, Azure Repos, CodeCommit
+- [Git providers](/reference/connectors/git/) — PlaidCloud Git (managed, built-in), plus GitHub, GitLab, Bitbucket, Azure Repos, CodeCommit
 
 ## Related
 


### PR DESCRIPTION
## Why

A user asking *"how do I serve a Panel app from PlaidCloud Git?"* had no definitive path. The pieces existed — [Creating a Panel App](/guides/panel-apps/creating/), [PlaidCloud Git repositories](/guides/git/repositories/), the [PlaidCloud Git connection guide](/guides/connections/plaidcloud-git/) — but **no single discoverable page tied them together**, and the `panel-apps/` and `git/` guides never referenced each other. This closes that seam.

## New pages

- **`guides/panel-apps/deploy-from-git.md`** — the flagship end-to-end tutorial (sidebar `order: 1`, right after the Panel Apps overview). Five stitched steps: write a Panel app → push it to a PlaidCloud Git repo → create the **managed, credential-free** connection → publish a Server app → open the served URL and read build logs if it fails. It **delegates** the connection-form detail to the existing connection guide rather than duplicating it.
- **`reference/connectors/git/plaidcloud-git.md`** — a PlaidCloud Git connector reference (the connector catalog previously listed only external providers: GitHub, GitLab, Bitbucket, Azure Repos, CodeCommit).

## Cross-links (the actual fix)

| From | To |
|---|---|
| `panel-apps/index`, `creating.md` | the new tutorial + the managed connection |
| `git/index`, `git/repositories` | deploy a Panel app from a repository |
| `connectors/git/index`, `connectors/index` | the PlaidCloud Git connector |
| connection guide ↔ tutorial | bidirectional |

## Accuracy

Matches the **shipped** managed form — Account Name, Repository Path (`<org>/apps`), Default Branch, Start Path; no Server URL or credentials — which is live on all tenants (client `beta-202607-229`). The credential-free note is phrased to hold on older builds too (leave any credential fields blank).

## Validation

- `npm run build` passes — 1,519 pages, no errors.
- All new internal links verified to resolve to existing pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)