### PR TITLE
Document published table performance guidance

### DIFF
--- a/src/content/docs/guides/data/index.md
+++ b/src/content/docs/guides/data/index.md
@@ -13,7 +13,7 @@ PlaidCloud's data layer is built around **tables** (structured row-and-column da
 - [Table explorer](/guides/data/table-explorer/) — browse and inspect tables in your project
 - [Currency data type](/guides/data/currency-data-type/) — an exact, half-width column type for money values, and when to choose it over Numeric
 - [Table snapshots](/guides/data/table-snapshots/) — browse snapshot history, view data as of a past snapshot, and revert or restore a table
-- [Publishing data](/guides/data/publish/) — make project tables available to dashboards, BI tools, and downstream systems
+- [Publishing data](/guides/data/publish/) — make project tables available to dashboards, BI tools, and downstream systems, and review their performance guidance
 - [Selecting the latest record in a large history table](/guides/data/selecting-latest-record-in-large-history-table/) — a common pattern with a performance-aware solution
 
 ## Where Data Comes From

--- a/src/content/docs/guides/data/publish.mdx
+++ b/src/content/docs/guides/data/publish.mdx
@@ -54,6 +54,15 @@ Once the table or view is published, its published name will appear in the `Publ
 
 <Aside>There are some restrictions on published names. They can be a maximum of 63 characters and do have some restrictions on special characters. This is needed to ensure maximum compatibility with systems, tools, and processes outside of PlaidCloud.</Aside>
 
+## Review Published Table Performance
+
+Published Table Performance is Phase 1 of PlaidCloud's table-performance autopilot. It monitors how people use published tables and gives you a recommendation; it does not change a table automatically yet. Open **Table Optimizer**, select a published table, and choose **Published Table Performance** to see the review.
+
+The review shows whether PlaidCloud has enough current activity to offer guidance, including repeated direct queries and dashboard use. When there is a useful pattern, it identifies columns to consider for a future layout improvement. It also makes clear when no change is needed or when it needs more current activity before reaching a conclusion.
+
+This Phase 1 release is passive: it provides guidance only. If you decide an improvement is worthwhile, plan and apply it through your normal change process. A future Phase 2 release is planned to use this evidence and the same safety checks to apply supported optimizations automatically.
+
+Guidance depends on the data platform and the current activity available for that published table. Where PlaidCloud cannot make a safe assessment, the review explains the limitation instead of presenting a suggestion as certain.
 
 ## Unpublish
 

--- a/src/content/docs/releases/2026-08.mdx
+++ b/src/content/docs/releases/2026-08.mdx
@@ -1,9 +1,11 @@
 ---
 title: August 2026
-description: Resume picks a workflow back up where it stopped, an interrupted step reports itself as abandoned instead of appearing to run forever, dashboards drop their cached results as soon as a table is republished, and AI agents connected over MCP read the workspace with far less of their capacity spent on the reading.
+description: Resume picks a workflow back up where it stopped, an interrupted step reports itself as abandoned instead of appearing to run forever, published tables gain safe performance guidance, dashboards drop their cached results as soon as a table is republished, and AI agents connected over MCP read the workspace with far less of their capacity spent on the reading.
 ---
 
 ## Added
+
+- **Published Table Performance begins its first phase.** Open **Published Table Performance** from a published table in **Table Optimizer** to see whether its current activity points to columns worth considering for a future layout improvement. Phase 1 passively monitors and recommends; it shows when no change is needed or more activity is required, while your team remains in control of every change. A future release is planned to add automatic optimization for supported tables. See [Review Published Table Performance](/guides/data/publish/#review-published-table-performance).
 
 - **Execution containers — run a block of related steps as one sealed unit.** On the Advanced workflow canvas, right-click a group and toggle **Execution** on: the group becomes a self-contained sub-workflow with its own entry and exit ports and behaves as a single node in the parent. Nothing inside starts until the group's inputs arrive and nothing downstream starts until every member finishes, while independent branches inside still run in parallel; disabling a container skips it — and everything downstream of it — as a unit.
 


### PR DESCRIPTION
## Summary
- explain the read-only Published Table Performance review alongside publishing instructions
- surface the guide from Data Management - Tabular
- add a customer-facing August 2026 What's New entry

## Validation
- git diff --check
- content and link review
- `npm run build` attempted but local Node 23 cannot load the repository's TypeScript Starlight plugin; the repository requires Node 22
- Vale attempted but the local installation is missing the configured Google style

Docs CI is the authoritative build and style validation.