### PR TITLE
Document dashboard caching and the invalidation fix (sc-23686)

### DIFF
--- a/src/content/docs/guides/dashboards/dashboard-caching.mdx
+++ b/src/content/docs/guides/dashboards/dashboard-caching.mdx
@@ -1,0 +1,103 @@
+---
+title: Dashboard Caching
+description: How PlaidCloud dashboards cache chart results, when a cached result is discarded, and how to hold results longer so repeat views load from cache.
+sidebar:
+  order: 6
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+A dashboard caches the result of every chart it draws. The first person to open a
+dashboard runs its queries against the data warehouse; everyone who opens it after
+that gets the stored result instead, which is why a second view is much faster than
+the first.
+
+A cached result is discarded — and the next view re-queries the warehouse — in two
+situations: the table behind the chart is republished, or the result reaches the end
+of its cache lifetime.
+
+## Republishing a Table Clears Its Cached Results
+
+When a workflow run republishes a table, every chart reading that table drops its
+cached results immediately. The next person to open the dashboard sees the refreshed
+numbers, without waiting and without forcing a refresh by hand.
+
+This means a dashboard is never showing pre-refresh numbers because of caching. If a
+dashboard looks stale after a workflow run, the cause is the workflow — check that
+the run finished and that it republished the table you expect — not the cache.
+
+<Aside type="caution" title="Publish Under a Stable Name">
+Cached results are tracked per published table. If you rebuild a table under a
+different published name, the charts still pointing at the old name keep serving the
+old table's data. Republish under the same name so the charts you already built stay
+attached to it.
+</Aside>
+
+## Cache Lifetime
+
+Every cached result also carries a lifetime, after which it expires on its own. The
+default is **5 minutes**.
+
+The default is deliberately short, but it is not what keeps a dashboard current —
+republishing does that. So on data that changes only when a workflow runs, a short
+lifetime buys nothing and costs a great deal: any view more than five minutes after
+the last one re-queries the warehouse from scratch. Dashboards that are used in
+bursts — a morning review, a month-end close — pay that cost on almost every load.
+
+Raising the lifetime is what makes repeat dashboard loads fast. Set it to comfortably
+longer than the gap between visits — an hour, or a day for tables that reload
+overnight — and the workflow that reloads the table still clears the cache the moment
+new data lands.
+
+<Aside>
+A longer lifetime is only safe for data that changes through PlaidCloud. If a chart
+reads a table that something outside PlaidCloud writes to, nothing signals the
+dashboard to drop its cache, and the lifetime is the only thing that refreshes it.
+Keep the lifetime short on those.
+</Aside>
+
+## Changing the Cache Lifetime
+
+Set the lifetime in seconds, either on a database or on an individual dataset. A value
+on the dataset wins over the value on its database, and the 5-minute default applies
+where you have set neither. Changing either needs the corresponding edit permission in
+the Dashboards area.
+
+**For every dataset on a database:**
+
+1. Go to **Data → Databases** in the Dashboards area
+2. Click the edit icon on the database
+3. Open the **Advanced** tab, then **Performance**
+4. Enter a value in seconds in **Chart cache timeout** — for example, `3600` for one
+   hour
+5. Click **Finish**
+
+**For a single dataset:**
+
+1. Go to **Data → Datasets**
+2. Click the edit icon on the dataset
+3. Open the **Settings** tab
+4. Enter a value in seconds in **Cache timeout**
+5. Click **Save**
+
+Two values have special meanings: `0` means never expire, so the result is only ever
+cleared by a republish, and `-1` disables caching entirely for that database or
+dataset.
+
+The change applies to results cached from that point on. Results already in the cache
+keep the lifetime they were stored with until they expire or the table is republished.
+
+## Refreshing a Dashboard by Hand
+
+You rarely need to, but you can discard a dashboard's cached results yourself: open
+the menu beside **Edit dashboard** and choose **Force refresh dashboard**. If a chart
+is serving an older result, a note in the upper right says how long ago the data was
+cached, and clicking it forces the same refresh.
+
+Prefer either of these to reloading the browser page — a browser reload re-requests the
+charts but still receives the cached results.
+
+## Related
+
+- [Using Dashboards](/guides/dashboards/using-dashboards/)
+- [Learning About Dashboards](/guides/dashboards/learning-dashboard/)

--- a/src/content/docs/guides/dashboards/learning-dashboard.mdx
+++ b/src/content/docs/guides/dashboards/learning-dashboard.mdx
@@ -29,7 +29,7 @@ Due to frequent caching, Google Chrome is usually the best web browser to use wi
 
 
 * *Problem:* After unpublishing and publishing tables in the Dashboards area, the data does not appear to be syncing properly.
-* *Solutions:* Refresh the dashboard. Currently, old table data is cached, so it is necessary to refresh the dashboard when rebuilding tables.
+* *Solutions:* Republishing a table clears the cached results of every chart reading it, so a dashboard opened after the workflow run shows the new data without a manual refresh. If it doesn't, check that the run finished and republished the table you expect. See [Dashboard Caching](/guides/dashboards/dashboard-caching/).
 
 ### Table Sync Error
 
@@ -41,7 +41,7 @@ Due to frequent caching, Google Chrome is usually the best web browser to use wi
 
 
 * *Problem:* A warning popped up on the upper right saying “Loaded data cached **3 hours ago**. Click to force-refresh.”
-* *Solutions:* Click on the warning to force-refresh the cache. You can also click the drop-down menu beside “Edit dashboard” and select “Force refresh dashboard” there. Either of these options will refresh within the system and is preferred to refreshing the web browser itself.
+* *Solutions:* Click on the warning to force-refresh the cache. You can also click the drop-down menu beside “Edit dashboard” and select “Force refresh dashboard” there. Either of these options will refresh within the system and is preferred to refreshing the web browser itself. How long a result is held is configurable — see [Dashboard Caching](/guides/dashboards/dashboard-caching/).
 
 ### Permission Warning
 

