### PR TITLE
docs(releases): add v5.11.1 and v5.11.2 to July Releases Shipped

### DIFF
--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -8,6 +8,8 @@ description: Machine learning in workflows, a Currency data type for money value
 | Version | Released |
 |---|---|
 | v5.11.0 | 2026-07-09 |
+| v5.11.1 | 2026-07-13 |
+| v5.11.2 | 2026-07-15 |
 
 ## Added
 


### PR DESCRIPTION
The July 2026 What'\''s New page listed only v5.11.0 in the Releases Shipped table. Add the two follow-on patch releases:

| Version | Released |
|---|---|
| v5.11.1 | 2026-07-13 |
| v5.11.2 | 2026-07-15 |

Dates are the `tenant-v5.11.x` tag commit dates in plaid-tenant-infrastructure (v5.11.0'\''s tag date matches the existing row, confirming the source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)