### PR TITLE
docs(projects): add Labels guide

### DIFF
--- a/src/content/docs/guides/projects/index.md
+++ b/src/content/docs/guides/projects/index.md
@@ -20,6 +20,7 @@ Most teams start with one project per analytical area: a project for headcount c
 - [Archive a project](/guides/projects/archive-a-project/) — preserve completed work without deleting
 - [Compare and merge projects](/guides/projects/compare-and-merge-projects/) — diff two projects and selectively copy changes between them
 - [Export to portable format](/guides/projects/export-to-portable-format/) — package a project as a standalone Python + DuckDB program that runs off-platform
+- [Organize work with labels](/guides/projects/organizing-with-labels/) — tag workflows, steps, tables, and other objects to group and filter them
 
 ## Related
 

--- a/src/content/docs/guides/projects/organizing-with-labels.mdx
+++ b/src/content/docs/guides/projects/organizing-with-labels.mdx
@@ -1,0 +1,52 @@
+---
+title: Organizing Work with Labels
+description: Tag PlaidCloud projects, workflows, steps, tables, and dimensions with labels to group related items and filter the project lists quickly.
+sidebar:
+  label: Labels
+  order: 10
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## Description
+
+**Labels** are free-form tags you attach to the objects in a project — the project itself, its workflows, steps, tables, dimensions, data editors, and user-defined functions. Use them to group related items by whatever matters to you (a phase of work, a source system, an owner, a release) and then find those items again quickly.
+
+Labels are stored in lowercase and shown as small chips wherever the object appears, so a consistent set of labels becomes a lightweight way to slice a large project.
+
+## Where to Manage Labels
+
+Every taggable object has a **Labels** box in its detail panel:
+
+- **Project Labels** — on the project home
+- **Workflow Labels**, **Step Labels**, **Table Labels**, **Dimension Labels**, **Data Editor Labels**, and **UDF Labels** — on the corresponding item's detail panel
+- **Labels** — on the **General** tab of a workflow step's form
+
+The box lists the object's current labels as chips and provides a field for adding more.
+
+## Adding a Label
+
+1. Click anywhere in the **Labels** box to place the cursor in the entry field.
+2. Type the label text.
+3. Press **Enter** (or type a comma) to add it.
+
+The new label appears as a chip, and the entry field clears so you can add another. The chips wrap onto more than one row as you add labels, so nothing is hidden.
+
+<Aside type="note">
+Labels are converted to lowercase automatically. If the label you type is already on that object, PlaidCloud tells you and does not add a duplicate.
+</Aside>
+
+## Removing a Label
+
+- Click the **×** on a chip to remove that label, or
+- With the entry field empty, press **Backspace** to remove the last chip.
+
+## Finding Items by Label
+
+Labels appear as chips in the **Labels** column of the project lists — Workflows, Steps, Tables, and so on. To narrow a list to the items carrying a particular label, type the label into the list's filter box; the search matches label text along with the item name. Hover a chip that is too long to fit its column to reveal the full label.
+
+## Related
+
+- [View projects](/guides/projects/viewing-projects/) — find and open the project whose objects you want to label
+- [Workflows](/guides/workflows/) — the workflows and steps you can tag inside a project
+- [Manage tables and views](/guides/projects/managing-tables-and-views/) — the data objects that also carry labels


### PR DESCRIPTION
Adds an end-user guide for the redesigned **Labels** control, under **Guides → Projects**.

## Covers
- What labels are and which objects they apply to (project, workflow, step, table, dimension, data editor, UDF)
- Where the **Labels** box appears (each object's detail panel + the step form's **General** tab)
- Adding a label (click to focus, type, **Enter**/comma; auto-lowercased; duplicates rejected)
- Removing a label (chip **×**, or **Backspace** on an empty field)
- How labels surface as chips in the project lists' **Labels** column and how to filter by them

Linked from the Projects section `index.md`. New page slug: `/guides/projects/organizing-with-labels/`.

Pairs with the client-side redesign in PlaidClient#1836.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