--- a/src/content/docs/releases/2026-08.mdx
+++ b/src/content/docs/releases/2026-08.mdx
@@ -1,6 +1,6 @@
 ---
 title: August 2026
-description: Resume now picks a workflow back up where it stopped — inside called workflows and loops, and without re-running steps that already succeeded — and an interrupted step reports itself as abandoned instead of appearing to run forever.
+description: Resume now picks a workflow back up where it stopped — inside called workflows and loops, and without re-running steps that already succeeded — an interrupted step reports itself as abandoned instead of appearing to run forever, and dashboards drop their cached results the moment a table is republished.
 ---
 
 ## Changed
@@ -11,9 +11,15 @@ description: Resume now picks a workflow back up where it stopped — inside cal
 
   Step names are long, so you can widen the palette by dragging the divider beside it, and it remembers the width for next time. See [Advanced Workflows](/guides/workflows/advanced-workflows/#the-step-palette).
 
+- **You can now hold a dashboard's cached results for longer than five minutes.** Because republishing a table now clears its charts' cached results immediately, the cache no longer has to expire quickly to keep a dashboard current — so the lifetime can be set to match how often the data actually changes. Set it in seconds on a database, under **Advanced → Performance → Chart cache timeout**, or on a single dataset under **Settings → Cache timeout**. On a table that reloads overnight, an hour or a day means a morning's dashboard views are served from cache instead of re-querying the warehouse each time — which is where most of a slow dashboard's time goes.
+
+  The default is unchanged at five minutes, so nothing is any staler than before unless you choose to raise it. Keep it short on tables written to from outside PlaidCloud, where the lifetime is the only thing that refreshes them. See [Dashboard Caching](/guides/dashboards/dashboard-caching/).
+
 - **Workflow runs are lighter on the platform.** A running workflow now asks PlaidCloud for far less of the same information while it works, which frees up capacity in busy workspaces where many workflows run at once.
 
 ## Fixed
+
+- **Republishing a table now clears the cached results of the dashboards reading it.** A dashboard caches each chart's results so repeat views don't re-query the warehouse. Those cached results were meant to be discarded the moment a workflow run republished the underlying table — but the discard never took effect, so a chart could keep serving pre-refresh numbers until its cached result expired on its own. Republishing now clears them straight away, and the next person to open the dashboard sees the new data without forcing a refresh. See [Dashboard Caching](/guides/dashboards/dashboard-caching/).
 
 - **A step whose run was interrupted now reports itself as abandoned, instead of appearing to run forever.** When the work behind a step went away mid-run — because someone pressed **Stop**, or because platform maintenance interrupted it — nothing ever corrected the step's status. The workflow view kept showing it as running with a duration climbing indefinitely, which reads as an extremely slow step: in the case that prompted this, a step that takes three seconds displayed as running for over twenty minutes.
 

--- a/src/content/docs/releases/index.mdx
+++ b/src/content/docs/releases/index.mdx
@@ -13,7 +13,7 @@ Monthly summaries of changes shipped to PlaidCloud tenants. Months with substant
 	<LinkCard
 		title="August 2026"
 		href="/releases/2026-08/"
-		description="Resume picks a workflow back up where it stopped, and an interrupted step now reports itself as abandoned instead of appearing to run forever."
+		description="Resume picks a workflow back up where it stopped, an interrupted step now reports itself as abandoned instead of appearing to run forever, and dashboards drop their cached results as soon as a table is republished."
 	/>
 	<LinkCard
 		title="July 2026"


### PR DESCRIPTION
Documents the Superset dashboard caching work from sc-23686.

## What a reader gets

- **New guide page — [Dashboard Caching](/guides/dashboards/dashboard-caching/).** What a dashboard caches, the two ways a cached result goes away (republish, or lifetime expiry), how to set the lifetime in seconds on a database (**Advanced → Performance → Chart cache timeout**) or a single dataset (**Settings → Cache timeout**), the `0` / `-1` special values, when a longer lifetime is *not* safe (tables written from outside PlaidCloud), and how to force a refresh by hand.
- **Learning About Dashboards.** The "Sync Delay" troubleshooting answer told readers that old table data is cached and they must refresh the dashboard after rebuilding a table. That is exactly the behaviour this change fixed, so it was actively wrong — rewritten. The "Cache Warning" answer now points at the new page.
- **August 2026 release notes.** A `## Fixed` entry for the invalidation fix and a `## Changed` entry for the now-tunable lifetime, explicitly noting the 300s default is unchanged. August LinkCard description on the releases index updated to match.

No internals in the customer-facing text — no Helm values, CronJobs, metadata tables, or metrics.

## Checks run locally

| Check | Result |
|---|---|
| `npm run build` | Complete, 1530 pages |
| Lychee (`--offline`, same args as CI) | 355,075 total / 12,576 unique / **0 errors** |
| Vale (Google pack + PlaidCloud vocab) | 0 errors, 0 warnings on the new/changed prose; the 1 error + 1 warning reported in `2026-08.mdx` are pre-existing lines ("tooltip", "above") |

## Release-timing note

What's New here is month-based and entries land ahead of the production tag — `2026-08.mdx` was created 1 Aug and has taken entries on 1 and 3 Aug, while the newest `tenant-v*` tag is v5.11.11 from 24 Jul. The page's **Releases Shipped** version table is filled in afterwards. This entry follows that convention. The change is live on beta-channel tenants; it reaches production with the next `tenant-v5.12.x` cut.
