### PR TITLE
docs(sc-24574): execution-container + iteration diagrams

### DIFF
--- a/src/content/docs/guides/workflows/advanced-workflows.mdx
+++ b/src/content/docs/guides/workflows/advanced-workflows.mdx
@@ -234,6 +234,32 @@ A plain container is a visual grouping — it tidies the canvas but doesn't chan
 
 **Turn it on** — right-click the container and toggle **Execution** on. The container is redrawn with a distinct border and a labeled **entry** port and **exit** port, so you can tell an execution container from an ordinary group at a glance.
 
+<figure style="margin:1.5rem 0;text-align:center;">
+<svg viewBox="0 0 660 210" role="img" aria-label="An execution container. An upstream step feeds the entry port on the container's left edge; inside, member steps run as one sealed unit; the exit port on the right edge feeds a downstream step." style="width:100%;max-width:660px;height:auto;">
+  <defs>
+    <marker id="ec-arrow" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto"><path d="M0,0 L8,4.5 L0,9 z" fill="var(--sl-color-gray-3)" /></marker>
+  </defs>
+  <rect x="6" y="84" width="120" height="42" rx="8" fill="var(--sl-color-gray-6)" stroke="var(--sl-color-gray-5)" />
+  <text x="66" y="110" text-anchor="middle" font-size="13" fill="var(--sl-color-text)">upstream step</text>
+  <path d="M126 105 L197 105" stroke="var(--sl-color-gray-3)" stroke-width="1.6" fill="none" marker-end="url(#ec-arrow)" />
+  <rect x="208" y="30" width="300" height="150" rx="12" fill="none" stroke="var(--sl-color-accent)" stroke-width="2" />
+  <text x="220" y="24" font-size="12" font-weight="700" fill="var(--sl-color-accent)">Execution container</text>
+  <circle cx="208" cy="105" r="7" fill="var(--sl-color-accent)" />
+  <text x="208" y="200" text-anchor="middle" font-size="11" fill="var(--sl-color-gray-3)">entry</text>
+  <rect x="230" y="85" width="100" height="42" rx="8" fill="var(--sl-color-gray-6)" stroke="var(--sl-color-gray-5)" />
+  <text x="280" y="110" text-anchor="middle" font-size="12" fill="var(--sl-color-text)">load</text>
+  <rect x="386" y="85" width="100" height="42" rx="8" fill="var(--sl-color-gray-6)" stroke="var(--sl-color-gray-5)" />
+  <text x="436" y="110" text-anchor="middle" font-size="12" fill="var(--sl-color-text)">normalize</text>
+  <path d="M330 106 L386 106" stroke="var(--sl-color-gray-3)" stroke-width="1.6" fill="none" marker-end="url(#ec-arrow)" />
+  <circle cx="508" cy="105" r="7" fill="var(--sl-color-accent)" />
+  <text x="508" y="200" text-anchor="middle" font-size="11" fill="var(--sl-color-gray-3)">exit</text>
+  <path d="M515 105 L586 105" stroke="var(--sl-color-gray-3)" stroke-width="1.6" fill="none" marker-end="url(#ec-arrow)" />
+  <rect x="588" y="84" width="66" height="42" rx="8" fill="var(--sl-color-gray-6)" stroke="var(--sl-color-gray-5)" />
+  <text x="621" y="110" text-anchor="middle" font-size="12" fill="var(--sl-color-text)">next</text>
+</svg>
+<figcaption style="font-size:0.85em;color:var(--sl-color-gray-3);margin-top:0.5rem;">One edge into the <strong>entry</strong> port feeds the sealed group; the <strong>exit</strong> port releases to downstream work only once every member has finished.</figcaption>
+</figure>
+
 **How it runs — a sealed sub-DAG.** Once a container is marked for execution, its boundary is sealed in both directions:
 
 - **Nothing inside starts until the container's inputs have arrived.** Every member step waits for whatever feeds the group, even a member that has no upstream of its own.
@@ -280,6 +306,34 @@ Neither re-runs the upstream steps that feed the container — they run the grou
 ### Iterating a Container
 
 An execution container can run its sealed sub-DAG **once per iteration** of a set of values — so a group that loads and transforms one region's data can process every region in turn without you copying the steps once per region. Right-click an execution container and choose **Iterate…** (the action appears only on execution containers, since iteration drives a group that runs as a unit).
