### PR TITLE
docs(panel-apps): requirements.txt can live next to the app (sc-22788)

### DIFF
--- a/src/content/docs/guides/connections/plaidcloud-git.mdx
+++ b/src/content/docs/guides/connections/plaidcloud-git.mdx
@@ -53,7 +53,7 @@ For `Specific Members Only` or `Specific Security Groups Only`, grant the access
 
 A [Server Panel app](/guides/panel-apps/creating/) builds from a Git branch and rebuilds automatically on every push to that branch. Pointing it at a PlaidCloud Git connection keeps the whole loop inside your workspace — no external host and no personal access token to keep alive.
 
-1. Push your Panel app to a repository on your workspace's PlaidCloud Git server — an entry-point `.py` file that calls `.servable()`, and an optional `requirements.txt` at the repository root. See [Creating a Panel App](/guides/panel-apps/creating/#prepare-your-app-repository) for the repository layout.
+1. Push your Panel app to a repository on your workspace's PlaidCloud Git server — an entry-point `.py` file that calls `.servable()`, and an optional `requirements.txt` at the repository root or next to your entry point. See [Creating a Panel App](/guides/panel-apps/creating/#prepare-your-app-repository) for the repository layout.
 2. Create a PlaidCloud Git connection whose **Repository** is that repository, following the steps above.
 3. In **My Panel Apps**, click **New Server App** and, under **Git Connection and Publish Watcher**:
    - **Git Connection** — choose the PlaidCloud Git connection you just created

--- a/src/content/docs/guides/panel-apps/creating.md
+++ b/src/content/docs/guides/panel-apps/creating.md
@@ -16,12 +16,12 @@ A server app is built from a git repository and served at `https://<your-tenant-
 
 ### Prepare Your App Repository
 
-Your repository needs two things: an **entry point** — a Python file that builds a Panel app and marks it `.servable()` — and, optionally, a **`requirements.txt`** at the repository root listing any extra packages.
+Your repository needs two things: an **entry point** — a Python file that builds a Panel app and marks it `.servable()` — and, optionally, a **`requirements.txt`** listing any extra packages, either at the repository root or beside your entry point.
 
 ```
 my-panel-app/
 ├── app.py            # entry point — calls .servable()
-└── requirements.txt  # optional; extra dependencies, at the repo root
+└── requirements.txt  # optional; extra dependencies (repo root or next to app.py)
 ```
 
 #### Hello World
@@ -65,19 +65,19 @@ pn.Column(
 
 #### Add Dependencies
 
-This second example imports `pandas`, which isn't part of the base image, so add a `requirements.txt` at the repository root:
+This second example imports `pandas`, which isn't part of the base image, so add a `requirements.txt` (at the repository root, or next to your entry point):
 
 ```text
 pandas
 ```
 
-PlaidCloud installs these with `pip` when it builds the image.
+PlaidCloud installs these with `pip` when it builds the image. Common visualization libraries — `plotly`, `holoviews`, `hvplot` — aren't in the base image either, so list any your app imports here.
 
 > **What the platform provides — and expects.** Keep these assumptions in mind when you write your app:
 >
 > - **`panel` and `bokeh` are pre-installed** by the platform base image. Don't list them in `requirements.txt`, and avoid pinning an older Panel version — the live-update reconnect relies on a recent one.
 > - **The PlaidCloud client libraries (`plaidcloud-rpc`, `plaidcloud-utilities`) are pre-installed.** Import `plaidcloud.rpc` or `plaidcloud.utilities` directly — don't list them in `requirements.txt`.
-> - **`requirements.txt` must be at the repository root.** A file in a subdirectory is ignored, even if your entry point lives in one.
+> - **`requirements.txt` can be at the repository root or next to your entry point.** In a shared (monorepo) repository, keep each app's dependencies in its own folder. A root-level file, if present, is installed too — put shared dependencies there and app-specific ones beside the app.
 > - **The app runs as a non-root user on a read-only filesystem.** Only `/tmp` is writable, so write any temporary files there (most libraries already honor `$TMPDIR`).
 > - **Don't hardcode the port, URL prefix, or host.** PlaidCloud assigns them and injects them at deploy time — just call `.servable()`.
 
@@ -176,6 +176,10 @@ FROM us-docker.pkg.dev/plaidcloud-build/panel-base/platform-panel-base:0.5.1
 USER root
 COPY . /app
 RUN if [ -f /app/requirements.txt ]; then pip install --no-cache-dir -r /app/requirements.txt; fi
+# If your entry point is in a subfolder, PlaidCloud also installs that folder's requirements.txt,
+# after the root one (so a per-app pin wins). Replace <app-folder> with your entry point's folder,
+# or drop this line if your app is at the repository root.
+RUN if [ -f "/app/<app-folder>/requirements.txt" ]; then pip install --no-cache-dir -r "/app/<app-folder>/requirements.txt"; fi
 USER 10001
 ```
 
