### PR TITLE
docs(alteryx): Computer Vision tools, and what a .flat input needs

### DIFF
--- a/src/content/docs/guides/workflows/package-alteryx-dependencies.mdx
+++ b/src/content/docs/guides/workflows/package-alteryx-dependencies.mdx
@@ -63,6 +63,7 @@ Put input data under `inputs/`:
 - CSV, TSV, fixed-width, JSON, XML, Excel, Access, YXDB, SAS, SPSS, Stata, Avro, Parquet, and HDF files.
 - Lookup files used by formulas, dynamic replace, fuzzy matching, or joins.
 - Folders referenced by Directory and Dynamic Input tools.
+- Alteryx flat ASCII files: include the `.flat` layout file next to the data it describes. The column widths live only in that file, so without it the import stops and names the file to supply rather than guessing where the columns end.
 
 When PlaidCloud imports the package, converted steps point to the selected Document locations.
 

--- a/src/content/docs/reference/alteryx-conversion-matrix.md
+++ b/src/content/docs/reference/alteryx-conversion-matrix.md
@@ -37,7 +37,7 @@ Coverage levels:
 | DataCleansePro | Converts With Validation | Data cleanse transform | Cleans whitespace, nulls, punctuation, and casing according to configured options. |
 | Date | Fully Converts | Workflow variable date value | Emits ISO date values for downstream steps and conditions. |
 | DateTime | Converts With Validation | Date and time transform | Converts date and time parsing or formatting logic. |
-| DbFileInput | Fully Converts | Document-backed file input or data materializer | Loads source files from Document into workflow data. |
+| DbFileInput | Converts With Validation | Document-backed file input or data materializer | Loads source files from Document into workflow data, including `.yxdb`, `.dbf`, Excel, and fixed-width `.flat`. A `.flat` needs its layout file packaged alongside the workflow; without it the step stops and names the file to supply. Alteryx `.geo` files are not read — the step stops rather than risk a wrong shape. |
 | DbFileOutput | Fully Converts | Document-backed file output or table write | Writes output data to Document or PlaidCloud tables. |
 | Detour | Fully Converts | Conditional branch routing | Converts route selection to DAG conditions. |
 | DetourEnd | Fully Converts | Conditional branch merge | Rejoins conditionally selected branches. |
@@ -59,6 +59,11 @@ Coverage levels:
 | FuzzyMatch | Converts To Executor | Fuzzy matching executor | Uses managed fuzzy matching for match keys, thresholds, and candidate review. |
 | Generalize | Converts To Executor | [Spatial Generalize](/reference/workflow-steps/spatial/spatial-generalize/) | Simplifies geometry to a tolerance, preserving topology. |
 | HtmlBox | Cloud-Native Equivalent | Report text or HTML artifact | Preserves content in PlaidCloud report or artifact output. |
+| Barcode | Converts To Executor | Barcode executor | Reads or writes barcodes in the configured symbology. A row with no readable barcode returns empty; several return a joined list. |
+| ImageProcessing | Converts To Executor | Image transform executor | Applies the tool's pipeline in canvas order — grayscale, scale, crop, and custom-angle rotation — writing `<field>_processed`. Thresholding, brightness balance, OCR optimization, and automatic alignment stop with a message naming the setting, because Alteryx records the choice but not the values needed to reproduce it. |
+| ImageProfile | Converts To Executor | Image profile executor | Reports image dimensions, mode, format, and channel count, or luminance statistics. Column names are PlaidCloud's — Alteryx records none. |
+| ImageRecognition | Converts With Validation | ML Score step | Stops with a message pointing at ML Score, which reads the same trained model table. The tool's own VGG16 transfer learning is not reproduced. |
+| ImageTemplate | Converts With Validation | Manual region extraction | Stops with a message naming the missing page-region detection. Extract the regions with a Formula or Text step instead. |
 | ImageToText | Converts To Executor | OCR executor | Extracts text from images through managed OCR. |
 | Insights | Cloud-Native Equivalent | PlaidCloud dashboard or artifact output | Creates a cloud-native review artifact for repeatable sharing and review. |
 | Join | Fully Converts | Join transform | Produces joined, left-only, and right-only streams. |


### PR DESCRIPTION
## What changed

**Conversion matrix** had no rows for the Computer Vision tools at all, and listed `DbFileInput` as "Fully Converts" while an Alteryx `.geo` is refused.

Added `Barcode`, `ImageProcessing`, `ImageProfile`, `ImageRecognition`, `ImageTemplate`. Corrected `DbFileInput` to "Converts With Validation" and said which formats it reads.

**Packaging guide** listed "fixed-width" among input files but never mentioned that a `.flat` carries its column widths in a separate layout file. That is the one thing a user has to do differently, and it was undocumented.

## Why the honest wording

Three CV ops run: Barcode, Image Processing, Image Profile. Two stop with a message naming what is missing — Image Recognition (the tool's VGG16 transfer learning is not reproduced; it points at ML Score, which reads the same model table) and Image Template (page-region detection). Four Image Processing operations stop the same way, because Alteryx records the setting but not the values needed to reproduce it: thresholding window size and constant, brightness level scale, OCR optimization preset, and automatic alignment skew angle.

The matrix says so rather than implying full coverage. A user who reads "Fully Converts" and then hits a stop mid-migration is worse off than one who knows the boundary up front.

`.geo` was already documented in [Migrate Spatial Alteryx Workflows](/guides/workflows/migrate-spatial-alteryx-workflows/); the matrix now agrees with it instead of contradicting it.

## Ships with

- PlaidCloud/workflow-runner#1193 — the CV executor operations
- PlaidCloud/plaid#7056 — a `.flat` input finds its layout file

🤖 Generated with [Claude Code](https://claude.com/claude-code)