### PR TITLE
docs(releases): note the encoded-query hardening in August's What's New (sc-23730)

### DIFF
--- a/src/content/docs/releases/2026-08.mdx
+++ b/src/content/docs/releases/2026-08.mdx
@@ -35,6 +35,8 @@ description: Resume now picks a workflow back up where it stopped — inside cal
 
 ## Security
 
+- **Pre-built queries sent to the platform are now rebuilt under a restriction instead of being trusted.** Several Analyze operations — allocate, melt, pivot, update, delete, table exports and view definitions — accept a query that was assembled elsewhere and sent along with the request. The platform used to reconstruct whatever arrived, which meant a crafted request from anything able to reach those operations could have run code inside the server. Such a request now rebuilds only the database-query pieces a genuine query is made of, and anything else is refused with an invalid-argument error. Queries you build in the product are unaffected, and an export that supplies plain SQL rather than a pre-built query works exactly as before.
+
 - **Editing a security group's permissions no longer removes the permissions you don't hold yourself.** Anyone who was not a workspace administrator silently stripped every permission on that group they could not grant themselves — just by opening the permission matrix and saving it, even without changing anything. Workspace administrators were unaffected, which is why this looked like permissions disappearing at random for some people and never for others, and why a permission held by only a few, such as Panel app management, would drop off repeatedly and have to be re-added. Those permissions are now left untouched.
 
   Review any security group that a non-administrator has edited and confirm its permissions are what you expect — a permission removed this way was removed for everyone in the group. See [Managing Security Groups and Assignments](/administration/access/managing-security-groups-and-assignments/).


### PR DESCRIPTION
One Security entry on the August What's New page for the encoded-query hardening shipped in [plaid#6884](https://github.com/PlaidCloud/plaid/pull/6884) (sc-23730).

Allocate, melt, pivot, update, delete, table exports and view definitions accept a query assembled elsewhere and sent with the request; the platform used to reconstruct whatever arrived. It now rebuilds only the database-query pieces a genuine query is made of and refuses anything else.

No usage guide changes — nothing a user does is different, and a query built in the product is unaffected. Entry only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)