+
+<figure style="margin:1.5rem 0;text-align:center;">
+<svg viewBox="0 0 690 150" role="img" aria-label="An iterating execution container runs its whole sealed group once per value in order: first with region set to East, then West, then North." style="width:100%;max-width:690px;height:auto;">
+  <defs>
+    <marker id="it-arrow" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto"><path d="M0,0 L8,4.5 L0,9 z" fill="var(--sl-color-gray-3)" /></marker>
+  </defs>
+  <rect x="6" y="40" width="176" height="82" rx="12" fill="none" stroke="var(--sl-color-accent)" stroke-width="2" />
+  <text x="20" y="34" font-size="12" font-weight="700" fill="var(--sl-color-accent)">↻ Iterating container</text>
+  <rect x="24" y="66" width="66" height="34" rx="7" fill="var(--sl-color-gray-6)" stroke="var(--sl-color-gray-5)" />
+  <text x="57" y="87" text-anchor="middle" font-size="11" fill="var(--sl-color-text)">load</text>
+  <rect x="102" y="66" width="66" height="34" rx="7" fill="var(--sl-color-gray-6)" stroke="var(--sl-color-gray-5)" />
+  <text x="135" y="87" text-anchor="middle" font-size="11" fill="var(--sl-color-text)">clean</text>
+  <path d="M90 83 L102 83" stroke="var(--sl-color-gray-3)" stroke-width="1.4" fill="none" marker-end="url(#it-arrow)" />
+  <path d="M182 81 L214 81" stroke="var(--sl-color-gray-3)" stroke-width="1.6" fill="none" marker-end="url(#it-arrow)" />
+  <rect x="216" y="60" width="130" height="44" rx="8" fill="var(--sl-color-gray-6)" stroke="var(--sl-color-gray-5)" />
+  <text x="281" y="80" text-anchor="middle" font-size="12" fill="var(--sl-color-text)">region = East</text>
+  <text x="281" y="96" text-anchor="middle" font-size="10" fill="var(--sl-color-gray-3)">pass 1</text>
+  <path d="M346 82 L370 82" stroke="var(--sl-color-gray-3)" stroke-width="1.6" fill="none" marker-end="url(#it-arrow)" />
+  <rect x="372" y="60" width="130" height="44" rx="8" fill="var(--sl-color-gray-6)" stroke="var(--sl-color-gray-5)" />
+  <text x="437" y="80" text-anchor="middle" font-size="12" fill="var(--sl-color-text)">region = West</text>
+  <text x="437" y="96" text-anchor="middle" font-size="10" fill="var(--sl-color-gray-3)">pass 2</text>
+  <path d="M502 82 L526 82" stroke="var(--sl-color-gray-3)" stroke-width="1.6" fill="none" marker-end="url(#it-arrow)" />
+  <rect x="528" y="60" width="134" height="44" rx="8" fill="var(--sl-color-gray-6)" stroke="var(--sl-color-gray-5)" />
+  <text x="595" y="80" text-anchor="middle" font-size="12" fill="var(--sl-color-text)">region = North</text>
+  <text x="595" y="96" text-anchor="middle" font-size="10" fill="var(--sl-color-gray-3)">pass 3</text>
+</svg>
+<figcaption style="font-size:0.85em;color:var(--sl-color-gray-3);margin-top:0.5rem;">Each pass binds the loop variable to the next value, then runs the whole sealed group — in order, one pass at a time.</figcaption>
+</figure>
 
 **Configure the loop.** The Iterate dialog uses the same iteration model as the [Workflow Loop step](/reference/workflow-steps/workflow-control/workflow-loop/), on tabbed pages. On the **Iterate Over** tab, pick how the iteration set is built:
 


### PR DESCRIPTION
The advanced-workflow **container / iterator** guide explained the feature well in prose but had no visual — the design doc's glyphs were what made the entry/exit ports and the iteration passes click. Adds two theme-aware inline **SVG diagrams** (Starlight color tokens, light+dark) to the guide:

- **Execution Containers** — the anatomy: an upstream step → the **entry** port → the sealed member steps → the **exit** port → downstream work.
- **Iterating a Container** — the sealed group run once per value, in order (`region = East` → `West` → `North`, pass 1/2/3).

No prose changed. Verified with a full `astro build` (1564 pages, exit 0) — the SVG renders into the built page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)