### PR TITLE
docs(releases): note dimension-step and aggregate-step AI-assistant fixes

### DIFF
--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -39,6 +39,10 @@ description: Machine learning in workflows, self-service PlaidCloud Managed Buck
 
 ## Fixed
 
+- **Dimension steps created through the AI assistant.** Export, Load, Sort, and Clear dimension steps created or edited through the AI assistant no longer crash when run — the dimension you selected is now preserved instead of being dropped, and a step saved without one now fails with a clear message instead of an unexpected error.
+
+- **Aggregate steps created through the AI assistant.** Aggregate steps created or edited through the AI assistant now keep the columns you set to group by instead of dropping them, so they calculate correctly instead of failing to run or silently combining rows that should have stayed separate.
+
 - **Join steps — Output Columns fixes.** For Inner, Outer, Anti, and Cross Join, the Output Columns tab now lists only the columns you mapped from the two sources and drops stale rows when you remove a mapped source column; the column-mapper toolbar and multi-row selection are back; and Summarize is now a toggle that's off by default, so a join no longer forces its output to be grouped — and when you turn it on, new columns default to an aggregation based on their data type, which you can override per column. Multi-Table Join output columns now follow renames and removals in the join-graph designer. See [Table Inner Join](/reference/workflow-steps/tables/table-inner-join/) and [Multi-Table Join Step](/guides/workflows/multi-table-join-step/).
 
 - **REST Request reliability fixes.** Variables now substitute reliably in JSON request bodies, per-request timeout and retry settings are honored (retries limited to idempotent methods, so a POST/PUT/PATCH is never re-sent), rate-limited responses are retried with backoff, and request credentials are masked in any captured raw JSON. A test request now shows the response status code even on success, and a single-object response imports as one row. Sensor- and webhook-triggered workflows can also read the trigger's metadata and inbound payload as variables. See [REST Request Step](/guides/workflows/rest-request-step/).


### PR DESCRIPTION
## Summary
- Adds two customer-facing bullets under `## Fixed` in the July 2026 What's New page (`src/content/docs/releases/2026-07.mdx`), covering two bug fixes shipping now:
  - Export/Load/Sort/Clear dimension steps created or edited through the AI assistant no longer crash at run time (the chosen dimension is preserved; an unset dimension now fails with a clear message).
  - Aggregate steps created or edited through the AI assistant now keep their group-by columns instead of dropping them, so they calculate correctly instead of failing or silently miscalculating.
- No new month page or `index.mdx` `<LinkCard>` was needed — the July 2026 page and its card already existed.

## Test plan
- [x] Reviewed the diff for stray `{`/`}` JSX pitfalls in the added MDX bullets — none present.
- [ ] Astro build (`npm run build`) could not be verified in this local Windows environment — it fails identically on an unmodified checkout of this branch (a pre-existing `astro/tsconfigs/strict` package-exports resolution issue unrelated to this change). Confirmed by stashing the edit and reproducing the same failure. Rely on the Cloudflare "Workers Builds" preview check in CI to confirm the build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dae6Zts6EXp5XvhncKycrX