### PR TITLE
docs(alteryx): In-Database tool coverage, and the iterative-macro loop limit (sc-24849, sc-24911)

### DIFF
--- a/src/content/docs/guides/workflows/migrate-alteryx-workflows.mdx
+++ b/src/content/docs/guides/workflows/migrate-alteryx-workflows.mdx
@@ -178,6 +178,14 @@ A converted Loader and the readers of what it wrote are wired together, so a rea
 
 A Calgary Input's columns arrive as text: the stand-in table gives their names, not the database's own types.
 
+### In-Database Tools
+
+An In-Database workflow pushes its work to the warehouse rather than the Alteryx engine, and a PlaidCloud step already *is* warehouse SQL — so the In-Database **operation** tools convert to exactly the same steps as their in-memory twins. Filter In-DB becomes a filter, Formula In-DB a formula, Summarize In-DB an aggregate, and Join, Select, Sample, Sort, Union and Browse likewise.
+
+What does not convert is the pair of tools at either end of the chain. **Connect In-DB** and **Write Data In-DB** open a live warehouse connection that the tools between them hold and push SQL against, and PlaidCloud has no equivalent to that held-open connection. Each arrives as a step flagged for review, naming the tool and pointing at its replacement: an SQL import or export step bound to a PlaidCloud connection. Swap the two endpoints for those steps and the operation tools in between convert unchanged.
+
+Data Stream In, Data Stream Out, Dynamic Input In-DB, Dynamic Output In-DB, and In-Database Macro Input/Output are refused by name for the same reason.
+
 ### Cross Tab Percent And Total Columns
 
 A **Cross Tab** carrying one of its derived methods — **Percent Row**, **Percent Column**, **Total Column** or **Total Row** — used to stop the conversion and take every step below it. All four now convert:
@@ -200,7 +208,7 @@ Macros convert to native PlaidCloud constructs — not to an emulation of the Al
 
 - **Standard macros** are inlined into the calling workflow: the macro's tools become ordinary steps on the canvas, so there is no black box to trust — every step stays visible, reviewable, and editable. Nested standard macros inline to any depth, and a macro that ends up calling itself is caught and named rather than looped forever.
 - **Batch macros** become a macro workflow run once per record of the control parameter, with each pass's output collected back into a single stream — the same per-group execution Alteryx performs. The control parameter is bound as a per-pass variable, exactly as it drives the batch in Alteryx.
-- **Iterative macros** become a native workflow loop that carries state between passes and runs until the macro converges. If a macro cannot converge within its bound, the run **stops and says so** rather than reporting a partial result as a final answer.
+- **Iterative macros** become a native workflow loop that carries state between passes and runs until the macro converges. The loop's pass limit is the macro's own **Maximum Number of Iterations**, the same setting Alteryx runs it under; where that is left at Alteryx's runaway-guard default, or not set at all, conversion applies its own ceiling instead. If a macro has still not converged at that limit, the run **stops and says so** — naming the limit it reached — rather than reporting a partial result as a final answer. A macro that genuinely needs more passes than the ceiling allows can be re-imported with a higher one: the import's `iteration_ceiling` option sets it.
 - **Control parameters, Macro Input and Macro Output ports, Action tools, and Detour branching** all convert to their native equivalents, so the machinery that wires a macro together is preserved — not approximated. A macro called from inside a Batch or Iterative macro resolves and converts along with its caller.
 
 Two arrangements are refused by name rather than converted, so you know at import time: a looping macro nested inside another looping macro, and In-Database Macro Input/Output tools.

--- a/src/content/docs/reference/alteryx-conversion-matrix.md
+++ b/src/content/docs/reference/alteryx-conversion-matrix.md
@@ -78,7 +78,7 @@ and the like) are **connected, not converted** — see
 | Join | Full | Join transform | Produces joined, left-only, and right-only streams on a single- or multi-field key or by position. |
 | Join Multiple | Full | Multi-join transform | Joins multiple input streams. |
 | List Box | Full | Controlled workflow variable | Converts app list selections to controlled input. |
