### PR TITLE
What's New: retired in-app Reset Password option [sc-22938]

### DIFF
--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -68,3 +68,5 @@ description: Machine learning in workflows, a Currency data type for money value
 ## Removed
 
 - **Retired legacy import and export steps** — the SAS7BDAT import, HTML import, and HTML export steps have been removed. Use the current import and export steps for these formats instead.
+
+- **Retired the in-app Reset Password option** — the **Reset Password** item has been removed from the account (avatar) menu. To reset your password, use the **Forgot Password?** link on the sign-in page.


### PR DESCRIPTION
Adds a July 2026 What's New "Removed" note that the in-app **Reset Password** option is gone and password resets now use the sign-in page's **Forgot Password** link.

Companion to PlaidClient + plaid PRs for [sc-22938](https://app.shortcut.com/plaidcloud/story/22938).

🤖 Generated with [Claude Code](https://claude.com/claude-code)