### PR TITLE
docs(workflows): document the condition Timezone Offset and correct workday numbering

### DIFF
--- a/src/content/docs/guides/workflows/step-conditions.md
+++ b/src/content/docs/guides/workflows/step-conditions.md
@@ -81,7 +81,25 @@ For Date or Time selections you can add multiple conditions if a combination of 
  - Hour of the day set to 2
  - Minute of the hour set to 5
 
-For "Use Financial Close Workday", set that to the xth day of the month that your close happens on. For example, if your close happens on the 5th day of the month, have "5".
+### Timezone Offset
+
+Each Date and Time condition carries its own **Timezone Offset**, listed as a whole-hour offset named after a representative zone — for example *Eastern Time (US & Canada) (UTC -5)* or *Asia/Tokyo (UTC +9)*. The times you enter are compared against the clock in that zone.
+
+A new condition starts on the offset your browser reports, so in most cases you can leave it alone. Set it deliberately when the schedule belongs to somewhere other than where you are — a close that runs on the finance team's clock, say. Only whole hours are available, so a half-hour zone such as India (UTC +5:30) has to be rounded to the nearest whole hour.
+
+A condition saved before this setting took effect keeps evaluating against UTC until you pick a zone for it, so existing conditions carry on behaving exactly as they did.
+
+:::caution
+**Day of the week** conditions currently compare against UTC whatever offset you choose. If you need a day-of-the-week condition to land on a particular day in a zone far from UTC, be aware it can differ from your local day for several hours either side of midnight.
+:::
+
+### Financial Close Workday
+
+For **Use Financial Close Workday**, the count starts at **0 for the 1st of the month** — as the hint beside the field says. So a close that happens on the 5th day of the month is `4`, not `5`.
+
+:::caution
+This condition never currently matches, so a step guarded by one will not run. Use a **Day of the month** condition until this is resolved. Negative values, intended to count back from the end of the month, do not work either.
+:::
 
 ## Setting Conditions With an AI Assistant
 


### PR DESCRIPTION
Updates the **Conditional Step Execution** guide for the condition-checks fixes landing in PlaidClient.

## Timezone Offset — new section

A Date and Time condition's **Timezone Offset** was undocumented, and fairly so: the control was there but nothing read or wrote it, so picking a zone did nothing and the box always reopened on its first entry. It now persists per condition and decides which clock the condition's times are compared against, so the guide describes it: named whole-hour zones, seeded from the browser's own offset, whole hours only, and conditions saved before the change staying on UTC.

## Financial Close Workday — corrected example

The guide said a close on the 5th day of the month should be entered as `5`. It should be `4` — the count starts at 0 for the 1st, which is what the hint beside the field says and what the runner implements (`now_offset.day == compare_value + 1`).

## Two caveats called out

Both are runner defects, filed as [story 24773](https://app.shortcut.com/plaidcloud/story/24773). The guide already warned that the workday check never matches at all, so this is consistent with how the page already handles known gaps — better a reader knows than discovers it from a step that silently never runs.

- **Day of the week** conditions compare against UTC whatever offset is chosen.
- **Negative workday values** don't count back from month end. (I verified this while writing: for `-1` the arithmetic lands on the 1st of the *next* month rather than the last day of this one.)

Both warnings should be removed when that story is fixed.

## Checks

`npx astro build` passes locally — 1564 pages. Confirmed in the built HTML that both callouts render as real Starlight asides (`starlight-aside--caution`) with no leaked markup.

Worth knowing for future edits: this is a `.md` file, so callouts have to use the `:::caution` directive. A `<Aside>` component only works in `.mdx` — in `.md` it passes through as raw HTML and silently renders nothing. Two other `.md` pages in this repo currently have that latent problem (`reference/workflow-steps/document/document-delete-old-files.md` and `reference/workflow-steps/general/deactivate-workspace-members.md`); left alone here rather than widening this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
