### PR TITLE
docs(releases): note large/multi document move reliability fix (sc-23094)

### DIFF
--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -76,6 +76,8 @@ description: Machine learning in workflows, a Currency data type for money value
 
 - **Panel app dependencies can live next to the app.** A server-side Panel app built from a Git repository now installs a `requirements.txt` kept beside its entry point, not only one at the repository root — so an app stored in a subfolder of a shared repository can declare its own packages (for example `plotly`, `holoviews`, or `hvplot`) and no longer renders blank from a missing library. See [Creating a Panel App](/guides/panel-apps/creating/#add-dependencies).
 
+- **Moving large or many documents between folders.** Moving several files at once — or a single large file — from one Document folder to another now works reliably. Moves run one at a time so the file list stays consistent, and a large move is given the time it needs to finish instead of being cut off partway.
+
 ## Removed
 
 - **Retired legacy import and export steps** — the SAS7BDAT import, HTML import, and HTML export steps have been removed. Use the current import and export steps for these formats instead.


### PR DESCRIPTION
Adds a **Fixed** entry to the July 2026 What's New page for the sc-23094 document-move reliability fix (large / multi-file moves between Document folders).

Pairs with:
- PlaidCloud/plaid#6673 (backend GCS copy timeout)
- PlaidCloud/PlaidClient#1880 (client serialize + timeout + error surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)