-| Macro calls | Full | Macro invocation | Standard macros inline into the canvas; Batch and Iterative macros convert to native per-record and looping constructs. |
+| Macro calls | Full | Macro invocation | Standard macros inline into the canvas; Batch and Iterative macros convert to native per-record and looping constructs. An Iterative macro's loop runs to its own Maximum Number of Iterations, and stops with a message if it has not converged by then. |
 | Macro Input / Macro Output | Full | Macro input / output port | Map directly to PlaidCloud macro ports. |
 | Make Grid | Full | [Spatial Make Grid](/reference/workflow-steps/spatial/spatial-make-grid/) | Tiles an extent into square cells, one row per cell. |
 | Map | Full | Map artifact | Creates a PlaidCloud map artifact. |
@@ -146,6 +146,24 @@ importer stops with a message naming the tool, so you know at conversion time:
 | Centroid, Convex Hull, Line To Polygon, Point To Line | A [spatial SQL recipe](/reference/workflow-steps/spatial/spatial-sql-recipes/) or geometry step |
 | Geocoder, Redistribute | A native geospatial step or connection to a geocoding service |
 | Calgary Cross Count Append | A [Calgary Cross Count](/guides/workflows/migrate-alteryx-workflows/#calgary-databases), joined back to your input |
+| Connect In-DB, Write Data In-DB | An SQL import or export step against a PlaidCloud connection — see [In-Database Tools](#in-database-tools) |
+
+## In-Database Tools
+
+The Alteryx **In-Database** palette pushes work to the warehouse instead of the
+Alteryx engine. A PlaidCloud step already *is* warehouse SQL, so the In-Database
+operation tools — Filter, Formula, Join, Select, Sample, Sort, Summarize, Union,
+Browse — convert to the same steps as their in-memory twins and run the same way.
+
+The two **endpoint** tools do not. **Connect In-DB** and **Write Data In-DB** open
+a live warehouse connection that the rest of the In-DB chain holds and pushes SQL
+against, and PlaidCloud has no equivalent to that held-open connection. The
+importer stops on each one, names the tool, and points at the replacement: an SQL
+import or export step bound to a PlaidCloud connection. Replace the two endpoints
+and the operation tools between them convert unchanged.
+
+Data Stream In, Data Stream Out, Dynamic Input In-DB, Dynamic Output In-DB, and
+Macro Input/Output In-DB are likewise refused by name.
 
 ## Spatial Tool Coverage
 


### PR DESCRIPTION
Docs for PlaidCloud/plaid#7215 (sc-24849, sc-24911).

## In-Database tools

The conversion matrix had **no In-Database coverage at all**, which is a real gap for anyone migrating an In-DB workflow. Added to both the guide and the reference:

- The In-Database **operation** tools (Filter, Formula, Join, Select, Sample, Sort, Summarize, Union, Browse) convert to the same steps as their in-memory twins — a PlaidCloud step already *is* warehouse SQL. Each of those nine is `pass/pass/pass` in the parity matrix, backed by `test_lockin_indb.py`.
- **Connect In-DB** and **Write Data In-DB** have no equivalent to a held-open warehouse connection and are refused by name, pointing at an SQL import/export step against a PlaidCloud connection — plus a `Not Yet Supported` row.
- Data Stream In/Out, Dynamic Input/Output In-DB and Macro Input/Output In-DB are named refusals for the same reason.

The framing matters for a migrating customer: swapping the two endpoints is enough — everything between them converts unchanged.

## Iterative macro loop limit

The guide said only that a macro which "cannot converge within its bound" stops. It now names the bound: the macro's own **Maximum Number of Iterations**, or a conversion ceiling where Alteryx left its runaway-guard default — and says the ceiling is raisable via the import's `iteration_ceiling` option, which is the actionable half. Same one-line addition on the `Macro calls` matrix row.

No `releases/` entry: per `CLAUDE.md`, incremental Alteryx-conversion detail stays in the guide and reference pages.

`npm run build` clean — 1564 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
