### PR TITLE
Document the security group permission-revocation fix (sc-23663)

### DIFF
--- a/src/content/docs/administration/access/managing-security-groups-and-assignments/index.mdx
+++ b/src/content/docs/administration/access/managing-security-groups-and-assignments/index.mdx
@@ -38,6 +38,10 @@ Security groups can be added, updated, or deleted.
 4. Click the Member icon
 5. Drag desired members from the “Unassigned Members” column to the “Assigned Members” column or vice versa to remove members
 
+<Aside>Saving with the “Assigned Members” column empty makes no change, and tells you so. To take a group away from everyone, remove its permissions or delete the group rather than emptying its membership.</Aside>
+
+<Aside type="caution">Permissions you cannot grant yourself are left alone when you save a group’s permission matrix, and are not shown in it. If you need to change one, ask someone who holds that permission — the matrix only ever edits what you control.</Aside>
+
 ## Setting Default Security Groups
 
 

--- a/src/content/docs/releases/2026-08.mdx
+++ b/src/content/docs/releases/2026-08.mdx
@@ -18,3 +18,15 @@ description: Resume now picks a workflow back up where it stopped — inside cal
 - **Resume no longer re-runs completed steps on parallel and Advanced workflows.** On both, Resume restarted the whole workflow, so every step that had already succeeded ran a second time — including any sub-workflows they called. Both now re-run only the step or node that failed and whatever was still waiting on it. If you had been using Resume on a parallel workflow as a way to re-run everything, use **Run All** instead. See [Run a Workflow](/guides/workflows/run-a-workflow/#pause-stop-and-resume).
 
 - **Resuming a Run Selected run keeps its selection.** Resuming a run that had been scoped to a chosen set of nodes on the Advanced canvas widened it to the whole workflow. The original selection is now preserved. See [Advanced Workflows](/guides/workflows/advanced-workflows/).
+
+- **Saving a security form with nothing selected now tells you nothing changed.** Assigning members to a group, or groups to a member, and saving with an empty list reported success while making no change — and on the member form it could instead remove every group that member had. An empty list now leaves the assignment alone and says so. See [Managing Security Groups and Assignments](/administration/access/managing-security-groups-and-assignments/).
+
+## Security
+
+- **Editing a security group's permissions no longer removes the permissions you don't hold yourself.** Anyone who was not a workspace administrator silently stripped every permission on that group they could not grant themselves — just by opening the permission matrix and saving it, even without changing anything. Workspace administrators were unaffected, which is why this looked like permissions disappearing at random for some people and never for others, and why a permission held by only a few, such as Panel app management, would drop off repeatedly and have to be re-added. Those permissions are now left untouched.
+
+  Review any security group that a non-administrator has edited and confirm its permissions are what you expect — a permission removed this way was removed for everyone in the group. See [Managing Security Groups and Assignments](/administration/access/managing-security-groups-and-assignments/).
+
+- **A permission you do not hold can no longer be granted through the permission matrix.** The form only ever offered the permissions you are allowed to control, but a request naming others was accepted anyway, so someone able to manage users could grant a group — and through it themselves — broader access than they held. Permissions being granted are now checked against your own.
+
+- **Permission and membership changes are recorded in the security log.** Changing a group's permissions or members, or a member's groups, previously left no record unless the Git server sync failed, so a permission that changed could not be attributed to anyone afterwards. Every change is now logged with what was granted and what was revoked. See [Performing a Security Audit](/administration/access/managing-security-groups-and-assignments/#performing-a-security-audit).


### PR DESCRIPTION
Docs for [sc-23663](https://app.shortcut.com/plaidcloud/story/23663) / [plaid#6864](https://github.com/PlaidCloud/plaid/pull/6864), which shipped to `master` and `beta-202608` today.

## What's New — August 2026

**`## Security`** (new section on the page):
- Editing a security group's permissions no longer removes the permissions the editor doesn't hold themselves. Non-administrators stripped every permission on a group they couldn't grant themselves just by opening the matrix and saving — administrators were unaffected, which is why it looked random. Includes a call to action: **review any group a non-administrator edited**, since a permission removed this way was removed for everyone in the group and nothing in the product will say so retroactively.
- A permission you don't hold can no longer be granted through the matrix (the form only offered what you control, but a request naming anything else was accepted).
- Permission and membership changes now reach the security log. This complements July's "changes take effect immediately" note — that covered propagation, this covers the audit record.

**`## Fixed`**: an empty assignment list now reports that nothing changed rather than reporting success.

## Guide

Two `<Aside>`s on [Managing Security Groups and Assignments](/administration/access/managing-security-groups-and-assignments/), at the step where a reader would hit each: what an empty "Assigned Members" column does, and the fact that the matrix only ever edits permissions you can control (so a permission you can't see is not missing — it's out of your scope).

## Verification

- `npm run build` clean locally — 1529 pages.
- Confirmed against `dist/`: the guide page exists at the linked path, the `#performing-a-security-audit` anchor is really emitted, and all three asides render (one pre-existing + two new, one `type="caution"`). Lychee fails the build on a broken internal link, so these were checked rather than assumed.
- No `<LinkCard>` change needed — `releases/index.mdx` already has the August card.
- Vale isn't installed locally; it's advisory in CI (`--no-exit`).

No new pages, so no sidebar or index-page link list to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)