### PR TITLE
docs: a column note names the column without an ordinal (sc-24289 review r2)

### DIFF
--- a/src/content/docs/integrations/ai-coding-agents/honest-answers.mdx
+++ b/src/content/docs/integrations/ai-coding-agents/honest-answers.mdx
@@ -37,7 +37,7 @@ Instead of burying assumptions, PlaidCloud surfaces them as plain-language heads
 
 These aren't fine print. They're the safeguards that keep a confident-sounding answer from quietly overstating what the data actually supports.
 
-**A note that describes only part of the result says which part.** A note can be raised by one part of a result rather than by all of it, and its figures then belong to that part alone — so it now opens by naming it. On a result that combines several allocation branches that reads *"Branch 4 (admin costs): …"*; on one allocating several value columns at once it names the column, *"Column 2 (margin): …"*. Read an unprefixed note as being about the result you asked for, and a prefixed one as being about that part of it.
+**A note that describes only part of the result says which part.** A note can be raised by one part of a result rather than by all of it, and its figures then belong to that part alone — so it now opens by naming it. On a result that combines several allocation branches that reads *"Branch 4 (admin costs): …"*; on one allocating several value columns at once it names the column, *"Column margin: …"*. Read an unprefixed note as being about the result you asked for, and a prefixed one as being about that part of it.
 
 ## It Checks Its Own Math
 


### PR DESCRIPTION
Follow-up to [#387](https://github.com/PlaidCloud/plaidcloud-docs/pull/387), which was merged before a second adversarial review round on [plaid#7066](https://github.com/PlaidCloud/plaid/pull/7066) landed.

That review confirmed the `Column N` ordinal contradicts the `Stage N` numbering the same report shows whenever a boundary entry precedes the terminal — `interest_income` rendered as *Stage 2* in the trace path and *Column 1* in the note. The code now drops the ordinal and names the column alone, since the column name is unique within a step and already appears in both places.

One line: the guide's example becomes *"Column margin: …"*.

`npm run build` clean — 1,564 pages.