### PR TITLE
Document pasting a collection or spec into the REST step (sc-23214)

### DIFF
--- a/src/content/docs/guides/workflows/rest-request-step.mdx
+++ b/src/content/docs/guides/workflows/rest-request-step.mdx
@@ -42,6 +42,14 @@ Pick how you'll supply the endpoint, then PlaidCloud fills in the request for yo
 
 For an imported source, choose **Load Catalog** to list the available endpoints, filter to the one you want, and the step prefills the method, URL, headers, and parameters.
 
+### Paste a Collection or Spec Instead of Picking a File
+
+The three file-based sources — Postman collection, OpenAPI/Swagger, and HAR archive — each offer a **Paste…** button beside the file picker. Use it when you have the content to hand but haven't saved it to Document: paste the JSON and choose **Use This**. The catalog loads straight away, so there's no need to click **Load Catalog** afterwards.
+
+Pasted content is used in place of the file picker, and lasts as long as the step stays open — it isn't saved with the step, so paste it again if you reopen the step and want to reload the catalog from it. If you pick a file for that same source, the file wins and the pasted content is discarded — the step tells you when that happens.
+
+<Aside type="note">Paste accepts JSON. For a YAML spec, save the file to Document and pick it instead.</Aside>
+
 ### Reuse a Connection's API Definition
 
 Connectors built for a specific service already know their endpoints. Generic REST and MuleSoft connections don't — they can point at any API — so they let you attach the API's definition to the connection itself.

--- a/src/content/docs/reference/workflow-steps/general/rest-request.md
+++ b/src/content/docs/reference/workflow-steps/general/rest-request.md
@@ -17,7 +17,7 @@ While you edit, the browser keeps a local draft for the step. If you close or re
 
 ### Request
 
-* **Endpoint Source** — `Manual`, `Postman collection (file/URL)`, `OpenAPI / Swagger (URL/file)`, or `HAR archive (file)`. Use **Load Catalog** to list and pick an endpoint from an imported source.
+* **Endpoint Source** — `Manual`, `From the connection's API definition`, `Postman collection (file/URL)`, `OpenAPI / Swagger (URL/file)`, or `HAR archive (file)`. Use **Load Catalog** to list and pick an endpoint from an imported source. The three file sources also offer **Paste…**, letting you supply the collection or spec directly instead of picking a file.
 * **Connection** *(optional)* — a REST connection for auth and base URL; omit to call a full URL directly. The edit shortcut beside the picker opens the selected connection editor for viewing or editing.
 * **Method** — `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`.
 * **Endpoint** — path (with a connection) or full URL.

--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -15,6 +15,8 @@ description: Machine learning in workflows, a Currency data type for money value
 
 ## Added
 
+- **Paste a collection or spec into a REST Request step.** The Postman, OpenAPI/Swagger, and HAR sources each gained a **Paste…** button beside the file picker, so you can supply the content directly instead of saving it to Document first. See [REST Request Step](/guides/workflows/rest-request-step/#paste-a-collection-or-spec-instead-of-picking-a-file).
+
 - **Attach an API definition to a REST connection.** Generic REST and MuleSoft connections can now carry their own OpenAPI 3.x or Swagger 2.0 definition — a published address, or a specification file kept in Document. Set it once on the connection under **API Definition**, then any REST Request step using that connection can set **Endpoint Source** to **From the connection's API definition** and list the API's endpoints, with methods, parameters, and bodies filled in, without restating the definition on every step. See [Generic REST Connection](/reference/connectors/rest/generic-rest/#api-definition) and [REST Request Step](/guides/workflows/rest-request-step/#reuse-a-connections-api-definition).
 
 - **MuleSoft is available as a connection type.** Add a MuleSoft Anypoint gateway from the New Connection menu and configure it like any other REST connection — your own gateway address and whichever authentication it expects. See [MuleSoft REST Connector](/reference/connectors/rest/mulesoft/).


### PR DESCRIPTION
Documents the **Paste…** action added in PlaidCloud/PlaidClient#1899, which restores supplying a Postman collection, OpenAPI/Swagger spec, or HAR archive directly instead of saving it to Document first.

- `guides/workflows/rest-request-step.mdx` — new section under Endpoint Source covering the button, the JSON-only constraint (YAML still goes through Document), and the precedence rule: pasted content is used in place of the picker, and picking a file afterwards discards it, with the step saying so.
- `releases/2026-07.mdx` — matching entry under Added.

Raised because the repo convention is that a user-facing change lands its guide update in the same change rather than as a follow-up; a review of #1899 flagged that the guide documents every other endpoint source in detail but had no mention of this one.

Built locally — 1522 pages, clean.