### PR TITLE
Add Currency column data type guide and July release entry

### DIFF
--- a/src/content/docs/guides/data/currency-data-type.mdx
+++ b/src/content/docs/guides/data/currency-data-type.mdx
@@ -1,0 +1,68 @@
+---
+title: Currency Data Type
+description: Store money values as exact fixed-point decimals with the Currency column data type — half the in-memory width of Numeric, so money-heavy dashboards and workflow steps run faster.
+sidebar:
+  order: 3
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+**Currency** is a column data type built for money values. It appears alongside the familiar types — Numeric, Integer, Text, and the rest — in every data-type list, and it stores amounts as exact fixed-point decimals: 18 digits of precision with 4 decimal places. That is room for roughly ±100 trillion, exact to 1/10,000 of a unit, with no floating-point rounding.
+
+The payoff is speed. A Currency column occupies half the in-memory width of a Numeric column, so dashboards and workflow steps that scan tables full of amounts read roughly half the data and finish faster. Numeric remains the high-precision default (38 digits of precision, 10 decimal places); Currency is the leaner type you opt into wherever the values are money.
+
+<Aside>
+Currency rolls out with the current platform release. The option appears in your data-type lists once the update is live on your workspace.
+</Aside>
+
+
+## When to Use Currency
+
+Choose Currency for columns that hold monetary amounts — cost, revenue, price, margin, spend, allocated amounts. These are the columns that dominate profitability and financial models, so retyping them is usually the single biggest win for scan-heavy dashboards and workflows.
+
+Stay with Numeric when:
+
+* Values could exceed roughly ±100 trillion, or need more than 4 decimal places — think FX rates, unit rates, percentages, and allocation factors
+* The column mixes money with other measures, or you are not sure what it will hold
+
+<Aside type="note">
+Every Currency value must fit 18 digits of precision with 4 decimal places — about ±100 trillion at 4 decimal places. If a column needs more scale or more precision than that, use Numeric.
+</Aside>
+
+
+## Where to Set It
+
+Currency is available anywhere you choose a column's data type.
+
+### In a Workflow Step's Column Mapping
+
+In any step's output column mapping — the data mapper grid — pick **Currency** from the column's data-type dropdown, the same way you would choose Numeric or Text. The step writes that column as Currency from the next run onward.
+
+### In a Table's Column Properties
+
+Open a table's **Column Properties** and use the **Data Type** control to switch a column between **Numeric** and **Currency**. The change takes effect the next time the table is rebuilt — for example, the next time the workflow step that produces it runs.
+
+### With an AI Assistant or MCP Tooling
+
+Agents connected over [MCP](/integrations/ai-coding-agents/getting-started/) can set the type too: the data-type value is `currency` wherever a column type is given — creating a column, defining a table, or configuring a step. Asking your assistant to *"make the amount columns currency"* is often the fastest way to retype a wide table.
+
+
+## How Currency Behaves
+
+A few rules keep Currency predictable across the platform:
+
+* **Currency is always your explicit choice.** Imports, type auto-detection, SQL results, and derived columns (sums, expressions, allocation outputs) always default to Numeric. Where you want Currency on a result, retype that output column yourself.
+* **Once set, it is remembered.** A column declared Currency stays Currency through reads, downstream steps, and table rebuilds. When a downstream step populates its column mapping from the table, the Currency type carries into the step's configuration automatically.
+* **Aggregations return Numeric.** A SUM or other aggregation of a Currency column produces a Numeric result — set the output column back to Currency if you want the aggregate stored that way.
+* **Empty cells import as 0.** In file imports, an empty cell in a Currency column loads as 0, exactly as it does for Numeric.
+
+<Aside type="caution">
+On steps where you write raw SQL, the **Populate** button infers the output columns from the query result — and query results always come back as Numeric. Set the money columns to Currency after you run Populate, and expect to set them again if you re-run it.
+</Aside>
+
+
+## Related
+
+* [Using Tables and Views](/guides/data/tables-views/) — how tables store columns and why data types matter for size and speed
+* [Column Propagation](/guides/workflows/column-propagation/) — push a type change downstream through every step that consumes the column
+* [Table Explorer](/guides/data/table-explorer/) — inspect each column's data type at a glance

--- a/src/content/docs/guides/data/index.md
+++ b/src/content/docs/guides/data/index.md
@@ -11,6 +11,7 @@ PlaidCloud's data layer is built around **tables** (structured row-and-column da
 
 - [Tables and views](/guides/data/tables-views/) — what each is, when to use which, and how they interact
 - [Table explorer](/guides/data/table-explorer/) — browse and inspect tables in your project