@@ -183,7 +187,7 @@ To match the server build:
 
 1. Check out the same branch you select in **Branch**.
 2. Run the build from the repository root, so `COPY . /app` matches PlaidCloud.
-3. Put optional dependencies in `requirements.txt` at the repository root.
+3. Put optional dependencies in a `requirements.txt` — at the repository root, or next to your entry point. Both are installed, the app folder's last (so a per-app pin wins).
 4. Use the same entry-point path you select in **Entry Point**.
 
 ```sh

--- a/src/content/docs/guides/panel-apps/deploy-from-git.md
+++ b/src/content/docs/guides/panel-apps/deploy-from-git.md
@@ -24,12 +24,12 @@ Each step links to the deeper guide for that piece; this page stitches them into
 
 ## 1. Write a Minimal Panel App
 
-Your app needs an **entry point** — a Python file that builds a Panel app and marks it `.servable()` — and, optionally, a **`requirements.txt`** at the repository root for extra packages.
+Your app needs an **entry point** — a Python file that builds a Panel app and marks it `.servable()` — and, optionally, a **`requirements.txt`** for extra packages, either at the repository root or next to your entry point.
 
 ```
 apps/
 ├── app.py            # entry point — calls .servable()
-└── requirements.txt  # optional; extra dependencies, at the repo root
+└── requirements.txt  # optional; extra dependencies (repo root or next to app.py)
 ```
 
 Create `app.py`:
@@ -93,7 +93,7 @@ Every field in this dialog is described in [Creating a Panel App](/guides/panel-
 
 ## 5. Open the App — and Read Logs if It Doesn't Start
 
-After you publish, the app **builds**: PlaidCloud clones the branch, installs your `requirements.txt`, and builds a container image. Its **Status** shows in the **My Panel Apps** list and updates automatically.
+After you publish, the app **builds**: PlaidCloud clones the branch, installs your `requirements.txt` (the repository root's and your app folder's, if present), and builds a container image. Its **Status** shows in the **My Panel Apps** list and updates automatically.
 
 - When Status is **Ready**, open the app at `https://<your-tenant-host>/serve/<slug>/`. The first request after it has been idle spins it up (~15 seconds).
 - If the build fails, open the app and check its **Build** logs — a missing dependency or an import error shows up there. See [Using a Panel App](/guides/panel-apps/using/) for what each status means, how to read logs, and how to trigger a rebuild.

--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -67,6 +67,8 @@ description: Machine learning in workflows, a Currency data type for money value
 
 - **Create and Open now opens the right view for a DAG workflow.** Using **Create and Open Config** on a new Advanced (DAG) workflow opened the classic steps grid instead of the Visual Workflow Designer canvas. It now opens the canvas, matching what you get by double-clicking the workflow. See [Advanced Workflows](/guides/workflows/advanced-workflows/).
 
+- **Panel app dependencies can live next to the app.** A server-side Panel app built from a Git repository now installs a `requirements.txt` kept beside its entry point, not only one at the repository root — so an app stored in a subfolder of a shared repository can declare its own packages (for example `plotly`, `holoviews`, or `hvplot`) and no longer renders blank from a missing library. See [Creating a Panel App](/guides/panel-apps/creating/#add-dependencies).
+
 ## Removed
 
 - **Retired legacy import and export steps** — the SAS7BDAT import, HTML import, and HTML export steps have been removed. Use the current import and export steps for these formats instead.


### PR DESCRIPTION
Companion docs for PlaidCloud/plaid#6635.

Server-side Panel builds now install a `requirements.txt` from the **app's own folder**, not only the repository root (sc-22788).

- **creating.md** — corrects the callout that said a `requirements.txt` in a subdirectory is ignored; documents root-or-app-folder, monorepo guidance (shared deps at root, per-app deps beside the app), and adds `plotly` / `holoviews` / `hvplot` to the dependencies example.
- **deploy-from-git.md** — updates the entry-point/requirements description and the build explanation.
- **releases/2026-07.mdx** — a "Fixed" entry under What's New.

🤖 Generated with [Claude Code](https://claude.com/claude-code)