### PR TITLE
Document the Visual Workflow Designer's folder step palette

### DIFF
--- a/src/content/docs/guides/workflows/advanced-workflows.mdx
+++ b/src/content/docs/guides/workflows/advanced-workflows.mdx
@@ -94,7 +94,7 @@ A workflow can be **locked** to prevent accidental edits. Click the lock toggle 
 
 ## Add, Connect, and Edit Steps
 
-Drag a step type from the **palette** onto the canvas. To connect steps, drag from one step to another to draw a **connector** — this is what tells the runtime that one step's output feeds the next.
+Click a step type in the **[palette](#the-step-palette)** to drop it on the canvas, or drag it where you want it. To connect steps, drag from one step to another to draw a **connector** — this is what tells the runtime that one step's output feeds the next.
 
 <Aside type="caution">The workflow must stay a DAG: a connector that would create a cycle is rejected ("that connector would create a cycle"). Right-click a connector to **Remove Connector** or jump to **Edit Source Step…** / **Edit Target Step…** at either end.</Aside>
 
@@ -129,7 +129,19 @@ To clear it:
 
 ## The Step Palette
 
-The **Step Palette** lists every step type you can add. Use **Filter…** to find a step by name, and mark the ones you use most with **Add to Favorites** so they surface under **Favorites** at the top.
+The **Step Palette** on the left of the canvas holds every step type you can add, filed in ten folders: **Import**; **Export & Archive**; **Tables**; **Dimensions**; **Allocations**; **AI, ML & Text**; **Spatial**; **Documents & Reports**; **Workflow & Variables**; and **External Systems**. Folders start closed. Click one to open it; a few hold sub-folders, such as **Sage** under Import and **Notifications** under Workflow & Variables. The palette remembers which folders you left open.
+
+There are two ways to add a step:
+
+1. **Click it.** The step appears near the top-left of the visible canvas, already selected, so the Inspector shows its details. Drag it to where you want it. Clicked the wrong one? Press **Delete** and confirm — it's still selected, so there's nothing to hunt for.
+2. **Drag it** from the palette onto the canvas, and it lands where you drop it.
+
+Two more things worth knowing:
+
+- **Filter…** searches the whole catalog by step name, whatever is open or closed. Results come back as one flat list rather than in folders, so there is nothing to expand.
+- The **star** beside a step pins it to **Favorites**, a section that sits above the folders and is never filed inside one. Right-click a step for the same **Add to Favorites** / **Remove from Favorites**, plus **Add to Canvas**.
+
+<Aside type="note">Step names can be longer than the palette is wide. Drag the divider between the palette and the canvas to widen it — the width is remembered for next time. Hovering a step also shows what it does, or its full name if it has no description.</Aside>
 
 ## Run Controls
 

--- a/src/content/docs/releases/2026-08.mdx
+++ b/src/content/docs/releases/2026-08.mdx
@@ -3,6 +3,14 @@ title: August 2026
 description: Resume now picks a workflow back up where it stopped — inside called workflows and loops, and without re-running steps that already succeeded.
 ---
 
+## Changed
+
+- **The step palette in the Visual Workflow Designer is now organized into folders.** Every step type used to sit in one long list you scrolled through. Steps are now filed in ten folders that start closed, so you see a short, scannable list instead of the whole catalog — and your favorites stay pinned above the folders, where they were. **Filter…** still searches everything at once, open or closed, and returns a plain list of matches.
+
+  Clicking a step now adds it. It appears near the top left of the canvas, already selected, ready for you to drag where you want it — and if you picked the wrong one, Delete removes it without hunting for it first. Dragging a step from the palette still drops it exactly where you let go.
+
+  Step names are long, so you can widen the palette by dragging the divider beside it, and it remembers the width for next time. See [Advanced Workflows](/guides/workflows/advanced-workflows/#the-step-palette).
+
 ## Fixed
 
 - **Resume picks a workflow back up where it stopped, including inside called workflows.** A run that failed several levels deep — a workflow calling a workflow, or a loop step working through its iterations — restarted the first called workflow from its opening step instead of returning to the point of failure, repeating everything in between. Resume now returns to the step that failed, at whatever depth it sits, and a loop step resumes the interrupted iteration and skips the iterations that already completed. See [Run a Workflow](/guides/workflows/run-a-workflow/#pause-stop-and-resume).


### PR DESCRIPTION
Follows PlaidCloud/PlaidClient#1945 and PlaidCloud/PlaidClient#1946 ([sc-23595](https://app.shortcut.com/plaidcloud/story/23595)).

Rewrites **The Step Palette** section of the Advanced Workflows guide for the folder palette: the ten folders by name, closed-by-default with remembered state, sub-folders, click-to-add (lands top-left, selected, Delete undoes it) alongside drag-to-place, filter returning a flat list, the star / right-click favorites actions, and the draggable divider for long names.

Also updates "Add, Connect, and Edit Steps", which told the reader to drag from the palette without mentioning the click path, and links it to the palette section.

Labels are taken from the shipped `this.tr(...)` strings, not paraphrased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)