### PR TITLE
docs(releases): note push-triggered Panel app rebuilds are fixed

### DIFF
--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -10,6 +10,8 @@ description: Machine learning in workflows, a Currency data type for money value
 | v5.11.0 | 2026-07-09 |
 | v5.11.1 | 2026-07-13 |
 | v5.11.2 | 2026-07-15 |
+| v5.11.4 | 2026-07-20 |
+| v5.11.5 | 2026-07-21 |
 
 ## Added
 
@@ -57,6 +59,8 @@ description: Machine learning in workflows, a Currency data type for money value
 - **Presence in the Visual Workflow Designer now shows real avatars.** When several people have the same Advanced workflow open, the toolbar's presence row now shows each person by their gravatar (or their initials if they have none), and a person appears once no matter how many browser tabs they have it open in. See [Advanced Workflows](/guides/workflows/advanced-workflows/#whos-here).
 
 ## Fixed
+
+- **Pushing to a Server Panel app's repository now rebuilds the app.** Publishing a Server Panel app from a PlaidCloud Git or GitHub connection always worked, but pushes to the connection's branch afterwards were not picked up — the app kept serving the version it was first built from until someone republished it by hand. Pushes now rebuild and redeploy automatically, as described in [Deploy a Panel App from Git](/guides/panel-apps/deploy-from-git/). A locked app still skips the rebuild until you unlock it. No change is needed to existing apps or connections.
 
 - **Renaming a step's run conditions works again.** When you set conditions that must be met before a step runs, you can now rename each condition — edit the new **Name** field in the Configuration panel, or double-click the condition in the list. Right-click a condition for **Rename** and **Delete** as well. See [Run Conditions on a Step](/guides/workflows/step-conditions/).
 


### PR DESCRIPTION
[Deploy a Panel App from Git](https://docs.plaid.cloud/guides/panel-apps/deploy-from-git/) already tells users that *"every push to the connection's branch rebuilds and redeploys the app automatically"*. That did not actually happen — pushes were never picked up, so an app kept serving whatever it was first built from until someone republished it by hand.

Two independent bugs caused it, both now fixed and live fleet-wide (sc-23119): the tenant edge never routed webhook deliveries to the platform, and the receiver required a header Forgejo does not send. Verified end-to-end — a real push now drives build → deploy → ready.

The guide needed no change, since it already described the intended behaviour. This adds the `## Fixed` entry to July's What's New, plus the v5.11.4 and v5.11.5 rows to **Releases Shipped** (v5.11.3 was superseded and never deployed, so it is deliberately absent).

No new headings, no code samples, and no brace tokens that would trip the MDX build.