### PR TITLE
Document the AI and LLM architecture, with diagrams

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -192,6 +192,7 @@ export default defineConfig({
 					label: 'Integrations',
 					items: [
 						{ label: 'Overview',              link: '/integrations/' },
+						{ label: 'AI and LLM architecture', collapsed: true, items: [{ autogenerate: { directory: 'integrations/ai-architecture' } }] },
 						{ label: 'Microsoft 365 Copilot', link: '/integrations/microsoft-365-copilot/' },
 						{ label: 'AI coding agents',      collapsed: true, items: [{ autogenerate: { directory: 'integrations/ai-coding-agents' } }] },
 						{ label: 'PySpark',               collapsed: true, items: [{ autogenerate: { directory: 'integrations/pyspark' } }] },

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -243,7 +243,7 @@ Documentation structure:
 - \`get-started/\` — concepts, quickstart, end-to-end tutorials, FAQ
 - \`guides/\` — task-oriented how-to content
 - \`reference/\` — workflow steps, expressions (SQL functions), connectors, CLI, glossary
-- \`integrations/\` — AI coding agents, PySpark
+- \`integrations/\` — AI and LLM architecture, Microsoft 365 Copilot, AI coding agents, PySpark
 - \`administration/\` — access management, SSO/SAML, scheduled events
 - \`releases/\` — monthly release notes`,
 					customSets: [

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -191,11 +191,11 @@ export default defineConfig({
 				{
 					label: 'Integrations',
 					items: [
-						{ label: 'Overview',              link: '/integrations/' },
+						{ label: 'Overview',                link: '/integrations/' },
 						{ label: 'AI and LLM architecture', collapsed: true, items: [{ autogenerate: { directory: 'integrations/ai-architecture' } }] },
-						{ label: 'Microsoft 365 Copilot', link: '/integrations/microsoft-365-copilot/' },
-						{ label: 'AI coding agents',      collapsed: true, items: [{ autogenerate: { directory: 'integrations/ai-coding-agents' } }] },
-						{ label: 'PySpark',               collapsed: true, items: [{ autogenerate: { directory: 'integrations/pyspark' } }] },
+						{ label: 'Microsoft 365 Copilot',   link: '/integrations/microsoft-365-copilot/' },
+						{ label: 'AI coding agents',        collapsed: true, items: [{ autogenerate: { directory: 'integrations/ai-coding-agents' } }] },
+						{ label: 'PySpark',                 collapsed: true, items: [{ autogenerate: { directory: 'integrations/pyspark' } }] },
 					],
 				},
 				{

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -192,7 +192,7 @@ export default defineConfig({
 					label: 'Integrations',
 					items: [
 						{ label: 'Overview',                link: '/integrations/' },
-						{ label: 'AI and LLM architecture', collapsed: true, items: [{ autogenerate: { directory: 'integrations/ai-architecture' } }] },
+						{ label: 'AI and LLM Architecture', collapsed: true, items: [{ autogenerate: { directory: 'integrations/ai-architecture' } }] },
 						{ label: 'Microsoft 365 Copilot',   link: '/integrations/microsoft-365-copilot/' },
 						{ label: 'AI coding agents',        collapsed: true, items: [{ autogenerate: { directory: 'integrations/ai-coding-agents' } }] },
 						{ label: 'PySpark',                 collapsed: true, items: [{ autogenerate: { directory: 'integrations/pyspark' } }] },

--- a/public/images/ai-copilot-architecture.svg
+++ b/public/images/ai-copilot-architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1240" height="740" viewBox="0 0 1240 740" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" role="img" aria-label="Microsoft 365 Copilot architecture: a declarative agent published in your Microsoft tenant signs the user in to a dedicated PlaidCloud OAuth client, then calls the PlaidCloud MCP endpoint where a deny-by-default access tier and the user's own permissions gate every tool call. Credential, identity, and access-control tools are never reachable.">
+<svg xmlns="http://www.w3.org/2000/svg" width="1240" height="740" viewBox="0 0 1240 740" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" role="img" aria-label="Microsoft 365 Copilot architecture: a declarative agent published in your Microsoft tenant signs the user in to a dedicated PlaidCloud OAuth client, then calls the PlaidCloud MCP endpoint where a deny-by-default access level and the user's own permissions gate every tool call. Credential, identity, and access-control tools are never reachable.">
 <defs>
 <filter id="soft3" x="-20%" y="-20%" width="140%" height="140%"><feDropShadow dx="0" dy="2" stdDeviation="5" flood-color="#1B2A44" flood-opacity="0.10"/></filter>
 <marker id="a3" markerWidth="9" markerHeight="9" refX="6.5" refY="4" orient="auto"><path d="M1 1 L7 4 L1 7" fill="none" stroke="#5B6B82" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></marker>
@@ -47,22 +47,22 @@
 <text x="586" y="210" font-size="12" fill="#5B6B82">pre-registered and a longer refresh window so sign-in lasts about a month.</text>
 <text x="586" y="228" font-size="12" font-weight="700" fill="#0F7A63">The person signs in as themselves — no shared service account.</text>
 
-<text x="586" y="282" font-size="15" font-weight="700" fill="#1B2A44">Access tier — deny by default</text>
+<text x="586" y="282" font-size="15" font-weight="700" fill="#1B2A44">Access level — deny by default</text>
 <text x="586" y="304" font-size="12" fill="#5B6B82">Resolved on the server from the role an administrator assigned, not from anything</text>
 <text x="586" y="322" font-size="12" fill="#5B6B82">the token claims. No role means no data, and the agent says so plainly.</text>
 <text x="586" y="348" font-size="12.5" fill="#1B2A44"><tspan font-weight="700">Read-only</tspan> · list, describe, read, explain</text>
 <text x="586" y="368" font-size="12.5" fill="#1B2A44"><tspan font-weight="700">Read/write</tspan> · permitted writes   ·   <tspan font-weight="700">Full</tspan> · the person's whole toolset</text>
-<text x="586" y="386" font-size="11.5" fill="#5B6B82">Most permissive role wins. The tier is a ceiling, never an expansion.</text>
+<text x="586" y="386" font-size="11.5" fill="#5B6B82">Most permissive role wins. The level is a ceiling, never an expansion.</text>
 
 <text x="586" y="444" font-size="15" font-weight="700" fill="#1B2A44">Curated MCP server</text>
-<text x="586" y="466" font-size="12" fill="#5B6B82">Every call re-checks the tier, the person's own scopes and ACLs, and the denylist.</text>
+<text x="586" y="466" font-size="12" fill="#5B6B82">Every call re-checks the level, the person's own scopes and ACLs, and the denylist.</text>
 
 <text x="586" y="536" font-size="15" font-weight="700" fill="#1B2A44">Your project data</text>
 <text x="586" y="558" font-size="12" fill="#5B6B82">Read live under that person's permissions — the answer is a real query result.</text>
 
 <!-- denied -->
 <g filter="url(#soft3)"><rect x="40" y="636" width="1160" height="76" rx="12" fill="#FDF3F2" stroke="#E4B4AE"/></g>
-<text x="64" y="666" font-size="14" font-weight="700" fill="#A33227">Never reachable through Copilot, at any tier</text>
+<text x="64" y="666" font-size="14" font-weight="700" fill="#A33227">Never reachable through Copilot, at any level</text>
 <text x="64" y="690" font-size="12" fill="#8C4238">Credential and connection settings · identity and group management · access-control changes · publishing · deployable code. These stay human-only.</text>
 
 <!-- arrows -->

--- a/public/images/ai-copilot-architecture.svg
+++ b/public/images/ai-copilot-architecture.svg
@@ -51,7 +51,7 @@
 <text x="586" y="304" font-size="12" fill="#5B6B82">Resolved on the server from the role an administrator assigned, not from anything</text>
 <text x="586" y="322" font-size="12" fill="#5B6B82">the token claims. No role means no data, and the agent says so plainly.</text>
 <text x="586" y="348" font-size="12.5" fill="#1B2A44"><tspan font-weight="700">Read-only</tspan> · list, describe, read, explain</text>
-<text x="586" y="368" font-size="12.5" fill="#1B2A44"><tspan font-weight="700">Read/write</tspan> · permitted writes   ·   <tspan font-weight="700">Full</tspan> · the person's whole toolset</text>
+<text x="586" y="368" font-size="12.5" fill="#1B2A44"><tspan font-weight="700">Read/Write</tspan> · permitted writes   ·   <tspan font-weight="700">Full</tspan> · the person's whole toolset</text>
 <text x="586" y="386" font-size="11.5" fill="#5B6B82">Most permissive role wins. The level is a ceiling, never an expansion.</text>
 
 <text x="586" y="444" font-size="15" font-weight="700" fill="#1B2A44">Curated MCP server</text>

--- a/public/images/ai-copilot-architecture.svg
+++ b/public/images/ai-copilot-architecture.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1240" height="740" viewBox="0 0 1240 740" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" role="img" aria-label="Microsoft 365 Copilot architecture: a declarative agent published in your Microsoft tenant signs the user in to a dedicated PlaidCloud OAuth client, then calls the PlaidCloud MCP endpoint where a deny-by-default access tier and the user's own permissions gate every tool call. Credential, identity, and access-control tools are never reachable.">
+<defs>
+<filter id="soft3" x="-20%" y="-20%" width="140%" height="140%"><feDropShadow dx="0" dy="2" stdDeviation="5" flood-color="#1B2A44" flood-opacity="0.10"/></filter>
+<marker id="a3" markerWidth="9" markerHeight="9" refX="6.5" refY="4" orient="auto"><path d="M1 1 L7 4 L1 7" fill="none" stroke="#5B6B82" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></marker>
+</defs>
+
+<rect width="1240" height="740" fill="#FBFCFE"/>
+<text x="40" y="46" font-size="24" font-weight="700" fill="#002F6C">Microsoft 365 Copilot — What Makes It Different</text>
+<text x="40" y="70" font-size="13" fill="#5B6B82">Copilot cannot be pointed at an arbitrary server, so PlaidCloud ships a published agent package and a pre-registered OAuth client instead.</text>
+
+<!-- Microsoft side -->
+<rect x="40" y="100" width="440" height="510" rx="16" fill="#F4F6FA" stroke="#B9C6D8" stroke-dasharray="7 5"/>
+<text x="62" y="126" font-size="13" font-weight="700" fill="#3F5470">YOUR MICROSOFT 365 TENANT</text>
+
+<g filter="url(#soft3)">
+<rect x="64" y="142" width="392" height="76" rx="10" fill="#FFFFFF" stroke="#C6D6E8"/>
+<rect x="64" y="238" width="392" height="96" rx="10" fill="#FFFFFF" stroke="#C6D6E8"/>
+<rect x="64" y="354" width="392" height="96" rx="10" fill="#FFFFFF" stroke="#C6D6E8"/>
+</g>
+<text x="86" y="170" font-size="15" font-weight="700" fill="#1B2A44">A person in Teams, Outlook, or M365 chat</text>
+<text x="86" y="192" font-size="12" fill="#5B6B82">Asks in plain language — no PlaidCloud window, no SQL</text>
+<text x="86" y="210" font-size="12" fill="#5B6B82">"Why did allocated IT cost for Atlanta go up last quarter?"</text>
+
+<text x="86" y="266" font-size="15" font-weight="700" fill="#1B2A44">PlaidCloud declarative agent</text>
+<text x="86" y="288" font-size="12" fill="#5B6B82">A .zip package you download from the control plane and</text>
+<text x="86" y="306" font-size="12" fill="#5B6B82">your Teams admin uploads to the org app catalog.</text>
+<text x="86" y="324" font-size="12" font-weight="700" fill="#9A6B2E">Named for your workspace; one package per workspace.</text>
+
+<text x="86" y="382" font-size="15" font-weight="700" fill="#1B2A44">Microsoft-brokered sign-in</text>
+<text x="86" y="404" font-size="12" fill="#5B6B82">Copilot opens its own sign-in window and stores the result</text>
+<text x="86" y="422" font-size="12" fill="#5B6B82">against a fixed Microsoft redirect address.</text>
+<text x="86" y="440" font-size="12" font-weight="700" fill="#9A6B2E">Roughly monthly re-sign-in, not daily.</text>
+
+<!-- PlaidCloud side -->
+<rect x="540" y="100" width="660" height="510" rx="16" fill="#F3F7FC" stroke="#9FBEDC" stroke-dasharray="7 5"/>
+<text x="562" y="126" font-size="13" font-weight="700" fill="#002F6C">YOUR PLAIDCLOUD TENANT</text>
+
+<g filter="url(#soft3)">
+<rect x="564" y="142" width="612" height="92" rx="10" fill="#FFFFFF" stroke="#C6D6E8"/>
+<rect x="564" y="254" width="612" height="142" rx="10" fill="#FFFFFF" stroke="#C6D6E8"/>
+<rect x="564" y="416" width="612" height="72" rx="10" fill="#FFFFFF" stroke="#C6D6E8"/>
+<rect x="564" y="508" width="612" height="72" rx="10" fill="#EAF3FA" stroke="#9FBEDC"/>
+</g>
+
+<text x="586" y="170" font-size="15" font-weight="700" fill="#1B2A44">PlaidCloud identity — a dedicated Copilot client</text>
+<text x="586" y="192" font-size="12" fill="#5B6B82">A confidential OAuth client per tenant realm, with the Microsoft redirect address</text>
+<text x="586" y="210" font-size="12" fill="#5B6B82">pre-registered and a longer refresh window so sign-in lasts about a month.</text>
+<text x="586" y="228" font-size="12" font-weight="700" fill="#0F7A63">The person signs in as themselves — no shared service account.</text>
+
+<text x="586" y="282" font-size="15" font-weight="700" fill="#1B2A44">Access tier — deny by default</text>
+<text x="586" y="304" font-size="12" fill="#5B6B82">Resolved on the server from the role an administrator assigned, not from anything</text>
+<text x="586" y="322" font-size="12" fill="#5B6B82">the token claims. No role means no data, and the agent says so plainly.</text>
+<text x="586" y="348" font-size="12.5" fill="#1B2A44"><tspan font-weight="700">Read-only</tspan> · list, describe, read, explain</text>
+<text x="586" y="368" font-size="12.5" fill="#1B2A44"><tspan font-weight="700">Read/write</tspan> · permitted writes   ·   <tspan font-weight="700">Full</tspan> · the person's whole toolset</text>
+<text x="586" y="386" font-size="11.5" fill="#5B6B82">Most permissive role wins. The tier is a ceiling, never an expansion.</text>
+
+<text x="586" y="444" font-size="15" font-weight="700" fill="#1B2A44">Curated MCP server</text>
+<text x="586" y="466" font-size="12" fill="#5B6B82">Every call re-checks the tier, the person's own scopes and ACLs, and the denylist.</text>
+
+<text x="586" y="536" font-size="15" font-weight="700" fill="#1B2A44">Your project data</text>
+<text x="586" y="558" font-size="12" fill="#5B6B82">Read live under that person's permissions — the answer is a real query result.</text>
+
+<!-- denied -->
+<g filter="url(#soft3)"><rect x="40" y="636" width="1160" height="76" rx="12" fill="#FDF3F2" stroke="#E4B4AE"/></g>
+<text x="64" y="666" font-size="14" font-weight="700" fill="#A33227">Never reachable through Copilot, at any tier</text>
+<text x="64" y="690" font-size="12" fill="#8C4238">Credential and connection settings · identity and group management · access-control changes · publishing · deployable code. These stay human-only.</text>
+
+<!-- arrows -->
+<path d="M260 218 L260 238" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#a3)"/>
+<path d="M260 334 L260 354" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#a3)"/>
+
+<path d="M456 286 L556 196" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#a3)"/>
+<text x="506" y="228" font-size="11.5" fill="#5B6B82" text-anchor="middle">sign in</text>
+<path d="M456 402 L556 312" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#a3)"/>
+<text x="506" y="344" font-size="11.5" fill="#5B6B82" text-anchor="middle">then ask</text>
+
+<path d="M870 234 L870 254" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#a3)"/>
+<path d="M870 396 L870 416" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#a3)"/>
+<path d="M870 488 L870 508" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#a3)"/>
+</svg>

--- a/public/images/ai-llm-architecture.svg
+++ b/public/images/ai-llm-architecture.svg
@@ -1,0 +1,110 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1240" height="720" viewBox="0 0 1240 720" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" role="img" aria-label="PlaidCloud AI and LLM architecture: four client surfaces enter the PlaidCloud tenant boundary, which holds delegated tokens, the curated MCP server, access enforcement, AI services, and project data. Prompts travel outward to an LLM provider, which may be a vendor API or a model you host yourself.">
+<defs>
+<filter id="soft" x="-20%" y="-20%" width="140%" height="140%"><feDropShadow dx="0" dy="2" stdDeviation="5" flood-color="#1B2A44" flood-opacity="0.10"/></filter>
+<marker id="arrow" markerWidth="9" markerHeight="9" refX="6.5" refY="4" orient="auto"><path d="M1 1 L7 4 L1 7" fill="none" stroke="#5B6B82" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></marker>
+<marker id="arrowCyan" markerWidth="9" markerHeight="9" refX="6.5" refY="4" orient="auto"><path d="M1 1 L7 4 L1 7" fill="none" stroke="#0089BE" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></marker>
+</defs>
+
+<rect width="1240" height="720" fill="#FBFCFE"/>
+<text x="40" y="46" font-size="24" font-weight="700" fill="#002F6C">PlaidCloud AI and LLM Architecture</text>
+<text x="40" y="70" font-size="13" fill="#5B6B82">Every surface reaches your data through the same governed path. Only the model lives outside the tenant.</text>
+
+<!-- Column A: client surfaces -->
+<text x="40" y="112" font-size="12" font-weight="700" fill="#5B6B82" letter-spacing="1.2">CLIENT SURFACES</text>
+<g filter="url(#soft)">
+<rect x="40" y="126" width="212" height="66" rx="10" fill="#FFFFFF" stroke="#D3DEEA"/>
+<rect x="40" y="212" width="212" height="66" rx="10" fill="#FFFFFF" stroke="#D3DEEA"/>
+<rect x="40" y="298" width="212" height="66" rx="10" fill="#FFFFFF" stroke="#D3DEEA"/>
+<rect x="40" y="384" width="212" height="66" rx="10" fill="#FFFFFF" stroke="#D3DEEA"/>
+</g>
+<rect x="40" y="126" width="5" height="66" rx="2.5" fill="#00A3E0"/>
+<rect x="40" y="212" width="5" height="66" rx="2.5" fill="#00A3E0"/>
+<rect x="40" y="298" width="5" height="66" rx="2.5" fill="#00A3E0"/>
+<rect x="40" y="384" width="5" height="66" rx="2.5" fill="#00A3E0"/>
+<text x="60" y="152" font-size="14" font-weight="700" fill="#1B2A44">In-app AI Assistant</text>
+<text x="60" y="172" font-size="11.5" fill="#5B6B82">PlaidCloud web app and mobile</text>
+<text x="60" y="238" font-size="14" font-weight="700" fill="#1B2A44">Microsoft 365 Copilot</text>
+<text x="60" y="258" font-size="11.5" fill="#5B6B82">Teams, Outlook, M365 chat</text>
+<text x="60" y="324" font-size="14" font-weight="700" fill="#1B2A44">AI coding agents</text>
+<text x="60" y="344" font-size="11.5" fill="#5B6B82">Claude Code, Cursor, ChatGPT…</text>
+<text x="60" y="410" font-size="14" font-weight="700" fill="#1B2A44">LLM workflow step</text>
+<text x="60" y="430" font-size="11.5" fill="#5B6B82">Unattended, inside a pipeline</text>
+
+<!-- Column B: tenant boundary -->
+<rect x="290" y="100" width="530" height="580" rx="16" fill="#F3F7FC" stroke="#9FBEDC" stroke-dasharray="7 5"/>
+<text x="314" y="126" font-size="13" font-weight="700" fill="#002F6C">YOUR PLAIDCLOUD TENANT</text>
+<text x="796" y="126" font-size="11.5" fill="#5B6B82" text-anchor="end">data stays inside unless asked for</text>
+
+<g filter="url(#soft)">
+<rect x="314" y="142" width="482" height="78" rx="10" fill="#FFFFFF" stroke="#C6D6E8"/>
+<rect x="314" y="234" width="482" height="78" rx="10" fill="#FFFFFF" stroke="#C6D6E8"/>
+<rect x="314" y="326" width="482" height="78" rx="10" fill="#FFFFFF" stroke="#C6D6E8"/>
+<rect x="314" y="418" width="482" height="96" rx="10" fill="#FFFFFF" stroke="#C6D6E8"/>
+<rect x="314" y="578" width="482" height="80" rx="10" fill="#EAF3FA" stroke="#9FBEDC"/>
+</g>
+
+<text x="336" y="170" font-size="15" font-weight="700" fill="#1B2A44">Delegated tokens</text>
+<text x="336" y="192" font-size="12" fill="#5B6B82">Short-lived and revoked after use — agent session,</text>
+<text x="336" y="210" font-size="12" fill="#5B6B82">workflow step token, Copilot token</text>
+
+<text x="336" y="262" font-size="15" font-weight="700" fill="#1B2A44">Curated MCP server</text>
+<text x="336" y="284" font-size="12" fill="#5B6B82">One governed tool catalog: find, describe, read, run,</text>
+<text x="336" y="302" font-size="12" fill="#5B6B82">upsert — the only way in</text>
+
+<text x="336" y="354" font-size="15" font-weight="700" fill="#1B2A44">Access enforcement</text>
+<text x="336" y="376" font-size="12" fill="#5B6B82">Your own scopes and ACLs, an access-tier ceiling,</text>
+<text x="336" y="394" font-size="12" fill="#5B6B82">and a permanent tool denylist</text>
+
+<text x="336" y="446" font-size="15" font-weight="700" fill="#1B2A44">AI services</text>
+<text x="336" y="468" font-size="12" fill="#5B6B82">Orchestrator and task agents · documentation retrieval</text>
+<text x="336" y="488" font-size="12" fill="#5B6B82">Analysis paths · expression catalog · conversation history</text>
+
+<text x="336" y="606" font-size="15" font-weight="700" fill="#1B2A44">Your project data</text>
+<text x="336" y="628" font-size="12" fill="#5B6B82">Lakehouse tables, dimensions, workflows, documents —</text>
+<text x="336" y="646" font-size="12" fill="#5B6B82">read live, never pre-indexed</text>
+
+<!-- Column C: providers -->
+<text x="916" y="112" font-size="12" font-weight="700" fill="#5B6B82" letter-spacing="1.2">THE MODEL</text>
+<rect x="904" y="126" width="296" height="330" rx="14" fill="#FFF7EE" stroke="#E8C79A"/>
+<text x="922" y="152" font-size="11.5" font-weight="700" fill="#9A6B2E">A vendor API — outside your tenant</text>
+<g filter="url(#soft)">
+<rect x="922" y="166" width="260" height="44" rx="8" fill="#FFFFFF" stroke="#E3D3BC"/>
+<rect x="922" y="220" width="260" height="44" rx="8" fill="#FFFFFF" stroke="#E3D3BC"/>
+<rect x="922" y="274" width="260" height="44" rx="8" fill="#FFFFFF" stroke="#E3D3BC"/>
+<rect x="922" y="328" width="260" height="44" rx="8" fill="#FFFFFF" stroke="#E3D3BC"/>
+<rect x="922" y="382" width="260" height="44" rx="8" fill="#FFFFFF" stroke="#E3D3BC"/>
+</g>
+<text x="942" y="194" font-size="13.5" fill="#1B2A44">Anthropic — Claude</text>
+<text x="942" y="248" font-size="13.5" fill="#1B2A44">OpenAI — GPT</text>
+<text x="942" y="302" font-size="13.5" fill="#1B2A44">Google — Gemini</text>
+<text x="942" y="356" font-size="13.5" fill="#1B2A44">xAI — Grok</text>
+<text x="942" y="410" font-size="13.5" fill="#1B2A44">Azure OpenAI — your resource</text>
+
+<rect x="904" y="478" width="296" height="94" rx="14" fill="#EFF8F5" stroke="#7FBFAE"/>
+<text x="922" y="504" font-size="11.5" font-weight="700" fill="#0F7A63">…or a model you run yourself</text>
+<g filter="url(#soft)"><rect x="922" y="514" width="260" height="44" rx="8" fill="#FFFFFF" stroke="#7FBFAE"/></g>
+<text x="942" y="542" font-size="13.5" font-weight="700" fill="#0F7A63">Self-hosted — your hardware</text>
+
+<!-- flows: surfaces into the tenant -->
+<path d="M252 159 L284 159" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#arrow)"/>
+<path d="M252 245 L284 262" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#arrow)"/>
+<path d="M252 331 L284 274" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#arrow)"/>
+<path d="M252 417 L284 286" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#arrow)"/>
+
+<!-- flows: tenant to model and back -->
+<path d="M824 250 L898 250" stroke="#0089BE" stroke-width="1.8" fill="none" marker-end="url(#arrowCyan)"/>
+<text x="861" y="242" font-size="11" fill="#0089BE" text-anchor="middle">prompt</text>
+<path d="M898 330 L824 330" stroke="#0089BE" stroke-width="1.8" fill="none" marker-end="url(#arrowCyan)"/>
+<text x="861" y="322" font-size="11" fill="#0089BE" text-anchor="middle">answer</text>
+
+<!-- flows: inside the tenant -->
+<path d="M555 220 L555 234" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#arrow)"/>
+<path d="M555 312 L555 326" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#arrow)"/>
+<path d="M555 404 L555 418" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#arrow)"/>
+<path d="M450 514 L450 578" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#arrow)"/>
+<path d="M660 578 L660 514" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#arrow)"/>
+<text x="462" y="552" font-size="11" fill="#5B6B82">read / write</text>
+<text x="648" y="552" font-size="11" fill="#5B6B82" text-anchor="end">results</text>
+
+<text x="40" y="706" font-size="11.5" fill="#5B6B82">The model is a reasoning engine, not a data store: it asks for data through tools, under the signed-in person's permissions, one request at a time.</text>
+</svg>

--- a/public/images/ai-llm-architecture.svg
+++ b/public/images/ai-llm-architecture.svg
@@ -52,7 +52,7 @@
 <text x="336" y="302" font-size="12" fill="#5B6B82">upsert — the only way in</text>
 
 <text x="336" y="354" font-size="15" font-weight="700" fill="#1B2A44">Access enforcement</text>
-<text x="336" y="376" font-size="12" fill="#5B6B82">Your own scopes and ACLs, an access-tier ceiling,</text>
+<text x="336" y="376" font-size="12" fill="#5B6B82">Your own scopes and ACLs, an administrator-set ceiling,</text>
 <text x="336" y="394" font-size="12" fill="#5B6B82">and a permanent tool denylist</text>
 
 <text x="336" y="446" font-size="15" font-weight="700" fill="#1B2A44">AI services</text>

--- a/public/images/ai-llm-architecture.svg
+++ b/public/images/ai-llm-architecture.svg
@@ -87,9 +87,9 @@
 
 <!-- flows: surfaces into the tenant -->
 <path d="M252 159 L284 159" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#arrow)"/>
-<path d="M252 245 L284 262" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#arrow)"/>
-<path d="M252 331 L284 274" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#arrow)"/>
-<path d="M252 417 L284 286" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#arrow)"/>
+<path d="M252 245 L284 245" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#arrow)"/>
+<path d="M252 331 L284 331" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#arrow)"/>
+<path d="M252 417 L284 417" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#arrow)"/>
 
 <!-- flows: tenant to model and back -->
 <path d="M824 250 L898 250" stroke="#0089BE" stroke-width="1.8" fill="none" marker-end="url(#arrowCyan)"/>

--- a/public/images/ai-llm-providers.svg
+++ b/public/images/ai-llm-providers.svg
@@ -1,0 +1,81 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1240" height="660" viewBox="0 0 1240 660" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" role="img" aria-label="LLM Provider connection routing: one connection selects a provider, which maps to one of four execution adapters, and tools are brokered either server-side by Anthropic's MCP connector or client-side by PlaidCloud.">
+<defs>
+<filter id="soft2" x="-20%" y="-20%" width="140%" height="140%"><feDropShadow dx="0" dy="2" stdDeviation="5" flood-color="#1B2A44" flood-opacity="0.10"/></filter>
+<marker id="a2" markerWidth="9" markerHeight="9" refX="6.5" refY="4" orient="auto"><path d="M1 1 L7 4 L1 7" fill="none" stroke="#5B6B82" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></marker>
+</defs>
+
+<rect width="1240" height="660" fill="#FBFCFE"/>
+<text x="40" y="46" font-size="24" font-weight="700" fill="#002F6C">One Connection, Any Provider</text>
+<text x="40" y="70" font-size="13" fill="#5B6B82">The provider you pick decides which execution adapter runs and how the model reaches PlaidCloud tools.</text>
+
+<!-- Stage 1: connection -->
+<text x="40" y="112" font-size="12" font-weight="700" fill="#5B6B82" letter-spacing="1.2">1 · LLM PROVIDER CONNECTION</text>
+<g filter="url(#soft2)"><rect x="40" y="126" width="252" height="300" rx="12" fill="#FFFFFF" stroke="#C6D6E8"/></g>
+<rect x="40" y="126" width="252" height="6" rx="3" fill="#002F6C"/>
+<text x="60" y="164" font-size="14" font-weight="700" fill="#1B2A44">Provider</text>
+<text x="60" y="184" font-size="12" fill="#5B6B82">Anthropic · OpenAI · Gemini</text>
+<text x="60" y="202" font-size="12" fill="#5B6B82">Grok · Azure OpenAI · GitHub</text>
+<text x="60" y="234" font-size="14" font-weight="700" fill="#1B2A44">API key</text>
+<text x="60" y="254" font-size="12" fill="#5B6B82">Yours — billed to your account</text>
+<text x="60" y="286" font-size="14" font-weight="700" fill="#1B2A44">Default model</text>
+<text x="60" y="306" font-size="12" fill="#5B6B82">From the catalog, or free text</text>
+<text x="60" y="338" font-size="14" font-weight="700" fill="#1B2A44">Rules</text>
+<text x="60" y="358" font-size="12" fill="#5B6B82">Standing instructions, prepended</text>
+<text x="60" y="376" font-size="12" fill="#5B6B82">to every system message</text>
+<text x="60" y="404" font-size="12" font-weight="700" fill="#0F7A63">Access tier: read-only by default</text>
+
+<!-- Stage 2: adapters -->
+<text x="352" y="112" font-size="12" font-weight="700" fill="#5B6B82" letter-spacing="1.2">2 · EXECUTION ADAPTER</text>
+<g filter="url(#soft2)">
+<rect x="352" y="126" width="300" height="66" rx="10" fill="#FFFFFF" stroke="#C6D6E8"/>
+<rect x="352" y="206" width="300" height="66" rx="10" fill="#FFFFFF" stroke="#C6D6E8"/>
+<rect x="352" y="286" width="300" height="66" rx="10" fill="#FFFFFF" stroke="#C6D6E8"/>
+<rect x="352" y="366" width="300" height="66" rx="10" fill="#FFFFFF" stroke="#C6D6E8"/>
+</g>
+<text x="372" y="152" font-size="14" font-weight="700" fill="#1B2A44">anthropic</text>
+<text x="372" y="172" font-size="11.5" fill="#5B6B82">Native SDK · MCP connector</text>
+<text x="372" y="232" font-size="14" font-weight="700" fill="#1B2A44">openai_compatible</text>
+<text x="372" y="252" font-size="11.5" fill="#5B6B82">OpenAI, Grok, GitHub Models</text>
+<text x="372" y="312" font-size="14" font-weight="700" fill="#1B2A44">gemini</text>
+<text x="372" y="332" font-size="11.5" fill="#5B6B82">Google GenAI SDK</text>
+<text x="372" y="392" font-size="14" font-weight="700" fill="#1B2A44">azure</text>
+<text x="372" y="412" font-size="11.5" fill="#5B6B82">Your endpoint; model = deployment name</text>
+
+<!-- Stage 3: tool brokering -->
+<text x="712" y="112" font-size="12" font-weight="700" fill="#5B6B82" letter-spacing="1.2">3 · HOW TOOLS ARE BROKERED</text>
+<g filter="url(#soft2)">
+<rect x="712" y="126" width="488" height="150" rx="12" fill="#F3F7FC" stroke="#9FBEDC"/>
+<rect x="712" y="296" width="488" height="176" rx="12" fill="#F3F7FC" stroke="#9FBEDC"/>
+</g>
+<text x="734" y="156" font-size="15" font-weight="700" fill="#002F6C">Server-side connector (Anthropic)</text>
+<text x="734" y="180" font-size="12" fill="#5B6B82">Anthropic's API calls your public MCP endpoint directly,</text>
+<text x="734" y="198" font-size="12" fill="#5B6B82">carrying the short-lived delegated token.</text>
+<text x="734" y="222" font-size="12" fill="#5B6B82">Anthropic manages the tool catalog, so the model sees</text>
+<text x="734" y="240" font-size="12" fill="#5B6B82">everything the token is allowed to call.</text>
+<text x="734" y="262" font-size="11.5" font-weight="700" fill="#0F7A63">Scoped table, dimension, and document bindings live here.</text>
+
+<text x="734" y="326" font-size="15" font-weight="700" fill="#002F6C">Client-side loop (everyone else)</text>
+<text x="734" y="350" font-size="12" fill="#5B6B82">PlaidCloud connects to its own MCP server as a client, lists</text>
+<text x="734" y="368" font-size="12" fill="#5B6B82">the tools, hands them to the model as native functions, runs</text>
+<text x="734" y="386" font-size="12" fill="#5B6B82">the calls itself, and feeds results back until the model answers.</text>
+<text x="734" y="412" font-size="12" fill="#5B6B82">Bounded: capped tool surface and a fixed round-trip limit.</text>
+<text x="734" y="436" font-size="11.5" font-weight="700" fill="#9A6B2E">Same permissions, same enforcement — a different broker.</text>
+<text x="734" y="458" font-size="11.5" fill="#5B6B82">Nothing is sent to the provider except the prompt and tool results.</text>
+
+<!-- arrows -->
+<path d="M292 276 L352 159" stroke="#5B6B82" stroke-width="1.5" fill="none" marker-end="url(#a2)"/>
+<path d="M292 276 L352 239" stroke="#5B6B82" stroke-width="1.5" fill="none" marker-end="url(#a2)"/>
+<path d="M292 276 L352 319" stroke="#5B6B82" stroke-width="1.5" fill="none" marker-end="url(#a2)"/>
+<path d="M292 276 L352 399" stroke="#5B6B82" stroke-width="1.5" fill="none" marker-end="url(#a2)"/>
+
+<path d="M652 159 L712 190" stroke="#5B6B82" stroke-width="1.5" fill="none" marker-end="url(#a2)"/>
+<path d="M652 239 C690 239 680 370 712 370" stroke="#5B6B82" stroke-width="1.5" fill="none" marker-end="url(#a2)"/>
+<path d="M652 319 C690 319 690 376 712 376" stroke="#5B6B82" stroke-width="1.5" fill="none" marker-end="url(#a2)"/>
+<path d="M652 399 L712 382" stroke="#5B6B82" stroke-width="1.5" fill="none" marker-end="url(#a2)"/>
+
+<!-- footer -->
+<g filter="url(#soft2)"><rect x="40" y="510" width="1160" height="94" rx="12" fill="#FFFFFF" stroke="#D3DEEA"/></g>
+<text x="64" y="540" font-size="14" font-weight="700" fill="#1B2A44">The same for every provider</text>
+<text x="64" y="564" font-size="12" fill="#5B6B82">Your own scopes and ACLs · the connection's access tier as a ceiling · the permanent denylist on credential, identity, and access-control tools</text>
+<text x="64" y="586" font-size="12" fill="#5B6B82">Structured results are enforced against a JSON schema, translated per provider · outbound URLs are validated before any call is made</text>
+</svg>

--- a/public/images/ai-llm-providers.svg
+++ b/public/images/ai-llm-providers.svg
@@ -22,7 +22,7 @@
 <text x="60" y="338" font-size="14" font-weight="700" fill="#1B2A44">Rules</text>
 <text x="60" y="358" font-size="12" fill="#5B6B82">Standing instructions, prepended</text>
 <text x="60" y="376" font-size="12" fill="#5B6B82">to every system message</text>
-<text x="60" y="404" font-size="12" font-weight="700" fill="#0F7A63">Access tier: read-only by default</text>
+<text x="60" y="404" font-size="12" font-weight="700" fill="#0F7A63">Agent Access: Read-only by default</text>
 
 <!-- Stage 2: adapters -->
 <text x="352" y="112" font-size="12" font-weight="700" fill="#5B6B82" letter-spacing="1.2">2 · EXECUTION ADAPTER</text>
@@ -76,6 +76,6 @@
 <!-- footer -->
 <g filter="url(#soft2)"><rect x="40" y="510" width="1160" height="94" rx="12" fill="#FFFFFF" stroke="#D3DEEA"/></g>
 <text x="64" y="540" font-size="14" font-weight="700" fill="#1B2A44">The same for every provider</text>
-<text x="64" y="564" font-size="12" fill="#5B6B82">Your own scopes and ACLs · the connection's access tier as a ceiling · the permanent denylist on credential, identity, and access-control tools</text>
+<text x="64" y="564" font-size="12" fill="#5B6B82">Your own scopes and ACLs · the connection's Agent Access as a ceiling · the permanent denylist on credential, identity, and access-control tools</text>
 <text x="64" y="586" font-size="12" fill="#5B6B82">Structured results are enforced against a JSON schema, translated per provider · outbound URLs are validated before any call is made</text>
 </svg>

--- a/public/images/ai-private-llm.svg
+++ b/public/images/ai-private-llm.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1240" height="700" viewBox="0 0 1240 700" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" role="img" aria-label="Three LLM deployment choices — vendor API, a private cloud model resource, and a self-hosted model — compared by where prompts travel, with a summary of what does and does not cross the tenant boundary.">
+<defs>
+<filter id="soft5" x="-20%" y="-20%" width="140%" height="140%"><feDropShadow dx="0" dy="2" stdDeviation="5" flood-color="#1B2A44" flood-opacity="0.10"/></filter>
+<marker id="a5" markerWidth="9" markerHeight="9" refX="6.5" refY="4" orient="auto"><path d="M1 1 L7 4 L1 7" fill="none" stroke="#5B6B82" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></marker>
+</defs>
+
+<rect width="1240" height="700" fill="#FBFCFE"/>
+<text x="40" y="46" font-size="24" font-weight="700" fill="#002F6C">Where Your Prompts Travel — Three Choices</text>
+<text x="40" y="70" font-size="13" fill="#5B6B82">The connection you register decides how far your data travels. Everything else — permissions, tools, auditing — is identical.</text>
+
+<!-- shared origin -->
+<g filter="url(#soft5)"><rect x="40" y="104" width="1160" height="72" rx="12" fill="#F3F7FC" stroke="#9FBEDC"/></g>
+<text x="64" y="134" font-size="15" font-weight="700" fill="#002F6C">Inside your PlaidCloud tenant — identical in all three cases</text>
+<text x="64" y="158" font-size="12" fill="#5B6B82">Delegated short-lived token · curated MCP tools · your scopes and ACLs · access-tier ceiling · permanent denylist · live reads of your lakehouse</text>
+
+<!-- three lanes -->
+<g filter="url(#soft5)">
+<rect x="40" y="220" width="368" height="300" rx="12" fill="#FFF7EE" stroke="#E8C79A"/>
+<rect x="436" y="220" width="368" height="300" rx="12" fill="#F4F6FA" stroke="#B9C6D8"/>
+<rect x="832" y="220" width="368" height="300" rx="12" fill="#EFF8F5" stroke="#7FBFAE"/>
+</g>
+
+<!-- lane 1 -->
+<text x="64" y="252" font-size="12" font-weight="700" fill="#9A6B2E" letter-spacing="1.1">OPTION 1</text>
+<text x="64" y="278" font-size="17" font-weight="700" fill="#1B2A44">Vendor API</text>
+<text x="64" y="300" font-size="12" fill="#5B6B82">Anthropic, OpenAI, Google, xAI</text>
+<text x="64" y="332" font-size="12.5" font-weight="700" fill="#1B2A44">Where prompts go</text>
+<text x="64" y="352" font-size="12" fill="#5B6B82">The vendor's public API, over TLS,</text>
+<text x="64" y="370" font-size="12" fill="#5B6B82">on your own API key and account.</text>
+<text x="64" y="400" font-size="12.5" font-weight="700" fill="#1B2A44">Best for</text>
+<text x="64" y="420" font-size="12" fill="#5B6B82">Frontier capability, no infrastructure</text>
+<text x="64" y="438" font-size="12" fill="#5B6B82">to run, fastest to stand up.</text>
+<text x="64" y="468" font-size="12.5" font-weight="700" fill="#9A6B2E">Consider carefully when</text>
+<text x="64" y="488" font-size="12" fill="#8C6B3E">Regulated data — PHI, PII, trade</text>
+<text x="64" y="506" font-size="12" fill="#8C6B3E">secrets — would appear in prompts.</text>
+
+<!-- lane 2 -->
+<text x="460" y="252" font-size="12" font-weight="700" fill="#3F5470" letter-spacing="1.1">OPTION 2</text>
+<text x="460" y="278" font-size="17" font-weight="700" fill="#1B2A44">Private cloud model</text>
+<text x="460" y="300" font-size="12" fill="#5B6B82">Azure OpenAI in your subscription</text>
+<text x="460" y="332" font-size="12.5" font-weight="700" fill="#1B2A44">Where prompts go</text>
+<text x="460" y="352" font-size="12" fill="#5B6B82">Your own model resource, in your</text>
+<text x="460" y="370" font-size="12" fill="#5B6B82">cloud account, region, and contract.</text>
+<text x="460" y="400" font-size="12.5" font-weight="700" fill="#1B2A44">Best for</text>
+<text x="460" y="420" font-size="12" fill="#5B6B82">Enterprises already covered by a</text>
+<text x="460" y="438" font-size="12" fill="#5B6B82">cloud BAA or data-residency terms.</text>
+<text x="460" y="468" font-size="12.5" font-weight="700" fill="#3F5470">What you control</text>
+<text x="460" y="488" font-size="12" fill="#5B6B82">Region, retention, network policy,</text>
+<text x="460" y="506" font-size="12" fill="#5B6B82">logging — governed by your tenancy.</text>
+
+<!-- lane 3 -->
+<text x="856" y="252" font-size="12" font-weight="700" fill="#0F7A63" letter-spacing="1.1">OPTION 3</text>
+<text x="856" y="278" font-size="17" font-weight="700" fill="#1B2A44">Self-hosted model</text>
+<text x="856" y="300" font-size="12" fill="#5B6B82">Any OpenAI-compatible endpoint</text>
+<text x="856" y="332" font-size="12.5" font-weight="700" fill="#1B2A44">Where prompts go</text>
+<text x="856" y="352" font-size="12" fill="#5B6B82">A server you run. Prompts never</text>
+<text x="856" y="370" font-size="12" fill="#5B6B82">leave infrastructure you control.</text>
+<text x="856" y="400" font-size="12.5" font-weight="700" fill="#1B2A44">Best for</text>
+<text x="856" y="420" font-size="12" fill="#5B6B82">PHI, classified, or contractually</text>
+<text x="856" y="438" font-size="12" fill="#5B6B82">confined data; air-gapped estates.</text>
+<text x="856" y="468" font-size="12.5" font-weight="700" fill="#0F7A63">The trade</text>
+<text x="856" y="488" font-size="12" fill="#3F5470">You own the GPUs, the model choice,</text>
+<text x="856" y="506" font-size="12" fill="#3F5470">and the capability gap versus frontier.</text>
+
+<!-- arrows from shared band -->
+<path d="M224 176 L224 214" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#a5)"/>
+<path d="M620 176 L620 214" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#a5)"/>
+<path d="M1016 176 L1016 214" stroke="#5B6B82" stroke-width="1.6" fill="none" marker-end="url(#a5)"/>
+
+<!-- boundary summary -->
+<g filter="url(#soft5)">
+<rect x="40" y="560" width="568" height="112" rx="12" fill="#FFFFFF" stroke="#D3DEEA"/>
+<rect x="632" y="560" width="568" height="112" rx="12" fill="#FDF3F2" stroke="#E4B4AE"/>
+</g>
+<text x="64" y="590" font-size="14" font-weight="700" fill="#1B2A44">What reaches the model</text>
+<text x="64" y="614" font-size="12" fill="#5B6B82">Your prompt and the standing rules on the connection · the names and</text>
+<text x="64" y="632" font-size="12" fill="#5B6B82">shapes of objects it was told about · the results of the tool calls it made ·</text>
+<text x="64" y="650" font-size="12" fill="#5B6B82">the running conversation for the current chat.</text>
+
+<text x="656" y="590" font-size="14" font-weight="700" fill="#A33227">What never does</text>
+<text x="656" y="614" font-size="12" fill="#8C4238">Connection credentials and stored secrets · anything outside the asking</text>
+<text x="656" y="632" font-size="12" fill="#8C4238">person's permissions · whole tables it did not request · other tenants'</text>
+<text x="656" y="650" font-size="12" fill="#8C4238">data. Your content is not used to train anyone's model.</text>
+</svg>

--- a/public/images/ai-private-llm.svg
+++ b/public/images/ai-private-llm.svg
@@ -11,7 +11,7 @@
 <!-- shared origin -->
 <g filter="url(#soft5)"><rect x="40" y="104" width="1160" height="72" rx="12" fill="#F3F7FC" stroke="#9FBEDC"/></g>
 <text x="64" y="134" font-size="15" font-weight="700" fill="#002F6C">Inside your PlaidCloud tenant — identical in all three cases</text>
-<text x="64" y="158" font-size="12" fill="#5B6B82">Delegated short-lived token · curated MCP tools · your scopes and ACLs · access-tier ceiling · permanent denylist · live reads of your lakehouse</text>
+<text x="64" y="158" font-size="12" fill="#5B6B82">Delegated short-lived token · curated MCP tools · your scopes and ACLs · Agent Access ceiling · permanent denylist · live reads of your lakehouse</text>
 
 <!-- three lanes -->
 <g filter="url(#soft5)">

--- a/public/images/ai-retrieval.svg
+++ b/public/images/ai-retrieval.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1240" height="760" viewBox="0 0 1240 760" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" role="img" aria-label="Retrieval in PlaidCloud: a question drives tool selection by embedding similarity, keyword BM25 retrieval over the published documentation, and live permission-checked reads of your own data via analysis paths and MCP tools, producing a grounded answer.">
+<defs>
+<filter id="soft4" x="-20%" y="-20%" width="140%" height="140%"><feDropShadow dx="0" dy="2" stdDeviation="5" flood-color="#1B2A44" flood-opacity="0.10"/></filter>
+<marker id="a4" markerWidth="9" markerHeight="9" refX="6.5" refY="4" orient="auto"><path d="M1 1 L7 4 L1 7" fill="none" stroke="#5B6B82" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></marker>
+</defs>
+
+<rect width="1240" height="760" fill="#FBFCFE"/>
+<text x="40" y="46" font-size="24" font-weight="700" fill="#002F6C">How Retrieval Works — Three Separate Lanes</text>
+<text x="40" y="70" font-size="13" fill="#5B6B82">Only the documentation lane is a retrieval index. Your business data is read live, on demand, under your permissions — it is never embedded into a vector store.</text>
+
+<!-- question -->
+<g filter="url(#soft4)"><rect x="40" y="180" width="216" height="140" rx="12" fill="#FFFFFF" stroke="#C6D6E8"/></g>
+<rect x="40" y="180" width="216" height="6" rx="3" fill="#00A3E0"/>
+<text x="62" y="216" font-size="15" font-weight="700" fill="#1B2A44">A question</text>
+<text x="62" y="242" font-size="12" fill="#5B6B82">"Why did the Operations</text>
+<text x="62" y="260" font-size="12" fill="#5B6B82">Results drop last quarter,</text>
+<text x="62" y="278" font-size="12" fill="#5B6B82">and how do I chart it?"</text>
+<text x="62" y="304" font-size="11.5" font-style="italic" fill="#5B6B82">Asked from any surface</text>
+
+<!-- lanes -->
+<g filter="url(#soft4)">
+<rect x="300" y="108" width="640" height="176" rx="12" fill="#FFFFFF" stroke="#C6D6E8"/>
+<rect x="300" y="304" width="640" height="184" rx="12" fill="#FFFFFF" stroke="#C6D6E8"/>
+<rect x="300" y="508" width="640" height="192" rx="12" fill="#FFFFFF" stroke="#C6D6E8"/>
+</g>
+<rect x="300" y="108" width="6" height="176" rx="3" fill="#9FBEDC"/>
+<rect x="300" y="304" width="6" height="184" rx="3" fill="#9FBEDC"/>
+<rect x="300" y="508" width="6" height="192" rx="3" fill="#0F9B86"/>
+
+<text x="326" y="140" font-size="12" font-weight="700" fill="#5B6B82" letter-spacing="1.1">LANE 1 · WHICH TOOLS TO OFFER</text>
+<text x="326" y="168" font-size="15" font-weight="700" fill="#1B2A44">Semantic tool selection</text>
+<text x="326" y="192" font-size="12" fill="#5B6B82">Tool descriptions — not your data — are embedded once and cached. The question is</text>
+<text x="326" y="210" font-size="12" fill="#5B6B82">matched against them so the model is offered only plausibly relevant tools.</text>
+<text x="326" y="234" font-size="12" fill="#5B6B82">A few tools are always present so the agent can orient itself.</text>
+<text x="326" y="262" font-size="12" font-weight="700" fill="#9A6B2E">If confidence is low, it falls back to the full tool list — a confident wrong pick is worse.</text>
+
+<text x="326" y="336" font-size="12" font-weight="700" fill="#5B6B82" letter-spacing="1.1">LANE 2 · HOW THE PRODUCT WORKS</text>
+<text x="326" y="364" font-size="15" font-weight="700" fill="#1B2A44">Documentation retrieval (the actual RAG)</text>
+<text x="326" y="388" font-size="12" fill="#5B6B82">A keyword-ranking index (Okapi BM25) is built in memory over the published</text>
+<text x="326" y="406" font-size="12" fill="#5B6B82">documentation corpus — one entry per page, refreshed from the docs site.</text>
+<text x="326" y="430" font-size="12" fill="#5B6B82">The agent decides when to search, gets a ranked shortlist, then fetches one page</text>
+<text x="326" y="448" font-size="12" fill="#5B6B82">or a single section of it — so irrelevant pages never enter the context window.</text>
+<text x="326" y="472" font-size="12" font-weight="700" fill="#0F7A63">Public product documentation only. No customer content is in this index.</text>
+
+<text x="326" y="540" font-size="12" font-weight="700" fill="#0F7A63" letter-spacing="1.1">LANE 3 · WHAT YOUR DATA SAYS</text>
+<text x="326" y="568" font-size="15" font-weight="700" fill="#1B2A44">Live, permission-checked reads — not retrieval</text>
+<text x="326" y="592" font-size="12" fill="#5B6B82">Analysis paths resolve a friendly name — "the Operations Results", "the P&amp;L" — to a</text>
+<text x="326" y="610" font-size="12" fill="#5B6B82">real project and table, so nobody has to restate where the data lives.</text>
+<text x="326" y="634" font-size="12" fill="#5B6B82">The agent then reads schema, rows, dimension members, and allocation lineage</text>
+<text x="326" y="652" font-size="12" fill="#5B6B82">through MCP tools, one checked call at a time, at the moment it is asked.</text>
+<text x="326" y="678" font-size="12" font-weight="700" fill="#0F7A63">Answers reflect the data as it is right now, not as it was when something was indexed.</text>
+
+<!-- answer -->
+<g filter="url(#soft4)"><rect x="984" y="304" width="216" height="204" rx="12" fill="#EFF8F5" stroke="#7FBFAE"/></g>
+<text x="1006" y="340" font-size="15" font-weight="700" fill="#0F7A63">A grounded answer</text>
+<text x="1006" y="366" font-size="12" fill="#3F5470">Real query results, with</text>
+<text x="1006" y="384" font-size="12" fill="#3F5470">the documentation page</text>
+<text x="1006" y="402" font-size="12" fill="#3F5470">cited when it was used.</text>
+<text x="1006" y="428" font-size="12" fill="#3F5470">Carries a confidence signal</text>
+<text x="1006" y="446" font-size="12" fill="#3F5470">and plain-language caveats.</text>
+<text x="1006" y="472" font-size="11.5" font-weight="700" fill="#0F7A63">Says "I don't know" rather</text>
+<text x="1006" y="488" font-size="11.5" font-weight="700" fill="#0F7A63">than inventing a number.</text>
+
+<!-- arrows -->
+<path d="M256 226 C280 226 280 196 300 196" stroke="#5B6B82" stroke-width="1.5" fill="none" marker-end="url(#a4)"/>
+<path d="M256 250 C280 250 280 396 300 396" stroke="#5B6B82" stroke-width="1.5" fill="none" marker-end="url(#a4)"/>
+<path d="M256 274 C280 274 280 604 300 604" stroke="#5B6B82" stroke-width="1.5" fill="none" marker-end="url(#a4)"/>
+<path d="M940 196 C966 196 966 366 984 366" stroke="#5B6B82" stroke-width="1.5" fill="none" marker-end="url(#a4)"/>
+<path d="M940 396 L984 396" stroke="#5B6B82" stroke-width="1.5" fill="none" marker-end="url(#a4)"/>
+<path d="M940 604 C966 604 966 426 984 426" stroke="#5B6B82" stroke-width="1.5" fill="none" marker-end="url(#a4)"/>
+
+<text x="40" y="740" font-size="11.5" fill="#5B6B82">Grounding is not training. Nothing retrieved here is used to train a model, and the retrieval index holds published documentation — never your tables.</text>
+</svg>

--- a/src/content/docs/guides/ai-assistant/index.md
+++ b/src/content/docs/guides/ai-assistant/index.md
@@ -8,4 +8,7 @@ sidebar:
 
 The PlaidCloud AI Assistant is the in-app chat experience for asking questions about your data, generating workflow expressions, and performing operations in natural language. It is separate from the [AI Agents (MCP)](/integrations/ai-coding-agents/) area, which covers connecting external AI clients to your tenant.
 
+To see how it works underneath — which model answers, how retrieval grounds an answer, and what
+governs access — read [AI and LLM Architecture](/integrations/ai-architecture/).
+
 AI assistance also appears directly in some workflow steps — for example, [generating a SQL Extract step's query](/guides/ai-assistant/generate-sql-extract/) from a plain-language description.

--- a/src/content/docs/integrations/ai-architecture/index.mdx
+++ b/src/content/docs/integrations/ai-architecture/index.mdx
@@ -28,7 +28,7 @@ This section explains that architecture: what runs where, what crosses the bound
 | **In-app AI Assistant** | Anyone working in PlaidCloud | PlaidCloud's own agents call internal tools on your behalf | [Using the AI Assistant](/guides/ai-assistant/using-ai-assistant/) |
 | **Microsoft 365 Copilot** | Whole teams, in Teams and Outlook | A published agent signs the person in, then calls the MCP server | [Microsoft 365 Copilot](/integrations/microsoft-365-copilot/) |
 | **AI coding agents** | Analysts and developers | Their client connects directly to the MCP server over OAuth | [Getting started](/integrations/ai-coding-agents/getting-started/) |
-| **LLM workflow step** | Unattended pipelines | On Anthropic, a token scoped to just the objects you bind; on other providers, no data access at all — see [the step's rules](/integrations/ai-architecture/llm-providers/#the-llm-workflow-step-is-different) | [Workflow steps](/reference/workflow-steps/) |
+| **LLM workflow step** | Unattended pipelines | On Anthropic, a token scoped to just the objects you bind; on other providers, no data access at all — see [the step's rules](/integrations/ai-architecture/llm-providers/#the-llm-workflow-step-is-different) | [LLM Step](/reference/workflow-steps/general/llm-step/) |
 
 They differ in who is driving and where the conversation happens. They do not differ in what the
 model is allowed to touch.
@@ -50,13 +50,15 @@ Whichever surface a question arrives on, the same five things are true.
 3. **Your own permissions still bound it.** An AI request can never see or change something you
    could not see or change yourself. The AI layer narrows access; it never widens it.
 
-4. **An access tier sets a ceiling.** Read-only is the default. An administrator can raise a
-   connection or a person to read/write or full, but the tier is a cap applied *on top of* the
-   user's real permissions, not a grant of new ones.
+4. **An administrator sets a ceiling.** Read-only is the default everywhere. An administrator can
+   raise an LLM connection's **access tier**, or a person's Microsoft 365 Copilot **access level**,
+   to read/write or full. These are two separate mechanisms, but they behave the same way: each is
+   a cap applied *on top of* your real permissions, never a grant of new ones.
 
 5. **Some things are permanently off-limits.** Credential and connection settings, identity and
    group management, access-control changes, publishing, and deployable code are never callable by
-   an AI credential — at any tier, for any provider. Those stay human-only.
+   an AI credential — no matter what an administrator has granted, on any provider. Those stay
+   human-only.
 
 </Steps>
 
@@ -103,7 +105,7 @@ each ask is adjudicated.
 	<LinkCard
 		title="Microsoft 365 Copilot Architecture"
 		href="/integrations/ai-architecture/microsoft-365-copilot/"
-		description="Why Copilot needs a published agent package and its own OAuth client, and how deny-by-default access tiers work."
+		description="Why Copilot needs a published agent package and its own OAuth client, and how deny-by-default access levels work."
 	/>
 	<LinkCard
 		title="Retrieval, Grounding, and Analysis Paths"

--- a/src/content/docs/integrations/ai-architecture/index.mdx
+++ b/src/content/docs/integrations/ai-architecture/index.mdx
@@ -50,10 +50,11 @@ Whichever surface a question arrives on, the same five things are true.
 3. **Your own permissions still bound it.** An AI request can never see or change something you
    could not see or change yourself. The AI layer narrows access; it never widens it.
 
-4. **An administrator sets a ceiling.** Read-only is the default everywhere. An administrator can
-   raise an LLM connection's **Agent Access**, or a person's Microsoft 365 Copilot **access
-   level**, beyond read-only. These are two separate mechanisms, but they behave the same way:
-   each is a cap applied *on top of* your real permissions, never a grant of new ones.
+4. **An administrator sets the ceiling, and it starts closed.** An LLM connection's **Agent
+   Access** begins at read-only. Microsoft 365 Copilot begins at nothing at all: until an
+   administrator assigns someone an **access level**, a signed-in person gets no data. These are
+   two separate mechanisms, but raising either only ever caps what the AI may attempt — it never
+   widens what you could already reach yourself.
 
 5. **Some things are permanently off-limits.** Credential and connection settings, identity and
    group management, access-control changes, publishing, and deployable code are never callable by

--- a/src/content/docs/integrations/ai-architecture/index.mdx
+++ b/src/content/docs/integrations/ai-architecture/index.mdx
@@ -51,9 +51,9 @@ Whichever surface a question arrives on, the same five things are true.
    could not see or change yourself. The AI layer narrows access; it never widens it.
 
 4. **An administrator sets a ceiling.** Read-only is the default everywhere. An administrator can
-   raise an LLM connection's **access tier**, or a person's Microsoft 365 Copilot **access level**,
-   to read/write or full. These are two separate mechanisms, but they behave the same way: each is
-   a cap applied *on top of* your real permissions, never a grant of new ones.
+   raise an LLM connection's **Agent Access**, or a person's Microsoft 365 Copilot **access
+   level**, beyond read-only. These are two separate mechanisms, but they behave the same way:
+   each is a cap applied *on top of* your real permissions, never a grant of new ones.
 
 5. **Some things are permanently off-limits.** Credential and connection settings, identity and
    group management, access-control changes, publishing, and deployable code are never callable by

--- a/src/content/docs/integrations/ai-architecture/index.mdx
+++ b/src/content/docs/integrations/ai-architecture/index.mdx
@@ -28,7 +28,7 @@ This section explains that architecture: what runs where, what crosses the bound
 | **In-app AI Assistant** | Anyone working in PlaidCloud | PlaidCloud's own agents call internal tools on your behalf | [Using the AI Assistant](/guides/ai-assistant/using-ai-assistant/) |
 | **Microsoft 365 Copilot** | Whole teams, in Teams and Outlook | A published agent signs the person in, then calls the MCP server | [Microsoft 365 Copilot](/integrations/microsoft-365-copilot/) |
 | **AI coding agents** | Analysts and developers | Their client connects directly to the MCP server over OAuth | [Getting started](/integrations/ai-coding-agents/getting-started/) |
-| **LLM workflow step** | Unattended pipelines | The step mints a token scoped to just the objects you bind | [Workflow steps](/reference/workflow-steps/) |
+| **LLM workflow step** | Unattended pipelines | On Anthropic, a token scoped to just the objects you bind; on other providers, no data access at all — see [the step's rules](/integrations/ai-architecture/llm-providers/#the-llm-workflow-step-is-different) | [Workflow steps](/reference/workflow-steps/) |
 
 They differ in who is driving and where the conversation happens. They do not differ in what the
 model is allowed to touch.

--- a/src/content/docs/integrations/ai-architecture/index.mdx
+++ b/src/content/docs/integrations/ai-architecture/index.mdx
@@ -1,0 +1,124 @@
+---
+title: AI and LLM Architecture
+description: How PlaidCloud connects to large language models such as Claude, GPT, Gemini, and Grok — the four ways people reach AI, the governed path every request takes, and where your data does and does not travel.
+sidebar:
+  label: Overview
+  order: 1
+---
+
+import { Aside, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
+
+PlaidCloud does not have one AI feature. It has four ways to reach a model — the assistant inside
+the product, Microsoft 365 Copilot, external coding agents, and an LLM step inside a workflow — and
+all four run over the same governed path. The model itself is swappable: Claude, GPT, Gemini, Grok,
+an Azure OpenAI resource in your own subscription, or a model you host yourself.
+
+This section explains that architecture: what runs where, what crosses the boundary, and why.
+
+<img
+	src="/images/ai-llm-architecture.svg"
+	alt="PlaidCloud AI architecture. Four client surfaces — the in-app assistant, Microsoft 365 Copilot, AI coding agents, and the LLM workflow step — enter the tenant boundary, which contains delegated tokens, the curated MCP server, access enforcement, AI services, and project data. Prompts flow outward to LLM providers; data flows only within the boundary."
+	class="doc-diagram"
+/>
+
+## The Four Surfaces
+
+| Surface | Who uses it | How the model reaches data | Where to start |
+|---|---|---|---|
+| **In-app AI Assistant** | Anyone working in PlaidCloud | PlaidCloud's own agents call internal tools on your behalf | [Using the AI Assistant](/guides/ai-assistant/using-ai-assistant/) |
+| **Microsoft 365 Copilot** | Whole teams, in Teams and Outlook | A published agent signs the person in, then calls the MCP server | [Microsoft 365 Copilot](/integrations/microsoft-365-copilot/) |
+| **AI coding agents** | Analysts and developers | Their client connects directly to the MCP server over OAuth | [Getting started](/integrations/ai-coding-agents/getting-started/) |
+| **LLM workflow step** | Unattended pipelines | The step mints a token scoped to just the objects you bind | [Workflow steps](/reference/workflow-steps/) |
+
+They differ in who is driving and where the conversation happens. They do not differ in what the
+model is allowed to touch.
+
+## One Governed Path
+
+Whichever surface a question arrives on, the same five things are true.
+
+<Steps>
+
+1. **The model runs as a person, not as the platform.** Every request carries a short-lived,
+   revoked-when-finished credential that stands in for the signed-in user. There is no shared
+   service account with elevated rights behind the AI.
+
+2. **Tools are the only way in.** The model cannot query your lakehouse directly. It calls a
+   curated catalog of tools — find, describe, read, run, upsert — and every call is checked
+   independently.
+
+3. **Your own permissions still bound it.** An AI request can never see or change something you
+   could not see or change yourself. The AI layer narrows access; it never widens it.
+
+4. **An access tier sets a ceiling.** Read-only is the default. An administrator can raise a
+   connection or a person to read/write or full, but the tier is a cap applied *on top of* the
+   user's real permissions, not a grant of new ones.
+
+5. **Some things are permanently off-limits.** Credential and connection settings, identity and
+   group management, access-control changes, publishing, and deployable code are never callable by
+   an AI credential — at any tier, for any provider. Those stay human-only.
+
+</Steps>
+
+<Aside type="note">
+These are enforced in the server, not in the prompt. A prompt-injection attempt that talks the model
+into asking for a forbidden tool gets the same refusal a well-behaved model would.
+</Aside>
+
+## The Life of a Question
+
+Take *"Why did allocated IT cost for Atlanta go up last quarter?"*, asked from any surface:
+
+<Steps>
+
+1. **A credential is minted** for the asking person, scoped and short-lived.
+
+2. **Tools are put in front of the model** — narrowed to what the question plausibly needs on the
+   surfaces that do the narrowing, discovered from the catalog on the ones that don't.
+
+3. **The prompt goes to the model** — the question, any standing rules, and the tool descriptions.
+   No data yet.
+
+4. **The model asks for data** through tool calls: resolve the analysis path, read the schema, run
+   the allocation trace, read the driver rows. Each call is permission-checked on arrival.
+
+5. **The model answers** from what came back, cites the documentation page if it consulted one, and
+   carries a confidence signal and caveats.
+
+6. **The credential is revoked.** A captured token cannot be replayed after the request ends.
+
+</Steps>
+
+The important detail is step 4: the model does not have your data. It asks for slices of it, and
+each ask is adjudicated.
+
+## Read Next
+
+<CardGrid>
+	<LinkCard
+		title="LLM Providers and Connections"
+		href="/integrations/ai-architecture/llm-providers/"
+		description="Claude, GPT, Gemini, Grok, Azure OpenAI — one connection, four execution adapters, and two ways tools get brokered."
+	/>
+	<LinkCard
+		title="Microsoft 365 Copilot Architecture"
+		href="/integrations/ai-architecture/microsoft-365-copilot/"
+		description="Why Copilot needs a published agent package and its own OAuth client, and how deny-by-default access tiers work."
+	/>
+	<LinkCard
+		title="Retrieval, Grounding, and Analysis Paths"
+		href="/integrations/ai-architecture/retrieval/"
+		description="What RAG actually does here — and why your business data is read live rather than indexed into a vector store."
+	/>
+	<LinkCard
+		title="Using Your Own Controlled LLM"
+		href="/integrations/ai-architecture/private-llm/"
+		description="Keep proprietary, PHI, or contractually confined data inside infrastructure you control."
+	/>
+</CardGrid>
+
+## Related
+
+- [Answers You Can Trust](/integrations/ai-coding-agents/honest-answers/) — how answers are graded and caveated
+- [Analysis Paths](/integrations/ai-coding-agents/analysis-paths/) — friendly names for the tables your team asks about
+- [Platform Architecture](/get-started/platform-architecture/) — where AI sits in the wider platform

--- a/src/content/docs/integrations/ai-architecture/llm-providers.mdx
+++ b/src/content/docs/integrations/ai-architecture/llm-providers.mdx
@@ -6,7 +6,7 @@ sidebar:
   order: 2
 ---
 
-import { Aside, Steps } from '@astrojs/starlight/components';
+import { Aside } from '@astrojs/starlight/components';
 
 An **LLM Provider connection** is where you choose the model that powers AI in your workspace. It
 holds the provider, your API key, a default model, and standing instructions — and it is the point
@@ -62,8 +62,10 @@ Microsoft path for Copilot-class GPT models is **Azure OpenAI** (or GitHub Model
 
 ## How Tools Get Brokered
 
-An LLM is only useful here if it can call PlaidCloud tools. There are two mechanisms, and which one
-runs depends on the provider.
+An LLM is only useful here if it can call PlaidCloud tools. For **interactive** AI — the in-app
+assistant and the workspace chat agent — there are two mechanisms, and which one runs depends on the
+provider. (The unattended [LLM workflow step](#the-llm-workflow-step-is-different) works
+differently; read that section too.)
 
 ### Server-Side Connector — Anthropic
 
@@ -71,9 +73,7 @@ Anthropic's API connects to your PlaidCloud MCP endpoint itself, carrying the sh
 token. Anthropic manages the tool catalog on its side, so the model sees everything the token is
 permitted to call and discovers tools without help.
 
-This is the path that supports **scoped bindings**: an LLM workflow step names specific tables,
-dimensions, and documents, each marked read or write, and the token is gated to exactly those
-objects. Everything else is refused even though the tool exists.
+This is also the only path that supports **scoped bindings** — see below.
 
 ### Client-Side Loop — Everyone Else
 
@@ -95,6 +95,31 @@ delegated token, so scopes, ACLs, the access tier, and the denylist all apply ex
 the Anthropic path.
 </Aside>
 
+## The LLM Workflow Step Is Different
+
+Everything above describes interactive AI. The unattended **LLM workflow step** does not use the
+client-side loop at all, and the difference is worth understanding before you pick a provider for
+one.
+
+| Provider on the step's connection | What the step can do |
+|---|---|
+| **Anthropic** | Reaches your data through the MCP connector, gated to **scoped bindings** — the specific tables, dimensions, and documents you named on the step, each marked read or write. Anything outside those objects is refused even though the tool exists. |
+| **Everything else** | **No data access.** The step is a single structured completion: prompt, rules, and schema in; JSON out. |
+
+Two consequences follow directly:
+
+- **Bindings are ignored on a non-Anthropic step.** They are not silently honored and they are not
+  an error — the step logs that scoped data access is Anthropic-only and runs without them. If you
+  switch a bound step from Anthropic to another provider, it stops reading your data.
+- **A result schema is required on a non-Anthropic step.** With no tools to call, structured output
+  is the only thing the step produces.
+
+<Aside type="caution">
+If a step needs to read or write project objects, put it on an Anthropic connection. On any other
+provider the step can still classify, summarize, extract, or rewrite text you pass in the prompt —
+it simply cannot go and fetch anything.
+</Aside>
+
 ## Access Tiers
 
 Every LLM connection carries a tier. It is a **ceiling**, always intersected with the acting
@@ -111,8 +136,8 @@ document-account credentials and ACLs, member and group management, password res
 publishing, user-defined function code, and app deployments. Those are never callable by an AI
 credential at any tier.
 
-For a workflow step, the tier interacts with **bindings**: read/write is granted per bound object,
-so a step can write to the one table you checked and nothing else.
+For an Anthropic workflow step, the tier interacts with **bindings**: read/write is granted per bound
+object, so a step can write to the one table you checked and nothing else.
 
 ## Structured Results
 

--- a/src/content/docs/integrations/ai-architecture/llm-providers.mdx
+++ b/src/content/docs/integrations/ai-architecture/llm-providers.mdx
@@ -1,0 +1,138 @@
+---
+title: LLM Providers and Connections
+description: Register Claude, GPT, Gemini, Grok, Azure OpenAI, or a self-hosted model as an LLM Provider connection — and understand the execution adapters, access tiers, and tool brokering behind it.
+sidebar:
+  label: LLM Providers
+  order: 2
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+An **LLM Provider connection** is where you choose the model that powers AI in your workspace. It
+holds the provider, your API key, a default model, and standing instructions — and it is the point
+where an administrator decides how much the model is allowed to do.
+
+<img
+	src="/images/ai-llm-providers.svg"
+	alt="One LLM Provider connection selects a provider, which maps to one of four execution adapters — anthropic, openai_compatible, gemini, or azure. Tools are brokered either server-side by Anthropic's MCP connector or client-side by PlaidCloud. Permission enforcement is identical in both cases."
+	class="doc-diagram"
+/>
+
+## What the Connection Holds
+
+| Field | What it does |
+|---|---|
+| **Provider** | Anthropic, OpenAI, Google Gemini, xAI Grok, Azure OpenAI, or GitHub Models. |
+| **API key** | Yours. Usage is billed to your account with that provider, not resold through PlaidCloud. |
+| **Default model** | Picked from a curated catalog, or typed in free-hand so a model released this week still works. |
+| **Base URL** | Filled in per provider. Required for Azure OpenAI (your resource endpoint) and for a self-hosted endpoint. |
+| **Rules** | Standing instructions prepended to every system message — house conventions, tone, what to never do. |
+| **Access tier** | The ceiling on what agents and steps using this connection may do. Read-only unless raised. |
+
+A workspace can hold several connections; one is marked the default. A workflow step can pin a
+specific connection when it needs a different model from the workspace default.
+
+<Aside type="tip">
+**A model not in the dropdown still works.** The catalog exists so people choose deliberately
+between capability and cost. The model field accepts free text, so a brand-new model id works
+before the list catches up.
+</Aside>
+
+## Providers and Adapters
+
+Six user-facing providers map onto four execution adapters. The adapter decides how the request is
+shaped and what the model can reach.
+
+| Provider | Adapter | Notes |
+|---|---|---|
+| Anthropic (Claude) | `anthropic` | The only path with scoped table, dimension, and document bindings. |
+| OpenAI (ChatGPT) | `openai_compatible` | |
+| xAI (Grok) | `openai_compatible` | |
+| GitHub Models | `openai_compatible` | GitHub-hosted models for GitHub-centric teams. |
+| Google (Gemini) | `gemini` | |
+| Azure OpenAI | `azure` | Your resource endpoint; the "model" is your **deployment name**, and the API version comes from the connection. |
+
+<Aside type="caution">
+**GitHub Copilot is not an option here, and that is not an oversight.** Copilot has no standalone
+chat API you can point a server at — it exchanges an OAuth token for an editor entitlement. The
+Microsoft path for Copilot-class GPT models is **Azure OpenAI** (or GitHub Models). GitHub Copilot
+*as an IDE client* connecting to PlaidCloud is a different thing entirely, and it works — see
+[GitHub Copilot](/integrations/ai-coding-agents/copilot/).
+</Aside>
+
+## How Tools Get Brokered
+
+An LLM is only useful here if it can call PlaidCloud tools. There are two mechanisms, and which one
+runs depends on the provider.
+
+### Server-Side Connector — Anthropic
+
+Anthropic's API connects to your PlaidCloud MCP endpoint itself, carrying the short-lived delegated
+token. Anthropic manages the tool catalog on its side, so the model sees everything the token is
+permitted to call and discovers tools without help.
+
+This is the path that supports **scoped bindings**: an LLM workflow step names specific tables,
+dimensions, and documents, each marked read or write, and the token is gated to exactly those
+objects. Everything else is refused even though the tool exists.
+
+### Client-Side Loop — Everyone Else
+
+Other providers have no equivalent connector, so PlaidCloud drives the loop itself: it connects to
+its own MCP server as a client, lists the tools, hands them to the model as native function
+definitions, executes the calls the model asks for, feeds the results back, and repeats until the
+model produces an answer.
+
+Two bounds keep this predictable:
+
+- **A capped tool surface.** Providers limit how many functions one request may declare, and every
+  schema costs prompt tokens. The exposed set is capped, with the discovery meta-tools always
+  present so the model can still find and invoke anything outside the direct list.
+- **A fixed round-trip limit.** A runaway tool loop stops rather than burning tokens indefinitely.
+
+<Aside type="note">
+Different broker, same enforcement. The client-side loop calls the same MCP server with the same
+delegated token, so scopes, ACLs, the access tier, and the denylist all apply exactly as they do on
+the Anthropic path.
+</Aside>
+
+## Access Tiers
+
+Every LLM connection carries a tier. It is a **ceiling**, always intersected with the acting
+person's real permissions.
+
+| Tier | What agents and steps on this connection may do |
+|---|---|
+| **Read-only** *(default)* | List, describe, read table data, read dimension members, read documents, run read-only SQL. |
+| **Read/write** | The above, plus writes the person is already permitted to make — table rows, dimension nodes, document uploads. |
+| **Full** | The person's complete tool set. |
+
+Above read-only, an unconditional denylist still applies: connection and credential settings,
+document-account credentials and ACLs, member and group management, password reset, project ACLs,
+publishing, user-defined function code, and app deployments. Those are never callable by an AI
+credential at any tier.
+
+For a workflow step, the tier interacts with **bindings**: read/write is granted per bound object,
+so a step can write to the one table you checked and nothing else.
+
+## Structured Results
+
+When a step declares a result schema, the answer is validated against it rather than parsed out of
+prose. Because providers express schemas differently, the schema is translated per provider — the
+strict-JSON dialect for OpenAI-compatible endpoints, the OpenAPI subset for Gemini — and a refusal
+or a truncated response is surfaced as its own error instead of a confusing "invalid JSON".
+
+## Safeguards Worth Knowing
+
+- **Outbound URLs are validated before any call.** A base URL must be HTTPS and must resolve to a
+  public address; loopback, private-range, link-local, and cloud metadata addresses are rejected,
+  and redirects are disabled so a response cannot bounce the call somewhere else.
+- **Keys stay out of logs and errors.** Provider errors are scrubbed rather than echoed back with
+  credentials in them.
+- **Rules are instructions, not permissions.** The standing rules on a connection shape how the
+  model behaves. They cannot raise what it is allowed to reach.
+
+## Related
+
+- [AI and LLM Architecture](/integrations/ai-architecture/) — the surfaces and the shared path
+- [Using Your Own Controlled LLM](/integrations/ai-architecture/private-llm/) — Azure OpenAI and self-hosted options
+- [Connections](/guides/connections/) — creating and managing connections generally

--- a/src/content/docs/integrations/ai-architecture/llm-providers.mdx
+++ b/src/content/docs/integrations/ai-architecture/llm-providers.mdx
@@ -41,7 +41,8 @@ before the list catches up.
 ## Providers and Adapters
 
 Six user-facing providers map onto four execution adapters. The adapter decides how the request is
-shaped and what the model can reach.
+shaped and what the model can reach. Provider names below are the labels as they appear in the
+connection form's dropdown.
 
 | Provider | Adapter | Notes |
 |---|---|---|
@@ -62,10 +63,9 @@ Microsoft path for Copilot-class GPT models is **Azure OpenAI** (or GitHub Model
 
 ## How Tools Get Brokered
 
-An LLM is only useful here if it can call PlaidCloud tools. For **interactive** AI — the in-app
-assistant and the workspace chat agent — there are two mechanisms, and which one runs depends on the
-provider. (The unattended [LLM workflow step](#the-llm-workflow-step-is-different) works
-differently; read that section too.)
+An LLM is only useful here if it can call PlaidCloud tools. For the **interactive** assistant there
+are two mechanisms, and which one runs depends on the provider. (The unattended
+[LLM workflow step](#the-llm-workflow-step-is-different) works differently; read that section too.)
 
 ### Server-Side Connector — Anthropic
 

--- a/src/content/docs/integrations/ai-architecture/llm-providers.mdx
+++ b/src/content/docs/integrations/ai-architecture/llm-providers.mdx
@@ -1,6 +1,6 @@
 ---
 title: LLM Providers and Connections
-description: Register Claude, GPT, Gemini, Grok, Azure OpenAI, or a self-hosted model as an LLM Provider connection — and understand the execution adapters, access tiers, and tool brokering behind it.
+description: Register Claude, GPT, Gemini, Grok, Azure OpenAI, or a self-hosted model as an LLM Provider connection — and understand the execution adapters, Agent Access, and tool brokering behind it.
 sidebar:
   label: LLM Providers
   order: 2
@@ -27,7 +27,7 @@ where an administrator decides how much the model is allowed to do.
 | **Default model** | Picked from a curated catalog, or typed in free-hand so a model released this week still works. |
 | **Base URL** | Filled in per provider. Required for Azure OpenAI (your resource endpoint) and for a self-hosted endpoint. |
 | **Rules** | Standing instructions prepended to every system message — house conventions, tone, what to never do. |
-| **Access tier** | The ceiling on what agents and steps using this connection may do. Read-only unless raised. |
+| **Agent Access** | The ceiling on what agents and steps using this connection may do. Read-only unless raised. |
 
 A workspace can hold several connections; one is marked the default. A workflow step can pin a
 specific connection when it needs a different model from the workspace default.
@@ -91,7 +91,7 @@ Two bounds keep this predictable:
 
 <Aside type="note">
 Different broker, same enforcement. The client-side loop calls the same MCP server with the same
-delegated token, so scopes, ACLs, the access tier, and the denylist all apply exactly as they do on
+delegated token, so scopes, ACLs, Agent Access, and the denylist all apply exactly as they do on
 the Anthropic path.
 </Aside>
 
@@ -120,23 +120,23 @@ provider the step can still classify, summarize, extract, or rewrite text you pa
 it simply cannot go and fetch anything.
 </Aside>
 
-## Access Tiers
+## Agent Access
 
-Every LLM connection carries a tier. It is a **ceiling**, always intersected with the acting
-person's real permissions.
+Every LLM connection carries an **Agent Access** setting. It is a **ceiling**, always intersected
+with the acting person's real permissions.
 
-| Tier | What agents and steps on this connection may do |
+| Agent Access | What agents and steps on this connection may do |
 |---|---|
 | **Read-only** *(default)* | List, describe, read table data, read dimension members, read documents, run read-only SQL. |
-| **Read/write** | The above, plus writes the person is already permitted to make — table rows, dimension nodes, document uploads. |
+| **Read & write** | The above, plus writes the person is already permitted to make — table rows, dimension nodes, document uploads. |
 | **Full** | The person's complete tool set. |
 
 Above read-only, an unconditional denylist still applies: connection and credential settings,
 document-account credentials and ACLs, member and group management, password reset, project ACLs,
 publishing, user-defined function code, and app deployments. Those are never callable by an AI
-credential at any tier.
+credential at any Agent Access setting.
 
-For an Anthropic workflow step, the tier interacts with **bindings**: read/write is granted per bound
+For an Anthropic workflow step, Agent Access interacts with **bindings**: write is granted per bound
 object, so a step can write to the one table you checked and nothing else.
 
 ## Structured Results

--- a/src/content/docs/integrations/ai-architecture/microsoft-365-copilot.mdx
+++ b/src/content/docs/integrations/ai-architecture/microsoft-365-copilot.mdx
@@ -1,0 +1,121 @@
+---
+title: Microsoft 365 Copilot Architecture
+description: Why Microsoft 365 Copilot needs a published agent package and its own OAuth client, how deny-by-default access tiers are resolved, and what stays permanently off-limits.
+sidebar:
+  label: Copilot Architecture
+  order: 3
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+Microsoft 365 Copilot is the one integration that cannot follow the normal pattern. A coding agent
+can be handed a server address and told to authenticate; Copilot cannot. It only talks to agents
+that have been **published into your Microsoft 365 tenant**, and it hands sign-in back to Microsoft
+against a fixed redirect address.
+
+That constraint shapes everything on this page. For the click-by-click install, see
+[Microsoft 365 Copilot](/integrations/microsoft-365-copilot/) — this page explains what those steps
+are actually doing.
+
+<img
+	src="/images/ai-copilot-architecture.svg"
+	alt="A person in Teams or Outlook asks the PlaidCloud declarative agent, which is published in the Microsoft 365 tenant. Microsoft brokers sign-in to a dedicated PlaidCloud OAuth client. Requests then reach the curated MCP server, where a deny-by-default access tier and the person's own permissions gate every call. Credential, identity, and access-control tools are never reachable."
+	class="doc-diagram"
+/>
+
+## Why It Is a Special Case
+
+| Constraint Microsoft imposes | What PlaidCloud does about it |
+|---|---|
+| Copilot only runs agents published in your M365 app catalog | Ships a **declarative agent package** (a `.zip`) you download from the control plane and your Teams admin uploads |
+| Sign-in must return to a fixed Microsoft redirect address | Provisions a **dedicated confidential OAuth client** per tenant with that address pre-registered |
+| Custom apps are blocked by default | Requires the *Upload custom apps* setup policy to be turned on — a separate switch from being a global admin |
+| Copilot re-authenticates on its own schedule | Extends the refresh window so sign-in lasts roughly a month rather than a couple of days |
+
+The package is **per workspace**, named after that workspace. Installing it is not the same as
+granting access, which is the next section and the one people trip over.
+
+## Deny by Default
+
+A person who has installed the agent and signed in successfully still gets no data until an
+administrator assigns them an access level. The agent connects, authenticates, and answers *"no
+access has been granted"* — that is the system working, not an error.
+
+The tier is resolved **server-side from the assignment an administrator made**, not from anything
+the incoming token claims. A token cannot talk its way into a higher tier.
+
+| Level | The agent can… | Typical use |
+|---|---|---|
+| **Read-only** | List and describe projects and tables, read table data, list dimension members, explain allocations | Most people — the safe default |
+| **Read/write** | The above, plus writes that person is already permitted to make | Analysts who maintain data |
+| **Full** | That person's complete tool set, including raw SQL that writes | Power users and builders |
+
+Two rules on top:
+
+- **Most permissive wins.** If someone somehow holds more than one level, the highest applies.
+- **The tier is a ceiling, never a grant.** Within it, the person's own PlaidCloud roles and ACLs
+  still apply, so the agent can never surface data they could not already open themselves.
+
+<Aside type="note">
+The access groups behind these levels are locked in Identity — they cannot be renamed, deleted, or
+have their permissions edited. You add and remove members (including through a SAML group mapping),
+so the anchors cannot be accidentally repurposed.
+</Aside>
+
+## Always Off-Limits
+
+Regardless of tier, and regardless of the person's own permissions, Copilot can never reach:
+
+- connection and credential settings, or document-account credentials and access control
+- member management, group and role assignment, distribution lists, password reset
+- project access control and publishing
+- user-defined function code and app deployments
+
+These are irreversible or credential-bearing actions where a prompt-injection misfire would be
+costly and which are rarely part of analytical work. They stay human-only.
+
+## The Path of One Question
+
+<Steps>
+
+1. A person asks the agent in Teams, Outlook, or Microsoft 365 chat.
+
+2. Copilot calls the agent, which needs a PlaidCloud identity — on first use it prompts for sign-in
+   through Microsoft's own window, and stores the result.
+
+3. The request reaches the PlaidCloud MCP endpoint carrying that person's token.
+
+4. The server resolves their access tier from their assigned level. No level, no data.
+
+5. Every tool call is checked against the tier, their own scopes and ACLs, and the denylist.
+
+6. The answer comes back from a real query — with a confidence signal and caveats, not a guess.
+
+</Steps>
+
+Because the tier is checked live on every request, granting access takes effect on the person's very
+next message. There is nothing to sign out of or reinstall.
+
+<Aside type="tip">
+**A whole-lane kill switch exists.** Operators can disable the Copilot path outright, and it fails
+closed — every Copilot token is rejected while it is off, without touching the other AI surfaces.
+</Aside>
+
+## Copilot Versus Coding Agents
+
+Both connect to the same MCP server and obey the same enforcement, but they are aimed at different
+people:
+
+| | Microsoft 365 Copilot | AI coding agents |
+|---|---|---|
+| **Who** | Whole teams, non-technical | Analysts and developers |
+| **Where** | Teams, Outlook, M365 chat | An IDE or desktop client |
+| **Setup** | Admin publishes a package once | Each person connects their own client |
+| **Access model** | An assigned level, deny by default | The person's own permissions |
+
+## Related
+
+- [Microsoft 365 Copilot](/integrations/microsoft-365-copilot/) — the setup guide
+- [Analysis Paths](/integrations/ai-coding-agents/analysis-paths/) — so everyone asks about the same table the same way
+- [Answers You Can Trust](/integrations/ai-coding-agents/honest-answers/) — confidence and caveats
+- [AI and LLM Architecture](/integrations/ai-architecture/) — the shared governed path

--- a/src/content/docs/integrations/ai-architecture/microsoft-365-copilot.mdx
+++ b/src/content/docs/integrations/ai-architecture/microsoft-365-copilot.mdx
@@ -1,6 +1,6 @@
 ---
 title: Microsoft 365 Copilot Architecture
-description: Why Microsoft 365 Copilot needs a published agent package and its own OAuth client, how deny-by-default access tiers are resolved, and what stays permanently off-limits.
+description: Why Microsoft 365 Copilot needs a published agent package and its own OAuth client, how deny-by-default access levels are resolved, and what stays permanently off-limits.
 sidebar:
   label: Copilot Architecture
   order: 3
@@ -19,7 +19,7 @@ are actually doing.
 
 <img
 	src="/images/ai-copilot-architecture.svg"
-	alt="A person in Teams or Outlook asks the PlaidCloud declarative agent, which is published in the Microsoft 365 tenant. Microsoft brokers sign-in to a dedicated PlaidCloud OAuth client. Requests then reach the curated MCP server, where a deny-by-default access tier and the person's own permissions gate every call. Credential, identity, and access-control tools are never reachable."
+	alt="A person in Teams or Outlook asks the PlaidCloud declarative agent, which is published in the Microsoft 365 tenant. Microsoft brokers sign-in to a dedicated PlaidCloud OAuth client. Requests then reach the curated MCP server, where a deny-by-default access level and the person's own permissions gate every call. Credential, identity, and access-control tools are never reachable."
 	class="doc-diagram"
 />
 
@@ -41,8 +41,8 @@ A person who has installed the agent and signed in successfully still gets no da
 administrator assigns them an access level. The agent connects, authenticates, and answers *"no
 access has been granted"* — that is the system working, not an error.
 
-The tier is resolved **server-side from the assignment an administrator made**, not from anything
-the incoming token claims. A token cannot talk its way into a higher tier.
+The level is resolved **server-side from the assignment an administrator made**, not from anything
+the incoming token claims. A token cannot talk its way into a higher level.
 
 | Level | The agent can… | Typical use |
 |---|---|---|
@@ -53,7 +53,7 @@ the incoming token claims. A token cannot talk its way into a higher tier.
 Two rules on top:
 
 - **Most permissive wins.** If someone somehow holds more than one level, the highest applies.
-- **The tier is a ceiling, never a grant.** Within it, the person's own PlaidCloud roles and ACLs
+- **The level is a ceiling, never a grant.** Within it, the person's own PlaidCloud roles and ACLs
   still apply, so the agent can never surface data they could not already open themselves.
 
 <Aside type="note">
@@ -64,7 +64,7 @@ so the anchors cannot be accidentally repurposed.
 
 ## Always Off-Limits
 
-Regardless of tier, and regardless of the person's own permissions, Copilot can never reach:
+Regardless of level, and regardless of the person's own permissions, Copilot can never reach:
 
 - connection and credential settings, or document-account credentials and access control
 - member management, group and role assignment, distribution lists, password reset
@@ -85,15 +85,15 @@ costly and which are rarely part of analytical work. They stay human-only.
 
 3. The request reaches the PlaidCloud MCP endpoint carrying that person's token.
 
-4. The server resolves their access tier from their assigned level. No level, no data.
+4. The server resolves their access level from what an administrator assigned. No level, no data.
 
-5. Every tool call is checked against the tier, their own scopes and ACLs, and the denylist.
+5. Every tool call is checked against the level, their own scopes and ACLs, and the denylist.
 
 6. The answer comes back from a real query — with a confidence signal and caveats, not a guess.
 
 </Steps>
 
-Because the tier is checked live on every request, granting access takes effect on the person's very
+Because the level is checked live on every request, granting access takes effect on the person's very
 next message. There is nothing to sign out of or reinstall.
 
 <Aside type="tip">

--- a/src/content/docs/integrations/ai-architecture/microsoft-365-copilot.mdx
+++ b/src/content/docs/integrations/ai-architecture/microsoft-365-copilot.mdx
@@ -47,7 +47,7 @@ the incoming token claims. A token cannot talk its way into a higher level.
 | Level | The agent can… | Typical use |
 |---|---|---|
 | **Read-only** | List and describe projects and tables, read table data, list dimension members, explain allocations | Most people — the safe default |
-| **Read/write** | The above, plus writes that person is already permitted to make | Analysts who maintain data |
+| **Read/Write** | The above, plus writes that person is already permitted to make | Analysts who maintain data |
 | **Full** | That person's complete tool set, including raw SQL that writes | Power users and builders |
 
 Two rules on top:

--- a/src/content/docs/integrations/ai-architecture/private-llm.mdx
+++ b/src/content/docs/integrations/ai-architecture/private-llm.mdx
@@ -118,7 +118,7 @@ projects and tables a person's permissions reach.
 3. **Register the connection.** Choose the provider, paste the key, set the base URL, and set the
    model — for Azure OpenAI the model field is your **deployment name**.
 
-4. **Leave the access tier at read-only** unless a specific job needs more. It is the cheapest
+4. **Leave Agent Access at Read-only** unless a specific job needs more. It is the cheapest
    control you have.
 
 5. **Add your rules.** Standing instructions are the right place for house conventions — how to

--- a/src/content/docs/integrations/ai-architecture/private-llm.mdx
+++ b/src/content/docs/integrations/ai-architecture/private-llm.mdx
@@ -1,0 +1,147 @@
+---
+title: Using Your Own Controlled LLM
+description: Keep proprietary, PHI, or contractually confined data inside infrastructure you control — point PlaidCloud at an Azure OpenAI resource in your own subscription or at a model you host yourself.
+sidebar:
+  label: Your Own LLM
+  order: 5
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+If your data includes protected health information, personal data, trade secrets, or anything under
+a contract that names where it may be processed, the question that matters is not *which model is
+smartest*. It is **whose infrastructure sees the prompt**.
+
+PlaidCloud treats the model as a replaceable component so you can answer that question yourself.
+
+<img
+	src="/images/ai-private-llm.svg"
+	alt="Three deployment choices compared: a vendor API, a private cloud model resource such as Azure OpenAI in your own subscription, and a self-hosted model. All three share identical in-tenant governance. A summary lists what reaches the model and what never does."
+	class="doc-diagram"
+/>
+
+## The Three Choices
+
+| | **Vendor API** | **Private cloud model** | **Self-hosted model** |
+|---|---|---|---|
+| **What it is** | Anthropic, OpenAI, Google, or xAI's public API | An Azure OpenAI resource in your own subscription | Any OpenAI-compatible endpoint you run |
+| **Who sees the prompt** | The vendor, under their terms and your account | Your cloud tenancy, under your agreement | Only you |
+| **Region and retention** | The vendor's | Yours to set | Yours to set |
+| **Capability** | Frontier | Frontier, one step behind the public API | Whatever you can host |
+| **You operate** | Nothing | A cloud resource | Servers and GPUs |
+| **Fits** | General analytics on non-sensitive data | Enterprises already covered by a cloud agreement | PHI, classified, air-gapped, or contractually confined data |
+
+All three are configured the same way: an [LLM Provider
+connection](/integrations/ai-architecture/llm-providers/) with a provider, a key, a model, and — for
+the latter two — a base URL pointing at your endpoint.
+
+## Why a Controlled Model Is Worth the Trouble
+
+**The prompt is the exposure, and the prompt contains your data.** A grounded assistant is useful
+precisely because real rows reach the model: patient counts by facility, unreleased pricing, a cost
+structure you would not email out. Everything else in the architecture — permissions, tool gating,
+short-lived tokens — governs what leaves *your* systems. Choosing the model governs where it lands.
+
+Pointing PlaidCloud at a model you control means:
+
+- **One fewer processor to paper over.** No third-party sub-processor to add to a data-protection
+  agreement, a BAA, or a vendor review — because the inference happens somewhere already covered.
+- **Residency you can prove.** "Processed in this region, in this account, under this contract" is
+  an assertion you can evidence, not one you have to take on trust.
+- **Retention and logging on your terms.** You decide whether prompts are retained, for how long,
+  and who can read the logs.
+- **It survives a policy change.** A vendor's terms can change; infrastructure you operate does not
+  change under you.
+- **Air-gapped estates get an assistant at all.** For networks that cannot reach a public API, a
+  self-hosted model is the only option that exists.
+
+<Aside type="caution">
+PlaidCloud gives you the controls; it cannot make a compliance determination for you. Whether a
+given configuration satisfies HIPAA, GDPR, a BAA, or a customer contract is a decision for your own
+privacy, security, and legal teams. Bring them the architecture on this page — it is written to be
+reviewable.
+</Aside>
+
+## What Actually Reaches the Model
+
+Worth being precise, because the answer is narrower than people assume.
+
+**Sent to the provider:**
+
+- your prompt, and the standing rules on the connection
+- the names and shapes of the objects the agent was told about — table and column names, dimension
+  names, bound document paths
+- the results of the tool calls the model made, which is to say the rows it asked for and was
+  permitted to receive
+- the running conversation for the current chat
+
+**Never sent:**
+
+- connection credentials, stored secrets, or resolved authorization headers
+- anything outside the asking person's permissions
+- whole tables the model did not request
+- another tenant's data
+
+And your content is not used to train anyone's model.
+
+## Which Surfaces You Control the Model For
+
+This is the part worth reading twice, because it is not uniform.
+
+| Surface | Whose model runs |
+|---|---|
+| **LLM workflow step** | **Yours.** The step uses the LLM Provider connection you pin or the workspace default. |
+| **In-app AI Assistant** | **Yours**, via the workspace's default LLM Provider connection. The multi-agent backend behind some assistant features is set per deployment and can be pointed at a self-hosted model — arrange this with PlaidCloud. |
+| **AI coding agents** | **Theirs.** Claude Code uses Anthropic; ChatGPT uses OpenAI. PlaidCloud is the data source, not the model host. |
+| **Microsoft 365 Copilot** | **Microsoft's.** Copilot runs on Microsoft's models inside your M365 tenant, under your Microsoft agreement. |
+
+<Aside type="caution">
+**If regulated data must not reach a particular vendor, restricting the model is not enough — you
+must also govern the surfaces.** On Copilot and coding agents, PlaidCloud does not choose the model;
+the client does. Control those through the levers that do apply: whether the Copilot agent is
+published at all, who is granted an access level, whether the Copilot lane is enabled, and which
+projects and tables a person's permissions reach.
+</Aside>
+
+## Setting It Up
+
+<Steps>
+
+1. **Stand up the endpoint.** Create the Azure OpenAI resource and deployment in your subscription,
+   or run your model behind an OpenAI-compatible API.
+
+2. **Make it reachable over HTTPS at a resolvable public hostname.** Outbound calls are validated
+   before they are made: the base URL must be HTTPS, and a loopback, private-range, link-local, or
+   cloud-metadata address is refused, with redirects disabled. Front a self-hosted model with a TLS
+   gateway on a real hostname and restrict who can reach it at the network layer.
+
+3. **Register the connection.** Choose the provider, paste the key, set the base URL, and set the
+   model — for Azure OpenAI the model field is your **deployment name**.
+
+4. **Leave the access tier at read-only** unless a specific job needs more. It is the cheapest
+   control you have.
+
+5. **Add your rules.** Standing instructions are the right place for house conventions — how to
+   handle identifiers, what never to include in an answer, which caveats to always state.
+
+6. **Make it the workspace default**, or pin it on the specific workflow steps that handle
+   regulated data.
+
+</Steps>
+
+## A Reasonable Middle Ground
+
+Sensitivity is rarely uniform across a workspace, and the model is chosen per connection — so it can
+be chosen per job. A common arrangement:
+
+- a **frontier vendor model** as the workspace default, for schema questions, documentation help,
+  expression authoring, and analysis of non-sensitive data
+- a **controlled model** pinned on the workflow steps that touch regulated tables
+
+Same platform, same permissions, same audit trail — two different blast radii, matched to the data.
+
+## Related
+
+- [LLM Providers and Connections](/integrations/ai-architecture/llm-providers/) — the fields and the adapters
+- [AI and LLM Architecture](/integrations/ai-architecture/) — the governed path every surface shares
+- [Retrieval, Grounding, and Analysis Paths](/integrations/ai-architecture/retrieval/) — why your data is never pre-indexed

--- a/src/content/docs/integrations/ai-architecture/retrieval.mdx
+++ b/src/content/docs/integrations/ai-architecture/retrieval.mdx
@@ -23,10 +23,14 @@ performance decision; it is what makes an answer trustworthy and an access contr
 
 ## Lane 1 — Choosing Which Tools to Offer
 
-The assistant carries a large tool catalog, and every tool description it shows the model costs
-prompt tokens on every turn. So before the model sees anything, the question is matched by semantic
-similarity against **the tool descriptions** — never against your data — and only plausibly relevant
-tools are offered.
+This lane runs for the **in-app assistant**, which carries its own tool catalog. Every tool
+description it shows the model costs prompt tokens on every turn, so before the model sees anything,
+the question is matched by semantic similarity against **the tool descriptions** — never against
+your data — and only plausibly relevant tools are offered.
+
+On the other surfaces the tool catalog is handled by the MCP connection instead: Anthropic's
+connector manages it server-side, and the client-side loop caps the surface it declares. Lanes 2 and
+3 below apply everywhere.
 
 Three details matter:
 

--- a/src/content/docs/integrations/ai-architecture/retrieval.mdx
+++ b/src/content/docs/integrations/ai-architecture/retrieval.mdx
@@ -1,0 +1,125 @@
+---
+title: Retrieval, Grounding, and Analysis Paths
+description: What RAG actually does inside PlaidCloud — keyword retrieval over the documentation, semantic tool selection, and live permission-checked reads of your own data through analysis paths.
+sidebar:
+  label: Retrieval and RAG
+  order: 4
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+"RAG" usually means one thing: chop the corpus into fragments, embed them into a vector store, and
+paste the nearest matches into the prompt. PlaidCloud does that for exactly one corpus — the product
+documentation — and deliberately does **not** do it to your data.
+
+Your tables are read live, at the moment they are asked about, under your permissions. That is not a
+performance decision; it is what makes an answer trustworthy and an access control meaningful.
+
+<img
+	src="/images/ai-retrieval.svg"
+	alt="Three retrieval lanes. Lane one selects which tools to offer using embeddings of tool descriptions. Lane two is keyword BM25 retrieval over the published documentation corpus. Lane three reads your own data live through analysis paths and MCP tools. Together they produce a grounded answer with confidence and caveats."
+	class="doc-diagram"
+/>
+
+## Lane 1 — Choosing Which Tools to Offer
+
+The assistant carries a large tool catalog, and every tool description it shows the model costs
+prompt tokens on every turn. So before the model sees anything, the question is matched by semantic
+similarity against **the tool descriptions** — never against your data — and only plausibly relevant
+tools are offered.
+
+Three details matter:
+
+- **The embeddings describe tools, not content.** They are computed once from tool names and
+  descriptions and cached, and rebuilt automatically when a description changes.
+- **A few tools are always present** so the agent can orient itself — work out who is asking and in
+  which project — even when the question mentions neither.
+- **Low confidence falls back to the full list.** A confidently wrong narrowing is worse than paying
+  the full token cost once, so an uncertain match simply shows everything. Very short turns
+  ("thanks", "ok") skip the step entirely.
+
+## Lane 2 — Grounding in the Documentation
+
+This is the genuine retrieval-augmented generation path, and it answers *"how do I…"*, *"what
+is…"*, and *"where do I configure…"*.
+
+The published documentation is fetched as a structured corpus — one entry per page — and indexed
+in memory with **Okapi BM25**, a keyword ranking function. The agent then works in two moves:
+
+1. **Search** returns a ranked shortlist of pages: slug, title, description, score.
+2. **Fetch** pulls one page, or a single named section of it, once the agent has decided which one
+   it actually needs.
+
+<Aside type="note">
+**Why keyword ranking rather than embeddings?** This was measured, not assumed. A BM25 shortlist
+re-ranked by the chat model beat the embeddings-and-vector-store approach on every retrieval metric
+for this corpus, so the vector store was retired. Product documentation is dense with exact terms —
+step names, function names, field labels — which is precisely where keyword ranking is strong.
+</Aside>
+
+The design point is that **the agent decides when to search** and how much to read. Passive
+injection pastes something into every prompt whether it helps or not; tool-driven retrieval keeps
+irrelevant pages out of the context window entirely, and lets the agent cite the page it used so you
+can follow up.
+
+If the documentation corpus is briefly unreachable, the agent answers without it rather than failing
+the turn.
+
+## Lane 3 — Reading Your Own Data
+
+Questions about *your* numbers are not answered by retrieval at all. The agent reads what it needs,
+when it needs it, through permission-checked tools: table schemas, rows, dimension members, workflow
+lineage, allocation traces.
+
+This is why answers are current — they reflect the data as it is now, not as it was when something
+was last indexed — and it is why access control works: there is no pre-built index that could leak
+across a permission boundary, because there is no index.
+
+### Analysis Paths — The Naming Layer
+
+Live reads need to know *which* table. **Analysis paths** are the shared vocabulary that makes that
+painless: a friendly name — *"Operations Results"*, *"the P&L"*, *"Headcount"* — mapped once to a
+real project and table, and usable by everyone in the workspace from then on.
+
+- **Ask by name** instead of naming a project and a table every time.
+- **Mark one as the workspace default** so an untargeted *"what changed last quarter?"* lands
+  somewhere sensible.
+- **Everyone means the same thing.** When the whole team says "the P&L", they reach the same table.
+
+An administrator registers them; anyone can use them; every question still runs under the asking
+person's own permissions. They work identically from the in-app assistant, Microsoft 365 Copilot,
+and a connected coding agent. See [Analysis Paths](/integrations/ai-coding-agents/analysis-paths/)
+for how to set them up.
+
+### The Expression Catalog
+
+When the assistant writes an expression, it does not guess function names from memory. It consults a
+structured catalog of every PlaidCloud expression function — name, signature, documentation link,
+category — cross-checked against the functions your warehouse actually provides, with close-match
+suggestions when a name is nearly right. A lookup, not a similarity search, because for function
+names "nearly right" is wrong.
+
+## Grounding Is Not Training
+
+Two things people reasonably worry about:
+
+- **Nothing retrieved here trains a model.** Grounding puts information into one request. It does
+  not change model weights, and your content is not used to train anyone's model.
+- **The retrieval index holds public documentation only.** No customer content is embedded into it.
+
+Where your data does go — and how to keep it inside infrastructure you control — is covered in
+[Using Your Own Controlled LLM](/integrations/ai-architecture/private-llm/).
+
+## Why This Produces Better Answers
+
+Grounding is what lets the assistant say *"I don't know"* instead of inventing something. Because
+every figure comes from a real query and every product claim from a real documentation page, an
+answer can be graded: each one carries a confidence signal and plain-language caveats, and a
+narrative summary is checked so it cannot quietly drop a limitation or cite a number the analysis
+never produced. See [Answers You Can Trust](/integrations/ai-coding-agents/honest-answers/).
+
+## Related
+
+- [Analysis Paths](/integrations/ai-coding-agents/analysis-paths/) — set up the shared names
+- [Tracing Allocations](/integrations/ai-coding-agents/tracing-allocations/) — asking *why* a result moved
+- [AI and LLM Architecture](/integrations/ai-architecture/) — the surfaces and the shared path

--- a/src/content/docs/integrations/ai-coding-agents/analysis-paths.mdx
+++ b/src/content/docs/integrations/ai-coding-agents/analysis-paths.mdx
@@ -68,5 +68,6 @@ Setting up analysis paths — registering them and choosing the default — is a
 
 - [Answers You Can Trust](../honest-answers/) — how PlaidCloud grades and caveats every AI answer
 - [Tracing Allocations](../tracing-allocations/) — explain *why* a named result changed
+- [Retrieval, Grounding, and Analysis Paths](/integrations/ai-architecture/retrieval/) — where analysis paths sit in the wider retrieval architecture
 - [Getting Started with AI Coding Agents](../getting-started/) — connect an assistant over MCP
 - [Microsoft 365 Copilot](/integrations/microsoft-365-copilot/) — use analysis paths from Teams and Outlook

--- a/src/content/docs/integrations/ai-coding-agents/index.md
+++ b/src/content/docs/integrations/ai-coding-agents/index.md
@@ -8,7 +8,7 @@ sidebar:
 
 PlaidCloud exposes a curated [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server at `/mcp` on every workspace. AI agents connect to it the same way they connect to any other MCP server, then call the tools to read projects, run workflows, query tables, manage dimensions, and more.
 
-The pages in this section cover what the server exposes, how to authenticate, and step-by-step setup for the most common AI clients.
+The pages in this section cover what the server exposes, how to authenticate, and step-by-step setup for the most common AI clients. For the architecture behind them — the governed path every AI request takes, how retrieval works, and how to run your own model — see [AI and LLM Architecture](/integrations/ai-architecture/).
 
 ## What Makes PlaidCloud's AI Analysis Different
 

--- a/src/content/docs/integrations/index.mdx
+++ b/src/content/docs/integrations/index.mdx
@@ -9,7 +9,7 @@ Connect PlaidCloud to the tools your team already uses.
 
 <CardGrid>
 	<LinkCard
-		title="AI and LLM architecture"
+		title="AI and LLM Architecture"
 		href="/integrations/ai-architecture/"
 		description="How PlaidCloud works with Claude, GPT, Gemini, and Grok — the governed path, retrieval, and running your own controlled model."
 	/>

--- a/src/content/docs/integrations/index.mdx
+++ b/src/content/docs/integrations/index.mdx
@@ -9,6 +9,11 @@ Connect PlaidCloud to the tools your team already uses.
 
 <CardGrid>
 	<LinkCard
+		title="AI and LLM architecture"
+		href="/integrations/ai-architecture/"
+		description="How PlaidCloud works with Claude, GPT, Gemini, and Grok — the governed path, retrieval, and running your own controlled model."
+	/>
+	<LinkCard
 		title="Microsoft 365 Copilot"
 		href="/integrations/microsoft-365-copilot/"
 		description="Let your team ask Microsoft 365 Copilot about their PlaidCloud projects, tables, and allocations — read-only, sign in once."

--- a/src/content/docs/integrations/microsoft-365-copilot.mdx
+++ b/src/content/docs/integrations/microsoft-365-copilot.mdx
@@ -40,6 +40,10 @@ the request under that person's own permissions, and Copilot explains the answer
   person gets a clear *"no access has been granted"* message until a PlaidCloud administrator gives
   them an access level. This is deliberate — see [Access Levels](#access-levels).
 
+For what happens behind those points — the published agent package, the dedicated OAuth client, and
+how access levels are resolved and enforced — see [Copilot
+Architecture](/integrations/ai-architecture/microsoft-365-copilot/).
+
 ## Setup at a Glance
 
 The full path, in order. Up to three roles are involved — often the same person wears more than one
@@ -240,6 +244,7 @@ change above your level, it says so rather than guessing.
 
 ## Related
 
+- [Copilot Architecture](/integrations/ai-architecture/microsoft-365-copilot/) — what the setup steps are actually doing, and how access levels are enforced
 - [Answers You Can Trust](/integrations/ai-coding-agents/honest-answers/) — how PlaidCloud grades and caveats every AI answer
 - [Tracing Allocations](/integrations/ai-coding-agents/tracing-allocations/) — ask *why* an allocated result changed
 - [Analysis Paths](/integrations/ai-coding-agents/analysis-paths/) — name your key tables so the whole team asks about them the same way

--- a/src/styles/brand.css
+++ b/src/styles/brand.css
@@ -49,6 +49,19 @@
 	background: var(--sl-color-gray-7);
 }
 
+/* Content-width explanatory diagrams. Unlike .architecture-diagram (one
+ * full-bleed clickable poster), these sit in the prose column and keep their
+ * own aspect ratio. The light card background is part of the artwork, so the
+ * border/radius here just seat it against the page in either theme. */
+.doc-diagram {
+	display: block;
+	width: 100%;
+	height: auto;
+	margin: 1.5rem 0;
+	border: 1px solid var(--sl-color-gray-5);
+	border-radius: 0.5rem;
+}
+
 /* Top-level sidebar groups are section headings. Nested expandable items are
  * navigation entries and should match their sibling links. */
 #starlight__sidebar ul ul .large {


### PR DESCRIPTION
## Summary

Adds an **AI and LLM architecture** section under `integrations/` — five pages with five hand-drawn SVG diagrams explaining how PlaidCloud works with Claude, GPT, Gemini, Grok, Azure OpenAI, and self-hosted models.

Our AI docs were all task-oriented (install the Copilot agent, connect Claude Code, ask for a SQL extract). Nothing explained the architecture underneath, which is what a customer's security or compliance review actually asks for.

| Page | Covers |
|---|---|
| [Overview](/integrations/ai-architecture/) | The four surfaces and the one governed path they share |
| [LLM Providers](/integrations/ai-architecture/llm-providers/) | Six providers, four execution adapters, tool brokering, access tiers |
| [Copilot Architecture](/integrations/ai-architecture/microsoft-365-copilot/) | Why Copilot needs a published package + its own OAuth client; deny-by-default tiers |
| [Retrieval and RAG](/integrations/ai-architecture/retrieval/) | The three lanes people conflate; analysis paths |
| [Your Own LLM](/integrations/ai-architecture/private-llm/) | Proprietary/PHI workloads; vendor vs. private-cloud vs. self-hosted |

Two points the docs make deliberately, both checked against the backend source rather than assumed:

- **Customer data is never embedded into a vector store.** The only retrieval index is BM25 over the published docs corpus (the embeddings/Chroma path was measured and retired). Customer tables are read live through permission-checked tools. Embeddings survive only for *tool selection*, over tool descriptions.
- **Bring-your-own-LLM only covers two of the four surfaces.** On Copilot and coding agents the *client* picks the model, not PlaidCloud. The page says so plainly and points at the levers that do apply.

Also cross-links from the existing Copilot, coding-agent, analysis-path, and AI-assistant pages, and adds a `.doc-diagram` CSS class for content-width diagrams (the existing `.architecture-diagram` is sized for the one full-bleed poster).

## User-facing change?

- [x] Yes — customers will notice this
- [ ] No — internal/infrastructure only

**Customer summary:** New AI and LLM architecture documentation explains how PlaidCloud works with Claude, GPT, Gemini, and Grok, how Microsoft 365 Copilot access is granted and enforced, how retrieval grounds answers in your documentation and live data, and how to run your own model to keep proprietary or PHI data inside infrastructure you control.

## Category

- [x] Added — new feature or capability
- [ ] Changed — modified existing behavior
- [ ] Fixed — bug fix users would notice
- [ ] Security — auth, data handling, vuln fix
- [ ] Deprecated — feature on its way out

## Testing

- `npm run build` clean — 1,528 pages, no MDX/frontmatter errors, no "entry not found" link warnings.
- Verified every internal link emitted by the new and edited pages resolves to a built `index.html`.
- Rasterized all five SVGs and inspected each; fixed overlapping labels and three text overflows found that way.
- Cloudflare preview verified end to end: all five pages, all five diagrams, and the three cross-linked pages return 200. Confirmed `docs.plaidcloud.com` was unaffected by the branch build.

Preview: https://docs-ai-llm-architecture-plaidcloud-docs.paul-937.workers.dev/integrations/ai-architecture/

🤖 Generated with [Claude Code](https://claude.com/claude-code)