### PR TITLE
docs(releases): AI-assistant underscore-column expression fix (sc-23186)

### DIFF
--- a/src/content/docs/releases/2026-07.mdx
+++ b/src/content/docs/releases/2026-07.mdx
@@ -98,6 +98,8 @@ description: Machine learning in workflows, a Currency data type for money value
 
 - **Moving large or many documents between folders.** Moving several files at once — or a single large file — from one Document folder to another now works reliably. Moves run one at a time so the file list stays consistent, and a large move is given the time it needs to finish instead of being cut off partway.
 
+- **The AI assistant no longer refuses expressions that reference underscore-named columns.** An expression referencing a column whose name starts with an underscore (for example `_MajorAccountFlag`) is now accepted. And when an expression tests a column with `is`, `is not`, or `not` — which on a column never matches any row, or errors, rather than doing what it looks like — the assistant steers you to the operator that works (`is_(None)` for a null test, `!=`, `~`) instead of a plain rejection.
+
 ## Removed
 
 - **Retired legacy import and export steps** — the SAS7BDAT import, HTML import, and HTML export steps have been removed. Use the current import and export steps for these formats instead.


### PR DESCRIPTION
Adds a July What's New entry for the plaid-side change in PlaidCloud/plaid#6700 (sc-23186): the AI assistant now accepts expressions that reference underscore-named columns (e.g. `_MajorAccountFlag`) and steers `is` / `is not` / `not` on a column to the operator that actually works.

Scoped to what ships now — this is the AI assistant validator behaviour, which does not depend on the still-open runtime half (plaid-utilities#335). One bullet under `## Fixed` in `2026-07.mdx`; no other pages touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)