### PR TITLE
docs: document the new Row Access screen for security groups

### DIFF
--- a/src/content/docs/administration/access/managing-security-groups-and-assignments/index.mdx
+++ b/src/content/docs/administration/access/managing-security-groups-and-assignments/index.mdx
@@ -42,6 +42,49 @@ Security groups can be added, updated, or deleted.
 
 <Aside type="caution">Permissions you cannot grant yourself are left alone when you save a group’s permission matrix, and are not shown in it. If you need to change one, ask someone who holds that permission — the matrix only ever edits what you control.</Aside>
 
+## Managing Row Access
+
+Row Access lets you designate a column on a project as governing which rows a security group can see, and grant specific values of that column to specific groups. For example, a `region` column could be declared as governing, and a group granted `East` and `Central` would be limited to rows carrying those values.
+
+**To open Row Access for a security group:**
+
+1. Open Identity
+2. Select the "Security" tab
+3. Click "Security Groups" in the dropdown menu
+4. Click the Row Access icon beside the group
+
+This opens a list of every project that has at least one governed column, with the group's current standing on each one.
+
+**Every project and column always shows one of three states:**
+
+- **Granted** — the group has been given specific values it can see.
+- **Unrestricted** — the group holds no grant, and the column's default lets an ungranted group see every value.
+- **Denied** — the group holds no grant, and the column's default is to deny an ungranted group everything.
+
+<Aside type="caution">
+Denied is always shown as its own row rather than left out. A column set to deny by default is a total lockout for any group with no grant on it, and hiding that row would make the lockout look like nothing had been configured.
+</Aside>
+
+<Aside type="caution">
+"— all values (default) —" only applies to a group that holds **no** grant on that column at all. It does not widen a group that has been granted specific values elsewhere — that group still sees only what it was granted.
+</Aside>
+
+**To declare a governed column on a project:**
+
+1. From Row Access, click "Declare Attribute…"
+2. Choose the project and the column that will govern row access
+3. Choose where its grantable values come from — a dimension, another table's column, or a list you type in
+4. Choose what an ungranted group sees by default: every row, or none
+
+**To grant specific values to a security group:**
+
+1. From Row Access, click "Edit Grant" beside a column
+2. Move the values this group should see into the assigned side, and save
+
+<Aside>
+Declaring a column and granting values records the configuration only. It does not yet change what any group can see — enforcement is switched on separately, one workspace at a time.
+</Aside>
+
 ## Setting Default Security Groups
 
 

--- a/src/content/docs/releases/2026-08.mdx
+++ b/src/content/docs/releases/2026-08.mdx
@@ -3,6 +3,10 @@ title: August 2026
 description: Resume picks a workflow back up where it stopped, an interrupted step reports itself as abandoned instead of appearing to run forever, dashboards drop their cached results as soon as a table is republished, and AI agents connected over MCP read the workspace with far less of their capacity spent on the reading.
 ---
 
+## Added
+
+- **A new Row Access screen for security groups.** Under Identity → Security Group, declare which column on a project governs row access, and grant specific values of it to specific security groups — every project and attribute always shows Granted, Unrestricted, or Denied, so a locked-out group is visible rather than looking unconfigured. This screen only records the configuration for now; it doesn't yet change what anyone sees in a dashboard or Panel app. See [Managing Row Access](/administration/access/managing-security-groups-and-assignments/#managing-row-access).
+
 ## Changed
 
 - **An imported Alteryx workflow's random sampling tools now run.** **Create Samples** — the three-way Estimation / Validation / Holdout split — always draws from a fixed random seed and gives you no way to turn that off, and **Random % Sample** can be set to one. Both used to arrive as steps that stop with an error, so a workflow built around a sample could not be run at all. Both now run, and every size, percentage and split proportion comes across exactly: each sample holds the share of the records it was configured for.


### PR DESCRIPTION
## Summary
- Adds a What's New → Added entry for August covering the new Row Access screen under Identity → Security Group.
- Adds a usage-guide section under Managing Security Groups and Assignments: opening the screen, the Granted / Unrestricted / Denied states, declaring a governed column, and granting values.

## Notes
- Written for the screen as it exists today: declaring a column and granting values only records configuration, nothing is enforced yet.
- Callout on the "all values (default)" setting: it only widens a group holding no grant on that attribute at all, and never widens a group already granted specific values elsewhere.
- Callout on why "Denied" always appears as its own row rather than being omitted.

## Test plan
- [x] `npm ci`
- [x] `npm run build` — 1562 pages built, no errors
- [x] `lychee --offline --no-progress` over `dist/**/*.html` — 0 errors
- [x] `python3 scripts/check-orphans.py dist` — all reachable