### PR TITLE
Document the Light/Dark/Auto appearance switcher

### DIFF
--- a/src/content/docs/guides/launcher/index.mdx
+++ b/src/content/docs/guides/launcher/index.mdx
@@ -164,3 +164,32 @@ stale. To pull the latest immediately, click **Refresh** in the toolbar.
 
 The Launcher is where PlaidCloud opens by default. To start on a different app
 instead, turn off **Start on Launcher** in the Options menu.
+
+## Appearance (Light, Dark, Auto)
+
+The **Appearance** button in the top toolbar — the contrast icon beside the
+account menu — switches PlaidCloud between a light and a dark appearance. It
+applies everywhere: the Launcher, every app, and every window and dialog inside
+them.
+
+| Choice | What it does |
+| --- | --- |
+| **Light** | Always use the light appearance, whatever your device is set to. |
+| **Dark** | Always use the dark appearance, whatever your device is set to. |
+| **Auto (System)** | Follow your operating system's appearance setting. |
+
+**Auto (System)** is the default, and it tracks your system live: if your
+computer is set to switch to dark in the evening, PlaidCloud follows at the same
+moment, with no reload. Choosing **Light** or **Dark** pins the appearance and
+ignores the system setting from then on.
+
+<Aside type="note">
+Your choice is remembered in the browser you made it in, so it is not carried
+across to a different browser or a different computer — set it once in each.
+Clearing your browser's site data resets it to **Auto**. If your browser blocks
+local storage (some private-browsing modes do), the switcher still works for the
+session but starts again at **Auto** next time.
+</Aside>
+
+Embedded content keeps its own colors: dashboards and Panel apps are not
+restyled by this setting.

--- a/src/content/docs/releases/2026-08.mdx
+++ b/src/content/docs/releases/2026-08.mdx
@@ -1,9 +1,11 @@
 ---
 title: August 2026
-description: Resume picks a workflow back up where it stopped, an interrupted step reports itself as abandoned instead of appearing to run forever, dashboards drop their cached results as soon as a table is republished, and AI agents connected over MCP read the workspace with far less of their capacity spent on the reading.
+description: PlaidCloud gets a Light/Dark/Auto appearance switcher, Resume picks a workflow back up where it stopped, an interrupted step reports itself as abandoned instead of appearing to run forever, dashboards drop their cached results as soon as a table is republished, and AI agents connected over MCP read the workspace with far less of their capacity spent on the reading.
 ---
 
 ## Changed
+
+- **PlaidCloud has a Light, Dark, and Auto appearance.** The **Appearance** button in the top toolbar, beside the account menu, switches the whole interface — the Launcher, every app, and every window and dialog inside them — between a light and a dark look. **Auto (System)**, the default, follows your computer's own appearance setting and switches with it live, so a machine set to go dark in the evening takes PlaidCloud with it without a reload; **Light** and **Dark** pin the choice regardless of the system. The interface has also moved onto the Fluent design used across PlaidCloud, so buttons, inputs, tables, tabs, menus, and dialogs share one consistent look. Your choice is remembered per browser rather than per account, so set it once in each browser you use. See [Appearance (Light, Dark, Auto)](/guides/launcher/#appearance-light-dark-auto).
 
 - **AI agents connected over MCP get leaner results, and are told when a list was cut short.** Listing and lookup tools now return the first 25 matches per page rather than 50, and an agent can name the columns it wants with `fields=[...]` instead of taking the whole record — so a routine "list the tables in this project" costs a fraction of the agent's limited reading capacity, leaving more room for your actual question. A page that was capped now says so explicitly, so an agent asks for the next page instead of quietly treating the first 25 as the complete answer, and asking for a column that doesn't exist returns a clear error naming the columns that do, rather than silently leaving it out. Nothing is out of reach: raise `limit`, or page with the cursor. See [Getting Started with AI Coding Agents](/integrations/ai-coding-agents/getting-started/#keeping-results-small).
 
@@ -26,6 +28,8 @@ description: Resume picks a workflow back up where it stopped, an interrupted st
 - **Workflow runs are lighter on the platform.** A running workflow now asks PlaidCloud for far less of the same information while it works, which frees up capacity in busy workspaces where many workflows run at once.
 
 ## Fixed
+
+- **Dark mode is readable in the places it wasn't.** Several panels kept a fixed light-mode palette after the surface behind them turned dark, leaving near-black text on a dark card. The Workflow Inspector's step cards — table, file, and dimension — now take their titles, statistics, and dividers from the active appearance, as do the inspector's own header and the step palette. The focused row of a searchable grid (Projects, Workflows, and the other row-highlight tables) no longer paints a light-blue band behind near-white text, and the read-only banner shown on a connection you don't own uses a lighter teal so its message reads against the banner. See [Appearance (Light, Dark, Auto)](/guides/launcher/#appearance-light-dark-auto).
 
 - **Adding an output column to a Table Lookup or Join step saves again.** A column you added by hand started with no data type, and saving the step failed with **Update Failed – Internal Server Error** — removing the column again was the only way to save. New rows now start as **Text**, and you can change the type as usual. The same fix covers the Inner, Outer, Anti and Cross Join steps. If you have a step saved with a column that has no type, open it, set the column's **Type**, and save. See [Table Lookup](/reference/workflow-steps/tables/table-lookup/).
 


### PR DESCRIPTION
Docs owed by [PlaidClient #1654](https://github.com/PlaidCloud/PlaidClient/pull/1654) (Fluent theme, Phase 1) — raised as a follow-up in rad-pat's review.

## What's here

- **Launcher guide** — new *Appearance (Light, Dark, Auto)* section: the toolbar button, the three modes, Auto following the OS live, and the persistence change (the preference is now per-browser `localStorage`, not a server-side user option, so it no longer follows a user across devices).
- **August What's New** — the switcher and the Fluent look under **Changed**; the dark-mode readability fixes (Workflow Inspector cards, focused grid rows, read-only connection banner) under **Fixed**.

## Verified

- `npm run build` passes; 1530 pages built.
- The `/guides/launcher/#appearance-light-dark-auto` anchor referenced from both release entries resolves in the built HTML.
- Mode labels match the shipped UI (`Light` / `Dark` / `Auto (System)`, tooltip *Appearance*).

Draft until PlaidClient #1654 merges — this describes behaviour that isn't released yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)