### PR TITLE
docs: converted Alteryx tables are prefixed with the workflow name (sc-23944)

### DIFF
--- a/src/content/docs/guides/workflows/migrate-alteryx-workflows.mdx
+++ b/src/content/docs/guides/workflows/migrate-alteryx-workflows.mdx
@@ -44,7 +44,7 @@ Collect the workflow files and dependencies together before importing:
 1. Open the target project in PlaidCloud.
 2. Open **Tools → Import Alteryx Workflow**.
 3. Choose the target project and select the `.yxmd`, `.yxwz`, or `.yxmc` file to import.
-4. Optionally set workflow, step, and table name prefixes.
+4. Optionally set workflow, step, and table name prefixes. Table names are already prefixed with the workflow's own name — see [Table Names in a Converted Workflow](#table-names-in-a-converted-workflow) below.
 5. Choose the Document account and folder where imported files should be stored.
 6. Add any referenced files or folders that the workflow needs at runtime.
 7. Start the import.
@@ -54,6 +54,16 @@ Collect the workflow files and dependencies together before importing:
 When the import finishes, the import window replaces its form with a conversion report: a summary of how many steps mapped with high confidence and how many need review, and — when any step needs a look — a table of the lower-confidence or caveated steps listing each step's name, operation, confidence, and notes. Use it to go straight to the steps worth checking before you run the workflow; each of those steps also carries the same confidence note in its step memo on the canvas.
 
 PlaidCloud stores imported dependencies in the Document location selected during import. Converted steps then reference those Document paths, so the workflow can run repeatedly without relying on a desktop file system.
+
+### Table Names in a Converted Workflow
+
+Each converted step writes its own table, named after the Alteryx tool it came from — `tool_4_out` for Tool 4. Alteryx numbers tools per file, so those names repeat across workflows, and a PlaidCloud project is a single table namespace. Every import therefore prefixes its tables with the workflow's own name, giving `03_measure_the_quality_of_data_tool_4_out`. That is what lets a whole folder of Alteryx workflows go into one project without them writing over each other's results.
+
+<Aside type="caution" title="Two workflows with the same name">
+The workflow name is the only thing telling two imports apart. Two files with the same name — or names that differ only in punctuation or spacing, such as `Sales Report` and `Sales-Report` — still produce the same prefix, as does a file that carries no name at all. Set a **table name prefix** yourself when importing those, or import them into separate projects.
+</Aside>
+
+Set your own **table name prefix** during import to override the default, or set it to nothing to get the bare `tool_4_out` names back. Nothing depends on these names other than the converted steps themselves, so renaming a table afterwards means repointing the steps that read it.
 
 ## Use The Converted Workflow
 

--- a/src/content/docs/guides/workflows/orchestrate-alteryx-migrations-with-mcp.mdx
+++ b/src/content/docs/guides/workflows/orchestrate-alteryx-migrations-with-mcp.mdx
@@ -37,7 +37,7 @@ The conversion call includes:
 - Source Document account and path for the Alteryx file.
 - Destination PlaidCloud project.
 - Destination Document account and path for conversion artifacts.
-- Optional workflow, step, and table prefixes.
+- Optional workflow, step, and table prefixes. The table prefix defaults to the workflow's own name, which is what keeps two conversions in one project off each other's tables; pass an empty prefix to get the bare names.
 - Workflow type, with Advanced workflows as the default.
 
 The agent can combine this with the normal MCP project, workflow, Document, workflow-run, and table tools to manage the broader migration.

--- a/src/content/docs/releases/2026-08.mdx
+++ b/src/content/docs/releases/2026-08.mdx
@@ -27,6 +27,12 @@ description: Resume picks a workflow back up where it stopped, an interrupted st
 
 ## Fixed
 
+- **Converted Alteryx workflows no longer write over each other's tables.** Each converted step writes a table named after the Alteryx tool it came from — `tool_4_out` for Tool 4 — and Alteryx numbers tools per file, so those names repeat across workflows. A PlaidCloud project is a single table namespace, so importing a folder of Alteryx workflows into one project, which is the usual way to migrate, had each import claiming names an earlier one was already using. Across a 178-workflow reference set, 361 table names were claimed by more than one workflow.
+
+  Steps find their tables by name, so two imports ended up sharing one. That showed up two ways. A step whose columns were not in the table it landed on stopped the workflow with an error naming a column the table does not have. Where the two happened to be compatible, nothing errored and one workflow simply overwrote the other's results, with both runs reporting success.
+
+  Every import now prefixes its tables with the workflow's own name, so `tool_4_out` becomes `03_measure_the_quality_of_data_tool_4_out` and two imports cannot collide. Set your own **table name prefix** during import to override it, or an empty one to get the bare names back. Tables from imports you already ran are not renamed — re-import those workflows to separate them. One case still needs your attention: two files with the same name, names differing only in punctuation or spacing, or a file carrying no name at all all produce the same prefix, so set one yourself for those. See [Migrate Alteryx Workflows](/guides/workflows/migrate-alteryx-workflows/#table-names-in-a-converted-workflow).
+
 - **A member you disabled can be enabled again.** Disabling a member from **Identity → Members** recorded the time in a format the rest of the platform could not read back, and the only screen that can re-enable someone reads it first — so the **Enable** action failed with an internal error, and there was no way to reverse a disable. The same unreadable value also broke the member list itself: with one member disabled this way, **Identity → Members** and the member pickers that use it stopped loading for everyone in the workspace.
 
   Both work again, and members already disabled this way can be enabled normally — nothing needs to be re-done to them, and no data was lost. Disabled members remained disabled throughout; what was broken was reversing it and listing them.


### PR DESCRIPTION
Documents the naming change in PlaidCloud/plaid#6928.

A converted step writes a table named after the Alteryx tool it came from (`tool_4_out`), and Alteryx numbers tools per file, so those names repeat across workflows. A PlaidCloud project is one table namespace, so importing a folder of Alteryx workflows into one project — the usual migration shape — had each import claiming names an earlier one already used, and the two then shared a table. Every import now prefixes its tables with the workflow's own name.

- **Migrate Alteryx Workflows** — new *Table Names in a Converted Workflow* section explaining the prefix, how to override it, and the case that still needs attention (two files whose names reduce to one prefix). Linked from the import step that mentions prefixes.
- **Orchestrate Alteryx Migrations with MCP** — the prefix bullet now states the default.
- **August 2026 What's New** — a `## Fixed` entry covering both symptoms: the workflow that stopped with an error naming a column its table does not have, and the one that silently overwrote another's results on a green run.

Astro build passes locally (1562 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)