### PR TITLE
Document the abandoned workflow step status (sc-23718)

### DIFF
--- a/src/content/docs/guides/workflows/run-a-workflow.md
+++ b/src/content/docs/guides/workflows/run-a-workflow.md
@@ -1,6 +1,6 @@
 ---
 title: Run a workflow
-description: Run a PlaidCloud workflow manually or on demand, and pause, stop, or resume a run from where it left off.
+description: Run a PlaidCloud workflow manually or on demand, follow each step's status, and pause, stop, or resume a run from where it left off.
 sidebar:
   order: 6
 ---
@@ -10,6 +10,30 @@ You can trigger a full workflow run by either clicking on the run icon from the 
 
 
 You can also click on the **Toggle Start/Stop** button at the top of the workflow table. This toggle button will stop a running workflow or start a workflow.
+
+## Follow a Step's Status
+
+While a workflow runs, each step carries a status icon showing where it stands, alongside how long it has been running. Hover the icon for the message behind it.
+
+| Status | What it means |
+|---|---|
+| Waiting | The step is queued and hasn't started yet. |
+| Running | The step is working, and its duration counts up as it goes. |
+| Completed | The step finished successfully. |
+| Warning | The step finished, but flagged something worth reading in the [workflow log](/guides/workflows/viewing-workflow-log/). |
+| Error | The step failed. See [Managing Step Errors](/guides/workflows/managing-step-errors/). |
+| Skipped | The step was passed over — it's disabled, or its run conditions weren't met. See [Skip Steps in a Workflow](/guides/workflows/skip-steps-in-a-workflow/). |
+| Continued | The step failed but is set to continue on error, so the workflow carried on. See [Continue on Error](/guides/workflows/continue-on-error/). |
+| Stopped | The run was stopped before the step could finish. |
+| Abandoned | The step's execution was interrupted, so it will never finish. Re-run the workflow. |
+
+An open workflow view refreshes on its own as a run progresses, so the statuses you're looking at stay current without reloading the page.
+
+### Abandoned Steps
+
+A step is marked **abandoned** when whatever was executing it went away mid-run — most often because someone pressed **Stop**, or because platform maintenance interrupted the run. The step's duration stops climbing and the status tooltip explains what happened.
+
+An abandoned step did not complete and produced no output. It is not a slow step, and it is not a problem with your data or your configuration. Re-run the workflow.
 
 ## Pause, Stop, and Resume
 

--- a/src/content/docs/releases/2026-08.mdx
+++ b/src/content/docs/releases/2026-08.mdx
@@ -1,6 +1,6 @@
 ---
 title: August 2026
-description: Resume now picks a workflow back up where it stopped — inside called workflows and loops, and without re-running steps that already succeeded.
+description: Resume now picks a workflow back up where it stopped — inside called workflows and loops, and without re-running steps that already succeeded — and an interrupted step reports itself as abandoned instead of appearing to run forever.
 ---
 
 ## Changed
@@ -11,7 +11,13 @@ description: Resume now picks a workflow back up where it stopped — inside cal
 
   Step names are long, so you can widen the palette by dragging the divider beside it, and it remembers the width for next time. See [Advanced Workflows](/guides/workflows/advanced-workflows/#the-step-palette).
 
+- **Workflow runs are lighter on the platform.** A running workflow now asks PlaidCloud for far less of the same information while it works, which frees up capacity in busy workspaces where many workflows run at once.
+
 ## Fixed
+
+- **A step whose run was interrupted now reports itself as abandoned, instead of appearing to run forever.** When the work behind a step went away mid-run — because someone pressed **Stop**, or because platform maintenance interrupted it — nothing ever corrected the step's status. The workflow view kept showing it as running with a duration climbing indefinitely, which reads as an extremely slow step: in the case that prompted this, a step that takes three seconds displayed as running for over twenty minutes.
+
+  Such a step is now marked **abandoned**, with an explanation in its status tooltip, and its duration stops. An open workflow view refreshes on its own, so it corrects itself without a manual reload. An abandoned step did not complete and produced no output — it is not a slow step and not a data problem. Re-run the workflow. See [Follow a Step's Status](/guides/workflows/run-a-workflow/#follow-a-steps-status).
 
 - **Resume picks a workflow back up where it stopped, including inside called workflows.** A run that failed several levels deep — a workflow calling a workflow, or a loop step working through its iterations — restarted the first called workflow from its opening step instead of returning to the point of failure, repeating everything in between. Resume now returns to the step that failed, at whatever depth it sits, and a loop step resumes the interrupted iteration and skips the iterations that already completed. See [Run a Workflow](/guides/workflows/run-a-workflow/#pause-stop-and-resume).
 

--- a/src/content/docs/releases/index.mdx
+++ b/src/content/docs/releases/index.mdx
@@ -13,7 +13,7 @@ Monthly summaries of changes shipped to PlaidCloud tenants. Months with substant
 	<LinkCard
 		title="August 2026"
 		href="/releases/2026-08/"
-		description="Resume picks a workflow back up where it stopped — inside called workflows and loops, and without re-running steps that already succeeded."
+		description="Resume picks a workflow back up where it stopped, and an interrupted step now reports itself as abandoned instead of appearing to run forever."
 	/>
 	<LinkCard
 		title="July 2026"


### PR DESCRIPTION
A workflow step whose execution was interrupted — by pressing **Stop**, or by platform maintenance — used to keep showing as running, with a duration that climbed indefinitely. That reads as "extremely slow step". It now reports as **abandoned**, the duration stops, and an open workflow view corrects itself without a reload.

## Pages Touched

| Page | Change |
|---|---|
| `guides/workflows/run-a-workflow.md` | New **Follow a Step's Status** section — a table of every step status, plus an **Abandoned Steps** subsection covering what causes it and what to do (re-run; no output was produced, it is not a data problem). |
| `releases/2026-08.mdx` | `## Fixed` entry for the abandoned status; `## Changed` line noting a running workflow is lighter on the platform. Page description extended. |
| `releases/index.mdx` | August LinkCard description updated to match. |

## Validation

- `npm run build` passes locally (1,529 pages).
- No MDX brace-parsing errors.
- Both cross-page anchors verified against the generated HTML ids (`#follow-a-steps-status`, `#pause-stop-and-resume`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)