### PR TITLE
docs(workflows): document renaming/deleting step run conditions

### DIFF
--- a/src/content/docs/guides/workflows/step-conditions.md
+++ b/src/content/docs/guides/workflows/step-conditions.md
@@ -43,9 +43,11 @@ To activate and add conditions on a step:
 
 ## Managing Conditions
 
-You can add as many conditions as necessary in the **Conditions Check** section.  As you add them, it is a good idea to give them a useful name so you can find the conditions easily in the future.
+You can add as many conditions as necessary in the **Condition Checks** section.  As you add them, it is a good idea to give them a useful name so you can find the conditions easily in the future.
 
 Once you add a condition, select it on the left and the condition evaluation criteria will be editable on the right.
+
+To rename a condition, select it and edit the **Name** field at the top of the Configuration panel on the right — or double-click the condition in the list. You can also right-click a condition for **Rename** and **Delete**; **Delete** is also available from the "−" button above the list.
 
 
 ## Variable Conditions

--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -58,6 +58,8 @@ description: Machine learning in workflows, a Currency data type for money value
 
 ## Fixed
 
+- **Renaming a step's run conditions works again.** When you set conditions that must be met before a step runs, you can now rename each condition — edit the new **Name** field in the Configuration panel, or double-click the condition in the list. Right-click a condition for **Rename** and **Delete** as well. See [Run Conditions on a Step](/guides/workflows/step-conditions/).
+
 - **Clearer error when an import can't read any columns.** When you set up or auto-create a CSV or text import and PlaidCloud can't read any columns from the source file — for example some Microsoft Access text exports, or a file whose delimiter or quoting doesn't match — it now tells you right away, as you save or create the import, instead of letting the step run and fail later with a confusing message. Adjust the delimiter, quote, and escape settings or fix the file, then try again. See [Import CSV](/reference/workflow-steps/import/import-csv/).
 
 - **Managed bucket name collisions now explain themselves.** Creating a PlaidCloud Managed Bucket document account with a bucket name that's already in use previously failed with a generic "Internal server error". The Bucket Name field now flags the collision directly and explains that bucket names are globally unique, with guidance on picking a more specific name — for example, adding your company as a prefix. See [Add a PlaidCloud Managed Bucket Account](/guides/documents/adding-accounts/add-managed-bucket-account/).


### PR DESCRIPTION
Documents the fix in PlaidCloud/PlaidClient#1882 ([sc-23111](https://app.shortcut.com/plaidcloud/story/23111)).

- **Run Conditions guide** — explains renaming a condition via the new **Name** field or double-click, and the right-click **Rename**/**Delete** menu. Also corrects the section label to **Condition Checks** to match the UI.
- **July What's New** — adds a *Fixed* entry.