+- [Currency data type](/guides/data/currency-data-type/) — an exact, half-width column type for money values, and when to choose it over Numeric
 - [Table snapshots](/guides/data/table-snapshots/) — browse snapshot history, view data as of a past snapshot, and revert or restore a table
 - [Publishing data](/guides/data/publish/) — make project tables available to dashboards, BI tools, and downstream systems
 - [Selecting the latest record in a large history table](/guides/data/selecting-latest-record-in-large-history-table/) — a common pattern with a performance-aware solution

--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -1,6 +1,6 @@
 ---
 title: July 2026
-description: Machine learning in workflows, self-service PlaidCloud Managed Buckets, a more capable REST Request step, an expanded Help & Support experience, and a big accuracy-and-honesty pass on AI allocation cost-tracing.
+description: Machine learning in workflows, a Currency data type for money values, self-service PlaidCloud Managed Buckets, a more capable REST Request step, an expanded Help & Support experience, and a big accuracy-and-honesty pass on AI allocation cost-tracing.
 ---
 
 ## Releases Shipped
@@ -12,6 +12,8 @@ description: Machine learning in workflows, self-service PlaidCloud Managed Buck
 ## Added
 
 - **PlaidCloud Git connections.** Connect to your workspace's own managed Git server with a simplified form — just an account name, memo, repository path, default branch, and optional start path — with no server URL, username, token, or SSH key to enter, because your Git server and your access to it come from your normal PlaidCloud sign-in. Point a Server Panel app's build at a PlaidCloud Git connection to automate builds entirely inside your workspace, without an external GitHub account or access token. External Git providers (GitHub, GitLab, Bitbucket, Forgejo, Gitea) keep their full connection form. See [PlaidCloud Git Connection](/guides/connections/plaidcloud-git/).
+
+- **Currency — a column data type built for money.** Every column data-type list — step output column mappings, the data mapper grid, a table's Column Properties, and MCP/AI tooling — now offers **Currency**: an exact fixed-point type with 18 digits of precision and 4 decimal places (roughly ±100 trillion, exact to 1/10,000). It stores money in half the in-memory width of Numeric, so money-heavy dashboards and workflow steps scan about half the data and run faster; Numeric stays the high-precision default (38 digits, 10 decimal places). Currency is always your explicit choice — imports, type detection, SQL results, and derived columns still default to Numeric — and once set on a column it is remembered through reads, downstream steps, and table rebuilds. Aggregations of Currency return Numeric. The option appears once the platform update is live on your workspace. See [Currency Data Type](/guides/data/currency-data-type/).
 
 - **Skip re-importing unchanged source files** — file-import steps (CSV, Excel, Fixed Width, JSON, Avro, Parquet, Alteryx yxdb, dbf, XML, X12 EDI, Access) have a new **Skip re-import if source files unchanged** option. Turn it on and a workflow run skips the whole download, conversion, and table rebuild when the source files and the step's settings have not changed since the last successful run — so a scheduled reload no longer repeats the work. **On by default** — untick the option on a step to always re-import; the change is detected from each file's size and modified time, plus a content hash where the source provides one. Manual, one-off imports always run. See [Import CSV](/reference/workflow-steps/import/import-csv/).
 

--- a/src/content/docs/releases/index.mdx
+++ b/src/content/docs/releases/index.mdx
@@ -13,7 +13,7 @@ Monthly summaries of changes shipped to PlaidCloud tenants. Months with substant
 	<LinkCard
 		title="July 2026"
 		href="/releases/2026-07/"
-		description="v5.11.0 · PlaidCloud Git connections, Managed Buckets, ML workflow steps, REST Request fan-out, support attachments, and AI allocation cost-tracing confidence signals."
+		description="v5.11.0 · PlaidCloud Git connections, Managed Buckets, ML workflow steps, a Currency data type, REST Request fan-out, support attachments, and AI allocation cost-tracing confidence signals."
 	/>
 	<LinkCard
 		title="June 2026"


### PR DESCRIPTION
## What

Customer docs for the Currency column data type: new guide `guides/data/currency-data-type.mdx` (what it is, the three surfaces to set it, behavior rules incl. the Populate caveat and the 18,4 bound) + July What's New entry and index blurb.

## Merge timing

Opened as draft deliberately (this repo's PRs are normally non-draft): the guide documents the currency release train — **merge when the feature deploys** (rpc #156 → utilities #327 → runner #1109 → PlaidClient #1848 → plaid #6598 → PlaidClient UI). The guide carries an availability Aside so early publish is safe if preferred.

## Testing

`npm run build` (the CI gate) passed — 1521 pages, no MDX errors; internal link targets verified in dist/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)